### PR TITLE
Methods to extract single XMLElement children

### DIFF
--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -178,12 +178,39 @@
 		}
 
 		/**
+		 * Retrieves a child-element by position
+		 *
+		 * @since Symphony 2.3
+		 * @param int $position
+		 * @return XMLElement
+		 */
+		public function getChild($position){
+			if(!isset($this->_children[$this->getRealIndex($position)])) return null;
+			return $this->_children[$this->getRealIndex($position)];
+		}
+
+		/**
 		 * Accessor for `$this->_children`
 		 *
 		 * @return array
 		 */
 		public function getChildren(){
 			return $this->_children;
+		}
+
+		/**
+		 * Retrieves child-element by name and position. If no child is found,
+		 * NULL will be returned.
+		 *
+		 * @since Symphony 2.3
+		 * @param string $name
+		 * @return XMLElement
+		 */
+		public function getChildByName($name, $position) {
+			$result = array_values($this->getChildrenByName($name));
+
+			if(!isset($result[$position])) return null;
+			return $result[$position];
 		}
 
 		/**


### PR DESCRIPTION
A member of the community recently asked for a way to manipulate/extract data from a DataSource's XML using PHP. [The result](http://symphony-cms.com/discuss/thread/81494/2/#position-23) was a bit messy because XMLElement doesn't provide a "chainable" way of accessing children by always returning an `array()`. 

This PR implements two new methods that enable the developer to directly access only one single element from the returned XML. The returned value is either `NULL` or an instance of `XMLElement`.

The code by the aforementioned member

```
foreach($result->getChildrenByName('entry') as $entry){
    foreach($entry->getChildrenByName('redirect-to') as $parent) {
        foreach($parent->getChildrenByName('item') as $item){
            echo $item->getAttribute('handle');
        }
    }
}
```

would become

```
$result->getChildByName('entry', 1)->getChildByName('redirect-to', 1)->getChildByName('item', 1)->getAttribute('handle');
```

Next step: Full XPath support. ;-)
