### PR TITLE
Make sure file exists.

### DIFF
--- a/symphony/lib/core/class.errorhandler.php
+++ b/symphony/lib/core/class.errorhandler.php
@@ -53,6 +53,8 @@
 		 * @return array
 		 */
 		protected static function __nearbyLines($line, $file, $window=5){
+			if( !file_exists($file) ) return array();
+
 			return array_slice(file($file), ($line - 1) - $window, $window * 2, true);
 		}
 


### PR DESCRIPTION
I stumbled across a bug in error handler class.

Here's a [screenshot](http://postimage.org/image/ong7r100x/). Basically, Symphony tries to do something with a file that is not always a file. This commit fixes this by checking for file existence.
