### PR TITLE
Validate URL parameters before adding them to the XML

### DIFF
--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -339,7 +339,7 @@
 				'current-page-id' => $page['id'],
 				'current-path' => $current_path,
 				'parent-path' => '/' . $page['path'],
-				'current-query-string' => utf8_encode(urldecode($querystring)),
+				'current-query-string' => XMLElement::stripInvalidXMLCharacters(utf8_encode(urldecode($querystring))),
 				'current-url' => URL . $current_path,
 				'upload-limit' => min($upload_size_php, $upload_size_sym),
 				'symphony-version' => Symphony::Configuration()->get('version', 'symphony'),
@@ -363,7 +363,7 @@
 					// the parameter being set.
 					if(!General::createHandle($key)) continue;
 
-					$this->_param['url-' . $key] = utf8_encode(urldecode($val));
+					$this->_param['url-' . $key] = XMLElement::stripInvalidXMLCharacters(utf8_encode(urldecode($val)));
 				}
 			}
 

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -561,6 +561,39 @@
 		}
 
 		/**
+		 * This function strips characters that are not allowed in XML
+		 * @link http://www.w3.org/TR/xml/#charsets
+		 * @link http://www.phpedit.net/snippet/Remove-Invalid-XML-Characters
+		 * @param string $value
+		 * @return string
+		 */
+		public static function stripInvalidXMLCharacters($value)
+		{
+			if(Lang::isUnicodeCompiled())
+			{
+				return preg_replace('/[^\x{0009}\x{000a}\x{000d}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}]+/u', ' ', $value);
+			} else {
+				$ret = '';
+				if (empty($value)) {
+					return $ret;
+				}
+				$length = strlen($value);
+				for ($i=0; $i < $length; $i++) {
+					$current = ord($value{$i});
+					if (($current == 0x9) ||
+						($current == 0xA) ||
+						($current == 0xD) ||
+						(($current >= 0x20) && ($current <= 0xD7FF)) ||
+						(($current >= 0xE000) && ($current <= 0xFFFD)) ||
+						(($current >= 0x10000) && ($current <= 0x10FFFF))) {
+						$ret .= chr($current);
+					}
+				}
+				return $ret;
+			}
+		}
+
+		/**
 		 * This function will turn the `XMLElement` into a string
 		 * representing the element as it would appear in the markup.
 		 * The result is valid XML.


### PR DESCRIPTION
This commit is my second attempt to fix issue #872 where 'exotic' characters where putted in the XML, while they knew they where invalid! Those sneaky bastards!

It fixes the whole _'Each symphony site in the world crashes when you add something like `?a=%0C` after the URL'_-story.

My first attempt was to validate all XML, but while this was the most bulletproof solution, it also was the most CPU-cycle intensive...

However, this still my cause a problem when the same parameters are sent to forms on Symphony websites with POST-variables. I'll try to look into that later...
