### PR TITLE
Button hover

### DIFF
--- a/symphony/assets/css/symphony.forms.css
+++ b/symphony/assets/css/symphony.forms.css
@@ -188,7 +188,7 @@ button.create:focus,
 .button.create:active,
 .button.create:focus {
 	border-color: rgba(50, 70, 23, 0.6);
-	color: #fff;
+	color: rgba(255, 255, 255, 0.99);
 }
 
 /* Delete buttons */
@@ -201,7 +201,7 @@ button.delete:focus,
 .button.delete:focus {
 	background: #dd4422;
 	border-color: #bb2211;
-	color: #fff;
+	color: rgba(255, 255, 255, 0.99);
 }
 
 /* "With selected…" menu */


### PR DESCRIPTION
On webkit when the hover colour is `#fff` the result looks very muddy with the text shadow and background colour. Changing this to _almost_ white fixes it.
