### PR TITLE
Installer: Activate Extensions

### DIFF
--- a/symphony/lib/toolkit/include.install.php
+++ b/symphony/lib/toolkit/include.install.php
@@ -776,6 +776,13 @@ Options +FollowSymlinks -Indexes
 
 		        installResult($Page, $install_log, $start);
 
+				// Install extensions
+				require_once(CORE . '/class.administration.php');
+				foreach(Administration::instance()->ExtensionManager->listAll() as $name => $about) {
+				    if(Administration::instance()->ExtensionManager->enable($name) === false) continue;
+				}
+				
+				// Redirect to backend
 				redirect('http://' . rtrim(str_replace('http://', '', _INSTALL_DOMAIN_), '/') . '/symphony/');
 
 		    }


### PR DESCRIPTION
This commit activates extensions after the system has been released. Extensions that failed during install are ignored, the installer will proceed with the next one.

[See related discussion.](http://symphony-cms.com/discuss/issues/view/438/)
