### PR TITLE
Additional styles for field settings in section editor

### DIFF
--- a/symphony/assets/forms.css
+++ b/symphony/assets/forms.css
@@ -358,3 +358,90 @@ ul.tags .more:hover {
 .code {
 	font: 134%/1.3 monospace;
 }
+
+/* Field settings */
+
+.content fieldset {
+	border-top: 1px solid #eed;
+	border-bottom: none;
+	clear: both;
+	margin: 0 -1.75em 2.75em -2.5em;
+	padding: 0 2.75em 0 1.75em;
+	right: -8px;
+}
+
+.content fieldset.group {
+	padding: 0 0 0 1.75em;
+}
+
+.content fieldset legend {
+	color: #665;
+	float: none;
+	font-weight: normal;
+	line-height: 1;
+	text-indent: 0;
+	background: #DDC;
+	padding: 0;
+	margin: 0 0 0 -0.5em !important;
+	padding: 0 0.75em 0 0.5em;
+	display: block;
+	width: auto;
+}
+
+.content fieldset label {
+	margin: 1.75em 0 0 0em;
+	padding: 0;
+	min-width: 350px;
+}
+
+.content fieldset.group label, 
+.content fieldset.group div {
+	float: left;
+	width: 50%;
+	margin-left: 0;
+}
+
+.content fieldset.group div label {
+	float: none;
+	width: auto;
+	padding: 0 32px 0 0;
+}
+
+.content fieldset.group div ul.tags {
+	margin-top: 1em;
+}
+
+.content fieldset.group div ul.tags li {
+	overflow: visible;
+}
+
+.content fieldset.group div.invalid {
+	width: auto;
+	float: none;	
+	margin: 1.75em 32px 0 0;
+	padding: 1.25em 1.25em 2.5em;
+}
+
+.content fieldset.group div.invalid label {
+	padding: 0;
+	margin: 0;
+}
+
+.content fieldset.group div.invalid p {
+	margin: 1em 0 0;
+}
+
+.content fieldset.compact i {
+	color: #887;
+	display: block;
+	position: relative;
+	right: auto;
+	padding-left: 1.7em;
+}
+
+
+/* Fix code font size */
+
+.content i code {
+	font-size: 1em;
+}


### PR DESCRIPTION
These styles could alternatively be part of the duplicator stylesheet but it seems more convenient to put in `forms.css` here.
