### PR TITLE
Integration

### DIFF
--- a/symphony/lib/toolkit/class.authormanager.php
+++ b/symphony/lib/toolkit/class.authormanager.php
@@ -160,14 +160,13 @@
 			$records = Symphony::Database()->fetch(sprintf("
 					SELECT *
 					FROM `tbl_authors`
-					WHERE `id` IN (%d)
+					WHERE `id` IN (%s)
 					ORDER BY %s %s
-					%s %s
+					%s
 				",
 				implode(",", $id),
 				$sortby, $sortdirection,
-				($limit) ? "LIMIT " . $limit : '',
-				($start && $limit) ? ', ' . $start : ''
+				($limit) ? "LIMIT " . (($start) ? $start . ',':'') . $limit : ''
 			));
 
 			if(!is_array($records) || empty($records)) return ($return_single ? $authors[0] : $authors);


### PR DESCRIPTION
The correct sort order in mysql is: start, limit, not the other way around.
Also, because sprintf was set to accept %d on the IN() part of the query, only the first id would be listed, making the listing incomplete.
