### PR TITLE
Allow inline .frames to be used not only SPAN and FIELDSET, but any elem...

### DIFF
--- a/symphony/assets/css/symphony.frames.css
+++ b/symphony/assets/css/symphony.frames.css
@@ -36,7 +36,8 @@
 --------------------------------------------------------------------------*/
 
 span.frame,
-fieldset.frame {
+fieldset.frame,
+.frame.inline {
 	display: block;
 	margin-bottom: 15px;
 	border: 1px solid rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
This adds an additional selector, `.frame.inline` for, well, inline frames, which are not on span or fieldset elements. The `frame` class is quite limited in this regard.
