### PR TITLE
Fixes error surpression using the '@' sign. (proper)

### DIFF
--- a/symphony/lib/core/class.errorhandler.php
+++ b/symphony/lib/core/class.errorhandler.php
@@ -313,7 +313,7 @@
 				);
 			}
 
-			if((self::$raise || $code != E_WARNING) && error_reporting() !== 0) {
+			if((self::$raise || $code != E_WARNING) && (error_reporting() !== 0)) {
 				throw new ErrorException($message, 0, $code, $file, $line);
 			}
 		}


### PR DESCRIPTION
The error handler did not check if the error was surpressed.

This gave problems like the one described here: http://symphony-cms.com/discuss/thread/26297/5/#position-90

Sorry for the double post guys, my bad!
