### PR TITLE
Animations

### DIFF
--- a/symphony/assets/css/symphony.frames.css
+++ b/symphony/assets/css/symphony.frames.css
@@ -369,8 +369,9 @@ span.frame {
 
 .frame > ol > li .content,
 .frame > ul > li .content {
-	padding: 0 10px 10px;
+	padding: 0 10px;
 	margin: 0 -10px;
+	width: 100%;
 }
 
 .frame > ol > li:last-of-type .content,

--- a/symphony/assets/css/symphony.grids.css
+++ b/symphony/assets/css/symphony.grids.css
@@ -26,6 +26,7 @@
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 	float: left;
+	margin: 0 0 15px;
 	padding: 0 0 0 15px;
 }
 


### PR DESCRIPTION
This pull request switches most of the colours used by `.frames` from RGBA to HEX values. It also removes the box shadow of the headers in the field editor and make sure the animation doesn't "jump" at the end.

This should fix issues with bumpy animations on larger displays in Safari on Mac OS 10.6 and should close #1280.

We have to make sure that the colour changes don't have any side effects as `.frames` are used throughout the interface and maybe some areas are relying on transparent colours. Those areas I'm aware of have been adjusted so everything _should_ work just fine.
