### PR TITLE
Subsection Manager 2 and mysql toolkit

### DIFF
--- a/symphony/lib/toolkit/class.mysql.php
+++ b/symphony/lib/toolkit/class.mysql.php
@@ -524,7 +524,26 @@
 					if(!is_array($array)) continue;
 
 					self::cleanFields($array);
-					$rows[] = '('.implode(', ', $array).')';
+					
+					// check for to see if relation_id is an array of id's
+					if(is_array($array['relation_id'])) {
+						foreach($array as $key => $values) {
+							// get the entry_id
+							$entry_id = $array['entry_id'];
+							// if $values is an array continue
+							if(is_array($values)) {
+								// build rows based on relation_id being an array of id's
+								foreach($values as $value) {
+									$rows[] = "($entry_id, '$value')";
+								}
+							}
+						}
+					}
+					// relation id is not an array of id's, implode
+					else {
+						$rows[] = '('.implode(', ', $array).')';
+					}
+					
 				}
 
 				$sql .= implode(", ", $rows);


### PR DESCRIPTION
I've updated the mysql toolkit with the ability to use Subsection Manager 2. 

The problem is that when trying to assign multiple entries to subsection manager from a frontend event, mysql would error out because 'Array' was passed in for an ID number instead.

I updated the tool kit to check the 'relation_id' to see if it were a string or variable and then adjust accordingly.

Lines 528-542
