### PR TITLE
Fix blank login

### DIFF
--- a/symphony/content/content.login.php
+++ b/symphony/content/content.login.php
@@ -217,6 +217,7 @@
 							$email->send();
 							$this->_email_sent = true;
 						}
+						catch(Exception $e) {}
 						
 						## TODO: Fix Me
 						###


### PR DESCRIPTION
Commit [8c007c](https://github.com/symphonycms/symphony-2/commit/8c007c39ae8ea3f433146c7f3b3ba165f2ce76ee#comments) introduced some code that wasn't playing well with my PHP 5.3.3 installation.

It was missing a `catch` instruction. Apparently you can't `try` without a `catch`.
