### PR TITLE
Inverting order of elements in title

### DIFF
--- a/symphony/content/content.blueprintscomponents.php
+++ b/symphony/content/content.blueprintscomponents.php
@@ -18,7 +18,7 @@
 
 		public function view(){
 			$this->setPageType('forms');
-			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), __('Components'))));
+			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Components'), __('Symphony'))));
 
 			$this->appendSubheading(__('Components'));
 

--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -192,7 +192,7 @@
 			}
 
 			$this->setPageType('form');
-			$this->setTitle(__(($isEditing ? '%1$s &ndash; %2$s &ndash; %3$s' : '%1$s &ndash; %2$s'), array(__('Symphony'), __('Data Sources'), $about['name'])));
+			$this->setTitle(__(($isEditing ? '%1$s &ndash; %2$s &ndash; %3$s' : '%2$s &ndash; %3$s'), array($about['name'], __('Data Sources'), __('Symphony'))));
 			$this->appendSubheading(($isEditing ? $about['name'] : __('Untitled')));
 
 			$fieldset = new XMLElement('fieldset');
@@ -872,7 +872,7 @@
 			$datasource = DatasourceManager::create($this->_context[1], NULL, false);
 			$about = $datasource->about();
 
-			$this->setTitle(__('%1$s &ndash; %2$s &ndash; %3$s', array(__('Symphony'), __('Data Source'), $about['name'])));
+			$this->setTitle(__('%1$s &ndash; %2$s &ndash; %3$s', array($about['name'], __('Data Source'), __('Symphony'))));
 			$this->appendSubheading($about['name']);
 			$this->Form->setAttribute('id', 'controller');
 

--- a/symphony/content/content.blueprintsevents.php
+++ b/symphony/content/content.blueprintsevents.php
@@ -85,7 +85,7 @@
 			if(isset($_POST['fields'])) $fields = $_POST['fields'];
 
 			$this->setPageType('form');
-			$this->setTitle(__(($isEditing ? '%1$s &ndash; %2$s &ndash; %3$s' : '%1$s &ndash; %2$s'), array(__('Symphony'), __('Events'), $about['name'])));
+			$this->setTitle(__(($isEditing ? '%1$s &ndash; %2$s &ndash; %3$s' : '%2$s &ndash; %3$s'), array($about['name'], __('Events'), __('Symphony'))));
 			$this->appendSubheading(($isEditing ? $about['name'] : __('Untitled')));
 
 			if(!$readonly):

--- a/symphony/content/content.blueprintspages.php
+++ b/symphony/content/content.blueprintspages.php
@@ -21,7 +21,7 @@
 
 		public function __viewIndex() {
 			$this->setPageType('table');
-			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), __('Pages'))));
+			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Pages'), __('Symphony'))));
 
 			$nesting = (Symphony::Configuration()->get('pages_table_nest_children', 'symphony') == 'yes');
 
@@ -205,11 +205,11 @@
 			}
 
 			$this->setTitle(__(
-				($filename ? '%1$s &ndash; %2$s &ndash; %3$s' : '%1$s &ndash; %2$s'),
+				($filename ? '%1$s &ndash; %2$s &ndash; %3$s' : '%2$s &ndash; %3$s'),
 				array(
-					__('Symphony'),
+					$filename,
 					__('Pages'),
-					$filename
+					__('Symphony')
 				)
 			));
 
@@ -380,11 +380,11 @@
 			if(trim($title) == '') $title = $existing['title'];
 
 			$this->setTitle(__(
-				($title ? '%1$s &ndash; %2$s &ndash; %3$s' : '%1$s &ndash; %2$s'),
+				($title ? '%1$s &ndash; %2$s &ndash; %3$s' : '%2$s &ndash; %3$s'),
 				array(
-					__('Symphony'),
+					$title,
 					__('Pages'),
-					$title
+					__('Symphony')
 				)
 			));
 			if($existing) {

--- a/symphony/content/content.blueprintssections.php
+++ b/symphony/content/content.blueprintssections.php
@@ -18,7 +18,7 @@
 
 		public function __viewIndex(){
 			$this->setPageType('table');
-			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), __('Sections'))));
+			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Sections'), __('Symphony'))));
 			$this->appendSubheading(__('Sections'), Widget::Anchor(__('Create New'), Administration::instance()->getCurrentPageURL().'new/', __('Create a section'), 'create button', NULL, array('accesskey' => 'c')));
 
 			$sections = SectionManager::fetch(NULL, 'ASC', 'sortorder');
@@ -99,7 +99,7 @@
 
 		public function __viewNew(){
 			$this->setPageType('form');
-			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), __('Sections'))));
+			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Sections'), __('Symphony'))));
 			$this->appendSubheading(__('Untitled'));
 
 			$types = array();
@@ -325,7 +325,7 @@
 			}
 
 			$this->setPageType('form');
-			$this->setTitle(__('%1$s &ndash; %2$s &ndash; %3$s', array(__('Symphony'), __('Sections'), $meta['name'])));
+			$this->setTitle(__('%1$s &ndash; %2$s &ndash; %3$s', array($meta['name'], __('Sections'), __('Symphony'))));
 			$this->appendSubheading($meta['name']);
 
 			$fieldset = new XMLElement('fieldset');

--- a/symphony/content/content.blueprintsutilities.php
+++ b/symphony/content/content.blueprintsutilities.php
@@ -91,7 +91,7 @@
 				}
 			}
 
