### PR TITLE
EventPreBuild custom delegate

### DIFF
--- a/symphony/lib/toolkit/events/event.section.php
+++ b/symphony/lib/toolkit/events/event.section.php
@@ -18,6 +18,24 @@
 			$filter_results = array();
 			if(!is_array($filters)) $filters = array();
 
+			/**
+			* Prior to building the $post_values from the passed
+			* form fields, create an opertunity for a developer to
+			* make changes to the $fields array. This must be passed as
+			* a reference so the changes are made in this file.
+			*
+			* @delegate EventPreBuild
+			* @param string $context
+			* '/frontend/'
+			* @param array $fields 
+			*/
+
+			Symphony::ExtensionManager()->notifyMembers(
+				'EventPreBuild',
+				'/frontend/', 
+				array('fields' => &$fields)
+			);
+
 			## Create the post data cookie element
 			if (is_array($fields) && !empty($fields)) {
 				General::array_to_xml($post_values, $fields, true);


### PR DESCRIPTION
I would like to recommended this custom delegate that gives developers an opportunity to make changes to the data passed in the $fields array from a submitted form before the XMLElement is created. This allows for PHP calculations on form elements in a custom extension without editing the events.php file that's generated in workspace/events. 

I am not attached to the name "EventPreBuild" so please use a name that closer matches your API. 

For more information on why this could be useful and workarounds, please see this forum thread: http://symphony-cms.com/discuss/thread/67003/

Inline comment: Prior to building the $post_values from the passed form fields, create an opertunity for a developer to make changes to the $fields array. This must be passed as a reference so the changes are made in this file. 
