### PR TITLE
Force select[multiple] to be white

### DIFF
--- a/symphony/assets/forms.css
+++ b/symphony/assets/forms.css
@@ -41,6 +41,7 @@ select {
 }
 select[multiple] {
 	height: 10em;
+	background-color: #ffffff;
 }
 textarea,
 label input {


### PR DESCRIPTION
A fix for [Issue 473](http://symphony-cms.com/discuss/issues/view/473/) by forcing `select[multiple]` fields to have a white background.
