### PR TITLE
Fixed the EntryPreRender docs

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -780,7 +780,7 @@
 			 *
 			 * @delegate EntryPreRender
 			 * @param string $context
-			 * '/publish/new/'
+			 * '/publish/edit/'
 			 * @param Section $section
 			 * @param Entry $entry
 			 * @param array $fields


### PR DESCRIPTION
That puzzled me until I found the issue.

The [docs on the site](http://symphony-cms.com/learn/api/2.2.5/delegates/#EntryPreRender) will auto-update?
