### PR TITLE
Authors DS spams logs

### DIFF
--- a/symphony/lib/toolkit/data-sources/class.datasource.author.php
+++ b/symphony/lib/toolkit/data-sources/class.datasource.author.php
@@ -84,6 +84,11 @@
 				throw new FrontendPageNotFoundException;
 			}
 
+			elseif(!is_array($authors) || empty($authors)){
+				$result = $this->emptyXMLSet();
+				return $result;
+			}
+
 			else{
 
 				if(!$this->_param_output_only) $result = new XMLElement($this->dsParamROOTELEMENT);


### PR DESCRIPTION
An authors DS doesn't check if any authors are found. (It does, but only in combination with the `dsParamREDIRECTONEMPTY` setting.) So it tries to iterate over the `$authors` array, event though it's `null`, spamming the logs.
