### PR TITLE
Sync installer files with Export Ensemble extension files

### DIFF
--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -1,6 +1,7 @@
 <?php
 	$settings = array(
 
+
 		###### ADMIN ######
 		'admin' => array(
 			'max_upload_size' => '5242880',
@@ -15,7 +16,7 @@
 			'pages_table_nest_children' => 'no',
 			'version' => VERSION,
 			'cookie_prefix' => 'sym-',
-			'session_gc_divisor' => '10'
+			'session_gc_divisor' => '10',
 		),
 		########
 
@@ -27,13 +28,14 @@
 		),
 		########
 
+
 		###### DATABASE ######
 		'database' => array(
 			'host' => 'localhost',
 			'port' => '3306',
-			'user' => '',
-			'password' => '',
-			'db' => '',
+			'user' => null,
+			'password' => null,
+			'db' => null,
 			'character_set' => 'utf8',
 			'character_encoding' => 'utf8',
 			'tbl_prefix' => 'sym_',
@@ -78,4 +80,11 @@
 		),
 		########
 
+
+		###### IMAGE ######
+		'image' => array(
+			'cache' => '1',
+			'quality' => '90',
+		),
+		########
 	);

--- a/install/includes/install.sql
+++ b/install/includes/install.sql
@@ -19,16 +19,6 @@ CREATE TABLE `tbl_authors` (
   UNIQUE KEY `email` (`email`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
--- *** STRUCTURE: `tbl_sessions` ***
-DROP TABLE IF EXISTS `tbl_sessions`;
-CREATE TABLE IF NOT EXISTS `tbl_sessions` (
-  `session` varchar(100) NOT NULL,
-  `session_expires` int(10) unsigned NOT NULL default '0',
-  `session_data` text default null,
-  PRIMARY KEY  (`session`),
-  KEY `session_expires` (`session_expires`)
-) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
-
 -- *** STRUCTURE: `tbl_cache` ***
 DROP TABLE IF EXISTS `tbl_cache`;
 CREATE TABLE `tbl_cache` (
@@ -40,7 +30,7 @@ CREATE TABLE `tbl_cache` (
   PRIMARY KEY (`id`),
   KEY `expiry` (`expiry`),
   KEY `hash` (`hash`)
-) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- *** STRUCTURE: `tbl_entries` ***
 DROP TABLE IF EXISTS `tbl_entries`;
@@ -153,6 +143,19 @@ CREATE TABLE `tbl_fields_select` (
   `dynamic_options` int(11) unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `field_id` (`field_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+-- *** STRUCTURE: `tbl_fields_selectbox_link` ***
+DROP TABLE IF EXISTS `tbl_fields_selectbox_link`;
+CREATE TABLE `tbl_fields_selectbox_link` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `field_id` int(11) unsigned NOT NULL,
+  `allow_multiple_selection` enum('yes','no') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'no',
+  `show_association` enum('yes','no') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'yes',
+  `related_field_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `limit` int(4) unsigned NOT NULL DEFAULT '20',
+  PRIMARY KEY (`id`),
+  KEY `field_id` (`field_id`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- *** STRUCTURE: `tbl_fields_taglist` ***
@@ -251,3 +254,13 @@ CREATE TABLE `tbl_sections_association` (
   PRIMARY KEY (`id`),
   KEY `parent_section_id` (`parent_section_id`,`child_section_id`,`child_section_field_id`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+-- *** STRUCTURE: `tbl_sessions` ***
+DROP TABLE IF EXISTS `tbl_sessions`;
+CREATE TABLE `tbl_sessions` (
+  `session` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
+  `session_expires` int(10) unsigned NOT NULL DEFAULT '0',
+  `session_data` text COLLATE utf8_unicode_ci,
+  PRIMARY KEY (`session`),
+  KEY `session_expires` (`session_expires`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;


### PR DESCRIPTION
Apart from the `version` key in the `symphony` array of the default configuration file, all other values are synced with what the Export Ensemble extension will output. This makes it much easier to see the real differences when updating the installer files when creating ensembles.
