### PR TITLE
Escape special REGEX characters.

### DIFF
--- a/symphony/assets/symphony.tags.js
+++ b/symphony/assets/symphony.tags.js
@@ -67,7 +67,7 @@
 
 			// Multiple
 			else {
-				var exp = new RegExp('^' + tag + '$', 'i'),
+				var exp = new RegExp('^' + tag.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&") + '$', 'i'),
 					tags = value.split(/,\s*/),
 					removed = false;
 


### PR DESCRIPTION
For taglist JS, regex characters must be escaped or this will fail for something simple like "Garden ( Rose )". Note parenthesis `()`.
