### PR TITLE
Fix the `@total-entries` number in the pagination element for select box...

### DIFF
--- a/symphony/lib/toolkit/fields/field.select.php
+++ b/symphony/lib/toolkit/fields/field.select.php
@@ -79,6 +79,11 @@
 			return true;
 		}
 
+		public function requiresSQLGrouping(){
+			// SQL grouping follows the opposite rule as toggling.
+			return !$this->canToggle();
+		}
+
 	/*-------------------------------------------------------------------------
 		Setup:
 	-------------------------------------------------------------------------*/


### PR DESCRIPTION
... fields with the _allow multiple_ option set

The `@total-entries` number was to high in cases of entries with multiple values because of the missing `DISTINCT` in the generated SQL.
