### PR TITLE
CDATA treatment

### DIFF
--- a/symphony/lib/toolkit/fields/field.textarea.php
+++ b/symphony/lib/toolkit/fields/field.textarea.php
@@ -206,7 +206,7 @@
 				$wrapper->appendChild(
 					new XMLElement(
 						$this->get('element_name'),
-						sprintf('<![CDATA[%s]]>', $data['value']),
+						sprintf('<![CDATA[%s]]>', str_replace(']]>',']]]]><![CDATA[>',$data['value'])),
 						array(
 							'mode' => $mode
 						)


### PR DESCRIPTION
This commit should fix [Issue 429](http://symphony-cms.com/discuss/issues/view/429/) by replacing `]]>` with `]]]]><![CDATA[>`.

It basically closes the current CDATA section and opens a new one, deconstructing the "unwanted termination tag" into `]]` and `>` and putting them in the separate sections (see [Wikipedia](http://en.wikipedia.org/wiki/CDATA#Nesting) for more information).
