### PR TITLE
Data should not be sanitized before it is passed to text formatter.

### DIFF
--- a/symphony/lib/toolkit/fields/field.textarea.php
+++ b/symphony/lib/toolkit/fields/field.textarea.php
@@ -157,7 +157,7 @@
 				$tfm = new TextformatterManager($this->_engine);
 				$formatter = $tfm->create($this->get('formatter'));
 
-				$result = $formatter->run(General::sanitize($data));
+				$result = $formatter->run($data);
 			}
 
 			if($validate === true) {


### PR DESCRIPTION
As mentioned in comments (https://github.com/symphonycms/symphony-2/commit/a9398978c0cd3f20eb0b5ce878f65ed933d2644a#symphony/lib/toolkit/fields/field.textarea.php-P39).
