### PR TITLE
Fading Notices

### DIFF
--- a/symphony/assets/admin.js
+++ b/symphony/assets/admin.js
@@ -308,9 +308,11 @@ var Symphony = {};
 					};
 
 				// Delayed animation to new styles
-				notice.removeClass(newclass).delay(delay).animate(styles, 'slow', 'linear', function() {
-					$(this).removeClass('success');
-				});
+				if(notice.is(':visible')) {
+					notice.removeClass(newclass).delay(delay).animate(styles, 'slow', 'linear', function() {
+						$(this).removeClass('success');
+					});
+				}
 			},
 
 			/**


### PR DESCRIPTION
Fix issue with `jquery.color.js` when notices have been hidden before fading them to grey.
