### PR TITLE
Additional fix

### DIFF
--- a/symphony/lib/toolkit/class.extensionmanager.php
+++ b/symphony/lib/toolkit/class.extensionmanager.php
@@ -12,7 +12,7 @@
 
 		static private $_enabled_extensions = NULL;
 		static private $_subscriptions = NULL;
-		static private $_extensions = NULL;
+		static private $_extensions = array();
 
         function __getClassName($name){
 	        return 'extension_' . $name;
@@ -31,7 +31,7 @@
         }
 
 		private function __buildExtensionList() {
-			if (self::$_extensions == NULL) {
+			if (empty(self::$_extensions)) {
 				$extensions = Symphony::Database()->fetch("SELECT * FROM `tbl_extensions`");
 				foreach($extensions as $extension) {
 					self::$_extensions[$extension['name']] = $extension;


### PR DESCRIPTION
The latest commit includes an improvement to the first "array_key fix" which has been proposed by Brendan. The method should return a NULL value if the array_key doesn't exist.