-			$this->setTitle(__(($this->_context[0] == 'new' ? '%1$s &ndash; %2$s' : '%1$s &ndash; %2$s &ndash; %3$s'), array(__('Symphony'), __('Utilities'), $filename)));
+			$this->setTitle(__(($this->_context[0] == 'new' ? '%2$s &ndash; %3$s' : '%1$s &ndash; %2$s &ndash; %3$s'), array($filename, __('Utilities'), __('Symphony'))));
 			$this->appendSubheading(($this->_context[0] == 'new' ? __('Untitled') : $filename));
 
 			if(!empty($_POST)) $fields = $_POST['fields'];

--- a/symphony/content/content.login.php
+++ b/symphony/content/content.login.php
@@ -24,7 +24,7 @@
 			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/basic.css', 'screen', 40);
 			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/login.css', 'screen', 40);
 
-			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), __('Login'))));
+			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Login'), __('Symphony'))));
 
 			Symphony::Profiler()->sample('Page template created', PROFILE_LAP);
 		}

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -47,7 +47,7 @@
 			$section = SectionManager::fetch($section_id);
 
 			$this->setPageType('table');
-			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), $section->get('name'))));
+			$this->setTitle(__('%1$s &ndash; %2$s', array($section->get('name'), __('Symphony'))));
 			$this->Form->setAttribute("class", $this->_context['section_handle']);
 
 			$filters = array();
@@ -459,7 +459,7 @@
 
 			$this->setPageType('form');
 			$this->Form->setAttribute('enctype', 'multipart/form-data');
-			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), $section->get('name'))));
+			$this->setTitle(__('%1$s &ndash; %2$s', array($section->get('name'), __('Symphony'))));
 			$this->appendSubheading(__('Untitled'));
 			$this->Form->appendChild(Widget::Input('MAX_FILE_SIZE', Symphony::Configuration()->get('max_upload_size', 'admin'), 'hidden'));
 
@@ -756,7 +756,7 @@
 
 			$this->setPageType('form');
 			$this->Form->setAttribute('enctype', 'multipart/form-data');
-			$this->setTitle(__('%1$s &ndash; %2$s &ndash; %3$s', array(__('Symphony'), $section->get('name'), $title)));
+			$this->setTitle(__('%1$s &ndash; %2$s &ndash; %3$s', array($title, $section->get('name'), __('Symphony'))));
 			$this->appendSubheading($title);
 			$this->Form->appendChild(Widget::Input('MAX_FILE_SIZE', Symphony::Configuration()->get('max_upload_size', 'admin'), 'hidden'));
 

--- a/symphony/content/content.systemauthors.php
+++ b/symphony/content/content.systemauthors.php
@@ -20,7 +20,7 @@
 		public function __viewIndex(){
 
 			$this->setPageType('table');
-			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), __('Authors'))));
+			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Authors'), __('Symphony'))));
 
 			if (Administration::instance()->Author->isDeveloper()) {
 				$this->appendSubheading(__('Authors'), Widget::Anchor(__('Add an Author'), Administration::instance()->getCurrentPageURL().'new/', __('Add a new author'), 'create button', NULL, array('accesskey' => 'c')));
@@ -205,7 +205,7 @@
 				Administration::instance()->customError(__('Access Denied'), __('You are not authorised to edit other authors.'));
 			}
 
-			$this->setTitle(__(($this->_context[0] == 'new' ? '%1$s &ndash; %2$s &ndash; %3$s' : '%1$s &ndash; %2$s'), array(__('Symphony'), __('Authors'), $author->getFullName())));
+			$this->setTitle(__(($this->_context[0] == 'new' ? '%2$s &ndash; %3$s' : '%1$s &ndash; %2$s &ndash; %3$s'), array($author->getFullName(), __('Authors'), __('Symphony'))));
 			$this->appendSubheading(($this->_context[0] == 'new' ? __('Untitled') : $author->getFullName()));
 
 			### Essentials ###

--- a/symphony/content/content.systemextensions.php
+++ b/symphony/content/content.systemextensions.php
@@ -14,7 +14,7 @@
 
 		public function __viewIndex(){
 			$this->setPageType('table');
-			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), __('Extensions'))));
+			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Extensions'), __('Symphony'))));
 			$this->appendSubheading(__('Extensions'));
 
 			$this->Form->setAttribute('action', SYMPHONY_URL . '/system/extensions/');

--- a/symphony/content/content.systempreferences.php
+++ b/symphony/content/content.systempreferences.php
@@ -19,7 +19,7 @@
 		## Overload the parent 'view' function since we dont need the switchboard logic
 		public function view() {
 			$this->setPageType('form');
-			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), __('Preferences'))));
+			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Preferences'), __('Symphony'))));
 
 			$this->appendSubheading(__('Preferences'));
 

--- a/symphony/lib/toolkit/class.devkit.php
+++ b/symphony/lib/toolkit/class.devkit.php
@@ -84,9 +84,9 @@
 			$this->setTitle(__(
 				'%1$s &ndash; %2$s &ndash; %3$s',
 				array(
-					__('Symphony'),
+					$this->_pagedata['title'],
 					__($this->_title),
-					$this->_pagedata['title']
+					__('Symphony')
 				)
 			));
 


### PR DESCRIPTION
This fixes a suggestion that came up during the Symposium in Cologne. It inverts the order of elements in the `<title>` tag.

It replaces for example

```
Symphony - Section - Entry
```

by 

```
Entry Title - Section - Symphony
```

The rationale behind this was that with increasing number of open tags you'd eventually end up only seeing "Symphony, Symphony, Symphony, Symphony, Symphony, Symphony" in your tabs bar.
