### PR TITLE
Use X-Forwarded-Proto header to detect secure connections

### DIFF
--- a/symphony/lib/boot/defines.php
+++ b/symphony/lib/boot/defines.php
@@ -5,12 +5,6 @@
 	 */
 
 	/**
-	 * Use the Front-End-Https header to support downstream HTTPS proxies
-	 */
-	$https_on = ( $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' ||
-		getenv('HTTPS') ? 'on' : 'off' );
-
-	/**
 	 * Used to determine if Symphony has been loaded, useful to prevent
 	 * files from being accessed directly.
 	 * @var boolean
@@ -224,10 +218,16 @@
 	define_safe('HTTP_USER_AGENT', getenv('HTTP_USER_AGENT'));
 
 	/**
-	 * If HTTPS is on, `__SECURE__` will be set to true, otherwise false
+	 * If HTTPS is on, `__SECURE__` will be set to true, otherwise false. Use union of
+	 * the `HTTPS` environmental variable and the X-Forwarded-Proto header to allow
+	 * downstream proxies to inform the webserver of secured downstream connections
 	 * @var string|boolean
 	 */
-	define_safe('__SECURE__', ($https_on == 'on'));
+	define_safe('__SECURE__',
+		(HTTPS == 'on' ||
+			$_SERVER['HTTP_X_FORWARDED_PROTO'] &&
+			$_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
+	);
 
 	/**
 	 * The base URL of this Symphony install, minus the symphony path.


### PR DESCRIPTION
This pull request is in response to comments form https://github.com/symphonycms/symphony-2/pull/1498

See https://github.com/symphonycms/symphony-2/pull/1498#commitcomment-1987244 for an explanation of the use case for the modification herein.
