### PR TITLE
Fixed critical bug in DateTimeObj

### DIFF
--- a/symphony/lib/core/class.datetimeobj.php
+++ b/symphony/lib/core/class.datetimeobj.php
@@ -123,7 +123,7 @@
 				else {
 					$date = strptime($string, DateTimeObj::dateFormatToStrftime(__SYM_DATETIME_FORMAT__));
 					if($date === false) {
-						$date = DateTimeObj::dateFormatToStrftime(__SYM_DATE_FORMAT__, $string);
+						$date = strptime($string, DateTimeObj::dateFormatToStrftime(__SYM_DATE_FORMAT__));
 					}
 
 					if(is_array($date)) {


### PR DESCRIPTION
As pointed out by **Nils** at https://github.com/symphonycms/symphony-2/commit/80e214d70311610cf9a693997eacf71c065d09fd#commitcomment-461289.

This thing is critical on PHP 5.2.x, as it crashes even administration pages.
