### PR TITLE
Improved selectable plugin with "single" mode

### DIFF
--- a/symphony/assets/symphony.selectable.js
+++ b/symphony/assets/symphony.selectable.js
@@ -36,10 +36,11 @@
 		objects.delegate(settings.items, 'click.symSelectable', function(event) {
 			var item = $(this),
 				items = item.siblings().andSelf(),
+				object = $(event.liveFired),
 				selection, deselection, first, last;
 			
 			// Range selection
-			if((event.shiftKey) && items.filter('.selected').size() > 0) {
+			if((event.shiftKey) && items.filter('.selected').size() > 0 && !object.is('.single')) {
 				
 				// Select upwards
 				if(item.prevAll().filter('.selected').size() > 0) {
@@ -69,7 +70,7 @@
 			else {
 			
 				// Press meta key to adjust current range, otherwise the selection will be removed
-				if(!event.metaKey) {
+				if(!event.metaKey || object.is('.single')) {
 					deselection = items.not(item).filter('.selected').removeClass('selected').trigger('deselect');
 					deselection.find('input[type=checkbox]').attr('checked', false);
 				}


### PR DESCRIPTION
I'm currently updating some of my extensions to make full use of Symphony 2.2's new or updated features. In this context I noticed that I'm rebuilding the functionality of the new selectable plugin in Subsection Manager just because it doesn't offer a single mode, where only one item of a list can be selected.

This commits introduces this mode which is triggered by adding `.single` to the sortable list or table. It should make selectable suitable for more use cases.
