### PR TITLE
Fix for issues with IE8's image/x-png mime type.

### DIFF
--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -15,6 +15,7 @@
 			'image/jpeg',
 			'image/pjpeg',
 			'image/png',
+			'image/x-png',
 		);
 
 		public function __construct(){


### PR DESCRIPTION
This fixes an issue with IE8 sending a strange mime type when uploading an image. Adding the mime type to the `imageMimeTypes` array will fix the size detection feature of the upload field.

For this IE behaviour see http://msdn.microsoft.com/en-us/library/ie/ms775147(v=vs.85).aspx:

> …In some cases, the detected MIME type can differ from the generally accepted value for backward compatibility, as shown in the following table:
> 
> ```
>   Standard MIME Type    FindMimeFromData Returns
>   image/jpeg            image/pjpeg
>   image/png             image/x-png
> ```
