### PR TITLE
Support paragraphs as labels

### DIFF
--- a/symphony/assets/css/symphony.css
+++ b/symphony/assets/css/symphony.css
@@ -76,6 +76,7 @@ p {
 }
 
 p.label {
+	position: relative;
 	margin: 0 0 2px;
 }
 
@@ -196,7 +197,8 @@ label {
 	position: relative;
 }
 
-label > i {
+label > i,
+p.label > i {
 	position: absolute;
 	right: 0;
 	top: 0;


### PR DESCRIPTION
Sometimes you don't want to wrap your field with a `<label>`. There already is a `p.label` style for that, but it doesn't support inline `<i>` help texts. This fixes that. Haven't found any side effects, but maybe someone with a better overview about the backend styles (@nilshoerrmann?) can confirm that this doesn't do any harm.
