### PR TITLE
Backend Confirmations

### DIFF
--- a/symphony/assets/admin.js
+++ b/symphony/assets/admin.js
@@ -37,9 +37,7 @@ var Symphony = {};
 			Symphony.Language.add({
 				'Add item': false,
 				'Remove selected items': false,
-				'Are you sure you want to {$action} {$name}?': false,
-				'Are you sure you want to {$action} {$count} items?': false,
-				'Are you sure you want to {$action}?': false,
+				'Are you sure you want to proceed?': false,
 				'Reordering was unsuccessful.': false,
 				'Password': false,
 				'Change Password': false,
@@ -580,12 +578,14 @@ var Symphony = {};
 		$('button.confirm').live('click', function() {
 			var button = $(this),
 				name = document.title.split(/[\u2013]\s*/g)[2],
-				text = (name ? 'Are you sure you want to {$action} {$name}?' : 'Are you sure you want to {$action}?');
+				message = button.attr('data-message');
+				
+			// Set default message
+			if(!message) {
+				message = Symphony.Language.get('Are you sure you want to proceed?');
+			}
 
-			return confirm(Symphony.Language.get(text, {
-				'action': button.text().toLowerCase(),
-				'name': name
-			}));
+			return confirm(message);
 		});
 
 		// Confirm with selected actions
@@ -594,14 +594,17 @@ var Symphony = {};
 				option = select.find('option:selected'),
 				input = $('table input:checked'),
 				count = input.size(),
-				text = (count > 1 ? 'Are you sure you want to {$action} {$count} items?' : 'Are you sure you want to {$action} {$name}?');
-
+				message = option.attr('data-message');
+				
+			// Needs confirmation
 			if(option.is('.confirm')) {
-				return confirm(Symphony.Language.get(text, {
-					'action': option.text().toLowerCase(), // Does this work in all languages?
-					'name': $.trim(input.parents('tr').find('td:first').text()),
-					'count': count
-				}));
+			
+				// Set default message
+				if(!message) {
+					message = Symphony.Language.get('Are you sure you want to proceed?');
+				}
+
+				return confirm(message);
 			}
 		});
 

--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -761,7 +761,7 @@
 
 			if($isEditing){
 				$button = new XMLElement('button', __('Delete'));
-				$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this data source'), 'type' => 'submit', 'accesskey' => 'd'));
+				$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this data source'), 'type' => 'submit', 'accesskey' => 'd', 'data-message' => __('Are you sure you want to delete this data source?')));
 				$div->appendChild($button);
 			}
 

--- a/symphony/content/content.blueprintsevents.php
+++ b/symphony/content/content.blueprintsevents.php
@@ -170,7 +170,7 @@
 
 			if($isEditing){
 				$button = new XMLElement('button', __('Delete'));
-				$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this event'), 'type' => 'submit', 'accesskey' => 'd'));
+				$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this event'), 'type' => 'submit', 'accesskey' => 'd', 'data-message' => __('Are you sure you want to delete this event?')));
 				$div->appendChild($button);
 			}
 

--- a/symphony/content/content.blueprintspages.php
+++ b/symphony/content/content.blueprintspages.php
@@ -150,7 +150,9 @@
 
 			$options = array(
 				array(null, false, __('With Selected...')),
-				array('delete', false, __('Delete'), 'confirm')
+				array('delete', false, __('Delete'), 'confirm', null, array(
+					'data-message' => __('Are you sure you want to delete the selected pages?')
+				))
 			);
 
 			$tableActions->appendChild(Widget::Select('with-selected', $options));
@@ -582,7 +584,7 @@
 
 			if($this->_context[0] == 'edit'){
 				$button = new XMLElement('button', __('Delete'));
-				$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this page'), 'accesskey' => 'd'));
+				$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this page'), 'accesskey' => 'd', 'data-message' => __('Are you sure you want to delete this page?')));
 				$div->appendChild($button);
 			}
 

