### PR TITLE
Text-overflow added to `th` element in the publish area

### DIFF
--- a/symphony/assets/admin.css
+++ b/symphony/assets/admin.css
@@ -85,6 +85,13 @@ table input {
 	float: right;
 	margin-right: 19px;
 }
+th span {
+	float: left;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	max-width: 90%;
+}
 th a,
 th a:hover,
 th a:hover:after {

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -127,8 +127,8 @@
 
 			if(is_array($visible_columns) && !empty($visible_columns)){
 				foreach($visible_columns as $column){
-
-					$label = $column->label();
+					$label = new XMLElement('span', $column->label());
+					$label = $label->generate();
 
 					if($column->isSortable()) {
 


### PR DESCRIPTION
This pull request solves a problem with columns in the table head, behaving wrongly with long titles (#776)

Basically every column has got a `span` element inside which is targeted to apply the CSS `text-overflow` property. Like Nick [explained](http://symphony-cms.com/discuss/issues/view/616/) a while back:

> If you have a very long column heading it will be truncated and ellipsis added: http://d.pr/jrF9.

The only change to Nick's proposal is that, instead of using fixed widths, I use percentages that are computed based on the columns real width. This way, it is possible to truncate long names only when necessary (i.e. too many columns in a narrow screen).

Tested on Firefox, Opera & Chrome.
