### PR TITLE
Issue 872

### DIFF
--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -329,7 +329,7 @@
 				'current-page-id' => $page['id'],
 				'current-path' => $current_path,
 				'parent-path' => '/' . $page['path'],
-				'current-query-string' => $querystring,
+				'current-query-string' => utf8_encode(urldecode($querystring)),
 				'current-url' => URL . $current_path,
 				'upload-limit' => min($upload_size_php, $upload_size_sym),
 				'symphony-version' => Symphony::Configuration()->get('version', 'symphony'),
@@ -349,11 +349,11 @@
 					// to be used, $url-b
 					$key = preg_replace('/(^amp;|\/)/', null, $key);
 
-					// If the key gets replaced out then it will break the XML so prevent
-					// the parameter being set.
-					if(empty($key)) continue;
-
-					$this->_param['url-' . $key] = $val;
+					// The key gets sanitized later on, so make sure it doesn't end up empty:
+					if(General::createHandle($key))
+					{
+						$this->_param['url-' . $key] = utf8_encode(urldecode($val));
+					}
 				}
 			}
 

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -331,7 +331,35 @@
 		 */
 		public function setValue($value, $prepend=true){
 			if(!$prepend) $this->_placeValueAfterChildElements = true;
-			$this->_value = $value;
+			$this->_value = $this->stripInvalidXMLCharacters($value);
+		}
+
+		/**
+		 * This function removes characters that are not allowed in XML
+		 * @link http://www.w3.org/TR/xml/#charsets
+		 * @link http://www.phpedit.net/snippet/Remove-Invalid-XML-Characters
+		 * @param string $value
+		 * @return string
+		 */
+		public static function stripInvalidXMLCharacters($value)
+		{
+			$ret = '';
+			if (empty($value)) {
+				return $ret;
+			}
+			$length = strlen($value);
+			for ($i=0; $i < $length; $i++) {
+				$current = ord($value{$i});
+				if (($current == 0x9) ||
+					($current == 0xA) ||
+					($current == 0xD) ||
+					(($current >= 0x20) && ($current <= 0xD7FF)) ||
+					(($current >= 0xE000) && ($current <= 0xFFFD)) ||
+					(($current >= 0x10000) && ($current <= 0x10FFFF))) {
+					$ret .= chr($current);
+				}
+			}
+			return $ret;
 		}
 
 		/**

--- a/symphony/lib/toolkit/class.xsltpage.php
+++ b/symphony/lib/toolkit/class.xsltpage.php
@@ -107,13 +107,22 @@
 		 * and be accessible in the XSLT. This function translates all ' into
 		 * `&apos;`, with the tradeoff being that a <xsl:value-of select='$param' />
 		 * that has a ' will output `&apos;` but the benefit that ' and " can be
-		 * in the params
+		 * in the params.
+		 *
+		 * It also makes sure that the characters used are valid.
 		 *
 		 * @link http://www.php.net/manual/en/xsltprocessor.setparameter.php#81077
+		 * @link http://www.w3.org/TR/xml/#charsets
+		 * @link http://www.phpedit.net/snippet/Remove-Invalid-XML-Characters
 		 * @param array $param
 		 *  An associative array of params for this page
 		 */
 		public function setRuntimeParam($param){
+			// Make the parameters valid XML:
+			foreach($this->_param as &	$p)
+			{
+				$p = XMLElement::stripInvalidXMLCharacters($p);
+			}
 			$this->_param = str_replace("'", "&apos;", $param);
 		}
 


### PR DESCRIPTION
- fix issue where Symphony crashes on URL's like `?:`
- fix issue where Symphony crashes on URL's like `?%C9`
- fix issue where Symphony crashes on URL's like `?%09` (illegal characters for XML)

See also [this comment](https://github.com/symphonycms/symphony-2/issues/872#issuecomment-4272453)
