### PR TITLE
Simplify gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,5 @@
-._*
-.Apple*
-.DS_Store
-*config.php
 .htaccess
 workspace/
 manifest/
-*.esproj
-*~
-*.geany
 install-log.txt
-_docs/
-symphony-2.wiki/
 install/logs/


### PR DESCRIPTION
As per #1006, remove application and platform specific patterns from the project gitignore file. Things like `.DS_Store` and `*.esproj` belong in the user's global `.gitignore` file, not in the individual project.
