### PR TITLE
Show an appropriately worded message when there is no page as request, and no page name is returned for that page

### DIFF
--- a/symphony/lib/core/class.frontend.php
+++ b/symphony/lib/core/class.frontend.php
@@ -124,7 +124,7 @@
 			if (empty($pagename)) {
 				$this->message = __('The page you requested does not exist.');
 			} else {
-				$this->message = __('The page you requested, %s, does not exist.', array('<code>' . getCurrentPage() . '</code>'));
+				$this->message = __('The page you requested, %s, does not exist.', array('<code>' . $pagename . '</code>'));
 			}
 			$this->code = E_USER_NOTICE;
 		}


### PR DESCRIPTION
Show an appropriately worded message when there is no page as request, and no page name is returned for that page. Fixes #1025.
