### PR TITLE
Integration

### DIFF
--- a/symphony/lib/toolkit/class.general.php
+++ b/symphony/lib/toolkit/class.general.php
@@ -1069,7 +1069,9 @@
 			$string = substr($string, 0, $maxChars);
 
 			if($truncateToSpace && strpos($string, ' ')){
-				$string = str_replace(strrchr($string, ' '), '', $string);
+				$cut = strrchr($string, ' ');
+				if(strlen(trim($cut)) > 0) 
+					$string = str_replace($cut, '', $string);
 			}
 
 			$array  = explode(' ', $string);


### PR DESCRIPTION
Hi, team!

I don't know why this pull request shows up 23 commits – sorry for that if that's by my fault. Mine is the last one only :) This commit fixes the bug when `General::limitWords` function return string with all white spaces cutted from it. This issue uppears if value of `substr($string, 0, $maxChars);`  [(line 1068)](https://github.com/andrrr/symphony-2/blob/integration/symphony/lib/toolkit/class.general.php#L1069) is ended up with white space. 
