### PR TITLE
Fixed Delete notification

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -914,10 +914,11 @@
 				 * @param array $checked
 				 *  An array of Entry ID's passed by reference
 				 */
-				Symphony::ExtensionManager()->notifyMembers('Delete', '/publish/', array('entry_id' => &$entry_id));
+				$checked = array($entry_id);
+				Symphony::ExtensionManager()->notifyMembers('Delete', '/publish/', array('entry_id' => &$checked));
 
 				$entryManager = new EntryManager($this->_Parent);
-				$entryManager->delete($entry_id);
+				$entryManager->delete($checked);
 
 				redirect(SYMPHONY_URL . '/publish/'.$this->_context['section_handle'].'/');
 			}


### PR DESCRIPTION
Fixed `Delete` notification sent when edited entry is deleted. Notice should pass array of entries, extensions should be able to edit content of that array, and `$entryManager` should get edited array, not "hardcoded" `entry_id` :).
