### PR TITLE
Enable use of return button in preferences view

### DIFF
--- a/symphony/assets/admin.css
+++ b/symphony/assets/admin.css
@@ -201,7 +201,7 @@ tr.selecting .inactive {
 	color: #b4b4b4;
 }
 .irrelevant {
-	display: none;
+	display: none !important;
 }
 .selected, .selected a, .selected .inactive {
 	color: #fff;

--- a/symphony/content/content.systempreferences.php
+++ b/symphony/content/content.systempreferences.php
@@ -116,6 +116,7 @@
 			$attr = array('accesskey' => 's');
 			if(!$bIsWritable) $attr['disabled'] = 'disabled';
 			$div->appendChild(Widget::Input('action[save]', __('Save Changes'), 'submit', $attr));
+			$this->Form->prependChild(Widget::Input('action[save]', __('Save Changes'), 'submit', array_merge($attr, array('class' => 'irrelevant'))));
 
 			$this->Form->appendChild($div);
 		}


### PR DESCRIPTION
By default, browsers select the first submit button in a form if the return button is pressed inside an input field. But because extensions can add as many submit buttons as they like and Symphony's is always last, this behaviour breaks.

This fix adds an invisible submit button to the beginning of that form to re-enable that feature.
