### PR TITLE
Fix Textarea 65000 characters limit

### DIFF
--- a/symphony/lib/toolkit/fields/field.textarea.php
+++ b/symphony/lib/toolkit/fields/field.textarea.php
@@ -40,8 +40,8 @@
 				CREATE TABLE IF NOT EXISTS `tbl_entries_data_" . $this->get('id') . "` (
 				  `id` int(11) unsigned NOT NULL auto_increment,
 				  `entry_id` int(11) unsigned NOT NULL,
-				  `value` text,
-				  `value_formatted` text,
+				  `value` MEDIUMTEXT,
+				  `value_formatted` MEDIUMTEXT,
 				  PRIMARY KEY  (`id`),
 				  UNIQUE KEY `entry_id` (`entry_id`),
 				  FULLTEXT KEY `value` (`value`)

--- a/update.php
+++ b/update.php
@@ -432,6 +432,19 @@ Options +FollowSymlinks -Indexes
 
 				// Save the manifest changes
 				writeConfig(DOCROOT . '/manifest', $settings, $settings['file']['write_mode']);
+				
+				try {
+					// Change Textareas to be MEDIUMTEXT columns
+					$textarea_tables = $frontend->Database->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_textarea`");
+					
+					foreach($textarea_tables as $field) {
+						$frontend->Database->query(sprintf(
+							"ALTER TABLE `tbl_entries_data_%d` CHANGE `value` `value` MEDIUMTEXT, CHANGE `value_formatted` `value_formatted` MEDIUMTEXT",
+							$field
+						));
+					}
+				}
+				catch(Exception $ex) {}
 			}
 
 			$sbl_version = $frontend->Database->fetchVar('version', 0,


### PR DESCRIPTION
This fix includes an updated MySQL signature for the Textarea field as well as an update procedure to retroactively change the column type for all existing textarea fields to `MEDIUMTEXT`.
