### PR TITLE
Fixed typo in DateTimeObj: "Datetime" should be "DateTime".

### DIFF
--- a/symphony/lib/core/class.datetimeobj.php
+++ b/symphony/lib/core/class.datetimeobj.php
@@ -99,7 +99,7 @@
 
 			// Timestamp
 			elseif(is_numeric($string)) {
-				$date = new Datetime(date(DateTime::ISO8601, $string));
+				$date = new DateTime(date(DateTime::ISO8601, $string));
 			}
 
 			// Attempt to parse the date provided against the Symphony configuration setting


### PR DESCRIPTION
BTW maybe this part could check for availability of `DateTime::setTimestamp()` function? Looks like checking for function and then falling back to Date() is faster (at least if function exists, otherwise it probably slows down things a bit :) - [benchmark on gist](https://gist.github.com/1067053).
