### PR TITLE
Default Navigation Group

### DIFF
--- a/symphony/content/content.blueprintssections.php
+++ b/symphony/content/content.blueprintssections.php
@@ -116,7 +116,11 @@
 
 			$meta['entry_order'] = (isset($meta['entry_order']) ? $meta['entry_order'] : 'date');
 			$meta['hidden'] = (isset($meta['hidden']) ? 'yes' : 'no');
-			$meta['navigation_group'] = (isset($meta['navigation_group']) ? $meta['navigation_group'] : 'Content');
+			
+			// Set navigation group, if not already set 
+			if(!isset($meta['navigation_group'])) {
+				$meta['navigation_group'] = (isset($this->_navigation[0]['name']) ? $this->_navigation[0]['name'] : __('Content'));
+			}
 
 			$fieldset = new XMLElement('fieldset');
 			$fieldset->setAttribute('class', 'settings');


### PR DESCRIPTION
This is a fix for [#587: Default navigation group](http://symphony-cms.com/discuss/issues/view/587/). Symphony will now use the first user generated navigation group by default. If there is no navigation group yet it will default to "Content" as it did before - but "Content" will now be translatable.