--- a/symphony/content/content.blueprintssections.php
+++ b/symphony/content/content.blueprintssections.php
@@ -70,8 +70,12 @@
 
 			$options = array(
 				array(NULL, false, __('With Selected...')),
-				array('delete', false, __('Delete'), 'confirm'),
-				array('delete-entries', false, __('Delete Entries'), 'confirm')
+				array('delete', false, __('Delete'), 'confirm', null, array(
+					'data-message' => __('Are you sure you want to delete the selected sections?')
+				)),
+				array('delete-entries', false, __('Delete Entries'), 'confirm', null, array(
+					'data-message' => __('Are you sure you want to delete all entries in the selected sections?')
+				))
 			);
 
 			if (is_array($sections) && !empty($sections))  {
@@ -461,7 +465,7 @@
 			$div->appendChild(Widget::Input('action[save]', __('Save Changes'), 'submit', array('accesskey' => 's')));
 
 			$button = new XMLElement('button', __('Delete'));
-			$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this section'), 'type' => 'submit', 'accesskey' => 'd'));
+			$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this section'), 'type' => 'submit', 'accesskey' => 'd', 'data-message' => __('Are you sure you want to delete this section?')));
 			$div->appendChild($button);
 
 			$this->Form->appendChild($div);

--- a/symphony/content/content.blueprintsutilities.php
+++ b/symphony/content/content.blueprintsutilities.php
@@ -149,7 +149,7 @@
 
 			if($this->_context[0] == 'edit'){
 				$button = new XMLElement('button', __('Delete'));
-				$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this utility'), 'type' => 'submit', 'accesskey' => 'd'));
+				$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this utility'), 'type' => 'submit', 'accesskey' => 'd', 'data-message' => __('Are you sure you want to delete this Utility?')));
 				$div->appendChild($button);
 			}
 

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -311,7 +311,9 @@
 
 			$options = array(
 				array(NULL, false, __('With Selected...')),
-				array('delete', false, __('Delete'), 'confirm')
+				array('delete', false, __('Delete'), 'confirm', null, array(
+					'data-message' => __('Are you sure you want to delete the selected entries?')
+				))
 			);
 
 			$toggable_fields = $section->fetchToggleableFields();
@@ -817,7 +819,7 @@
 			$div->appendChild(Widget::Input('action[save]', __('Save Changes'), 'submit', array('accesskey' => 's')));
 
 			$button = new XMLElement('button', __('Delete'));
-			$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this entry'), 'type' => 'submit', 'accesskey' => 'd'));
+			$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this entry'), 'type' => 'submit', 'accesskey' => 'd', 'data-message' => __('Are you sure you want to delete this entry?')));
 			$div->appendChild($button);
 
 			$this->Form->appendChild($div);

--- a/symphony/content/content.systemauthors.php
+++ b/symphony/content/content.systemauthors.php
@@ -90,7 +90,9 @@
 
 				$options = array(
 					array(NULL, false, __('With Selected...')),
-					array('delete', false, __('Delete'), 'confirm')
+					array('delete', false, __('Delete'), 'confirm', null, array(
+					'data-message' => __('Are you sure you want to delete the selected authors?')
+				))
 				);
 
 				$tableActions->appendChild(Widget::Select('with-selected', $options));
@@ -390,7 +392,7 @@
 
 			if($this->_context[0] == 'edit' && !$isOwner && !$author->isPrimaryAccount()){
 				$button = new XMLElement('button', __('Delete'));
-				$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this author'), 'type' => 'submit', 'accesskey' => 'd'));
+				$button->setAttributeArray(array('name' => 'action[delete]', 'class' => 'button confirm delete', 'title' => __('Delete this author'), 'type' => 'submit', 'accesskey' => 'd', 'data-message' => __('Are you sure you want to delete this author?')));
 				$div->appendChild($button);
 			}
 

--- a/symphony/content/content.systemextensions.php
+++ b/symphony/content/content.systemextensions.php
@@ -112,7 +112,9 @@
 				array(NULL, false, __('With Selected...')),
 				array('enable', false, __('Enable')),
 				array('disable', false, __('Disable')),
-				array('uninstall', false, __('Uninstall'), 'confirm'),
+				array('uninstall', false, __('Uninstall'), 'confirm', null, array(
+					'data-message' => __('Are you sure you want to uninstall the selected extensions?')
+				))
 			);
 
 			$tableActions->appendChild(Widget::Select('with-selected', $options));


### PR DESCRIPTION
Move confirm messages to data attributes (`data-message`) to improve the localisation of the backend. Translations will be handled by the PHP core not by `admin.js`.
