### PR TITLE
Update symphony/lib/toolkit/fields/field.author.php

### DIFF
--- a/symphony/lib/toolkit/fields/field.author.php
+++ b/symphony/lib/toolkit/fields/field.author.php
@@ -272,6 +272,7 @@
 					$author->getFullName(),
 					array(
 						'id' => (string)$author->get('id'),
+						'email-hash' => md5($author->get('email')),
 						'username' => General::sanitize($author->get('username'))
 					)
 				));


### PR DESCRIPTION
Added md5 email hash output to the XML to enable the use of Gravatar avatars for authors in the front-end. Ideal for blogs and I'm sure loads of other stuff.

(re-submitted for the correct branch, the key is now also called 'email-hash' as requested)
