### PR TITLE
Duplicator

### DIFF
--- a/symphony/assets/js/symphony.duplicator.js
+++ b/symphony/assets/js/symphony.duplicator.js
@@ -60,22 +60,34 @@
 
 		objects.each(function duplicators() {
 			var object = $(this),
-				instances = object.find(settings.instances).addClass('instance'),
-				templates = object.find(settings.templates).addClass('template'),
-				items = instances.add(templates),
-				headers = items.find(settings.headers),
-				duplicator = object.parent('.frame'),
 				apply = $('<fieldset class="apply" />'),
 				selector = $('<select />'),
-				constructor = $('<button type="button" class="constructor">' + (object.attr('data-add') || Symphony.Language.get('Add item')) + '</button>');
-
-			// Check duplicator frame
-			if(duplicator.length == 0) {
-				duplicator = $('<div class="duplicator frame empty" />').insertBefore(object).prepend(object);
+				constructor = $('<button type="button" class="constructor">' + (object.attr('data-add') || Symphony.Language.get('Add item')) + '</button>'),
+				duplicator, list, instances, templates, items, headers;
+				
+			// New API (applying the plugin to the frame)
+			if(object.is('.frame')) {
+				duplicator = object;
+				list = duplicator.find('> ol, > ul');
 			}
+			
+			// Old API (applying the plugin to the list)
 			else {
-				duplicator.addClass('duplicator').addClass('empty');
+				list = object;
+				duplicator = object.parent('.frame');
+	
+				// Check if duplicator frame exists
+				if(duplicator.length == 0) {
+					duplicator = $('<div class="frame" />').insertBefore(object).prepend(object);
+				}
 			}
+
+			// Prepare duplicator
+			duplicator.addClass('duplicator').addClass('empty');
+			instances = list.find(settings.instances).addClass('instance');
+			templates = list.find(settings.templates).addClass('template');
+			items = instances.add(templates);
+			headers = items.find(settings.headers);
 
 		/*-------------------------------------------------------------------*/
 
@@ -87,7 +99,7 @@
 
 				instance.trigger('constructstart.duplicator');
 				instance.trigger('construct.duplicator'); /* deprecated */
-				instance.hide().appendTo(object);
+				instance.hide().appendTo(list);
 
 				// Duplicator is not empty
 				duplicator.removeClass('empty');
@@ -269,7 +281,7 @@
 			// Destructable interface
 			if(settings.destructable === true) {
 				duplicator.addClass('destructable');
-				headers.append('<a class="destructor">' + (object.attr('data-remove') || Symphony.Language.get('Remove item')) + '</a>');
+				headers.append('<a class="destructor">' + (list.attr('data-remove') || Symphony.Language.get('Remove item')) + '</a>');
 			}
 
 			// Collapsible interface


### PR DESCRIPTION
Two changes:
- First of all, this fixes backwards compatibility with old Duplicator implementation
- Secondly, this introduces two separate APIs: one that applies the Duplicator to the list (old style) and another one the applies it to the wrapping frame (new style). This should help making the Duplicator less complex for new developers as it won't add elements _around_ the one the plugin is applied to anymore. These changes are backwards compatible with Symphony 2.3 beta 3 and before.
