### PR TITLE
Fix for Fatal Error in content.blueprintsdatasources.php: Call by reference removed in 5.4

### DIFF
--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -836,7 +836,7 @@
 		// creating a 'big' page and then hiding the fields with JS
 			if(!empty($providers)) {
 				foreach($providers as $providerClass => $provider) {
-					call_user_func(array($providerClass, 'buildEditor'), $this->Form, &$this->_errors, $fields, $handle);
+					call_user_func(array($providerClass, 'buildEditor'), $this->Form, $this->_errors, $fields, $handle);
 				}
 			}
 
@@ -1036,7 +1036,7 @@
 			elseif (!empty($providers)) {
 				foreach($providers as $providerClass => $provider) {
 					if($fields['source'] == call_user_func(array($providerClass, 'getSource'))) {
-						call_user_func(array($providerClass, 'validate'), &$fields, &$this->_errors);
+						call_user_func(array($providerClass, 'validate'), $fields, $this->_errors);
 						break;
 					}
 					unset($providerClass);


### PR DESCRIPTION
Removed three ampersands. Pass by reference was deprecated in PHP 5.0.0 and has been removed in PHP 5.4. See http://www.php.net/manual/en/ini.core.php#ini.allow-call-time-pass-reference
