### PR TITLE
Update symphony/lib/toolkit/fields/field.author.php

### DIFF
--- a/symphony/lib/toolkit/fields/field.author.php
+++ b/symphony/lib/toolkit/fields/field.author.php
@@ -214,7 +214,7 @@
 					$author->getFullName(),
 					array(
 						'id' => (string)$author->get('id'),
-						'email' => md5($author->get('email')),
+						'emailhash' => md5($author->get('email')),
 						'username' => General::sanitize($author->get('username'))
 					)
 				));


### PR DESCRIPTION
Added md5 email hash output to the XML to enable the use of Gravatar avatars for authors in the front-end. (ideal for blogs)
