### PR TITLE
Add new constant for physical folder url

### DIFF
--- a/install/lib/class.installerpage.php
+++ b/install/lib/class.installerpage.php
@@ -30,11 +30,11 @@
 			$this->setTitle($this->_page_title);
 			$this->addElementToHead(new XMLElement('meta', NULL, array('charset' => 'UTF-8')), 1);
 
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.css', 'screen', 30);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.grids.css', 'screen', 31);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.forms.css', 'screen', 32);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.frames.css', 'screen', 33);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/installer.css', 'screen', 40);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.css', 'screen', 30);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.grids.css', 'screen', 31);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.forms.css', 'screen', 32);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.frames.css', 'screen', 33);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/installer.css', 'screen', 40);
 
 			return parent::generate();
 		}

--- a/symphony/content/content.login.php
+++ b/symphony/content/content.login.php
@@ -21,9 +21,9 @@
 			$this->Html->setDTD('<!DOCTYPE html>'); //PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd"
 			$this->Html->setAttribute('lang', Lang::get());
 			$this->addElementToHead(new XMLElement('meta', NULL, array('http-equiv' => 'Content-Type', 'content' => 'text/html; charset=UTF-8')), 0);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.css', 'screen', 30);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.forms.css', 'screen', 31);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.frames.css', 'screen', 32);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.css', 'screen', 30);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.forms.css', 'screen', 31);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.frames.css', 'screen', 32);
 
 			$this->setTitle(__('%1$s &ndash; %2$s', array(__('Login'), __('Symphony'))));
 

--- a/symphony/lib/boot/defines.php
+++ b/symphony/lib/boot/defines.php
@@ -242,3 +242,10 @@
 	 * @var string
 	 */
 	define_safe('SYMPHONY_URL', URL . '/symphony');
+
+	/**
+	 * Returns the folder name for Symphony as an application
+	 * @since Symphony 2.3.2
+	 * @var string
+	 */
+	define_safe('APPLICATION_URL', URL . '/symphony');

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -338,30 +338,30 @@
 			$this->addElementToHead(new XMLElement('meta', NULL, array('charset' => 'UTF-8')), 0);
 			$this->addElementToHead(new XMLElement('meta', NULL, array('http-equiv' => 'X-UA-Compatible', 'content' => 'IE=edge,chrome=1')), 1);
 
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.css', 'screen', 30);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.legacy.css', 'screen', 31);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.grids.css', 'screen', 32);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.forms.css', 'screen', 34);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.tables.css', 'screen', 34);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.frames.css', 'screen', 33);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.drawers.css', 'screen', 34);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.tabs.css', 'screen', 34);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.notices.css', 'screen', 34);
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/admin.css', 'screen', 40);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.css', 'screen', 30);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.legacy.css', 'screen', 31);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.grids.css', 'screen', 32);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.forms.css', 'screen', 34);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.tables.css', 'screen', 34);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.frames.css', 'screen', 33);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.drawers.css', 'screen', 34);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.tabs.css', 'screen', 34);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.notices.css', 'screen', 34);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/admin.css', 'screen', 40);
 
-			$this->addScriptToHead(SYMPHONY_URL . '/assets/js/jquery.js', 50);
-			$this->addScriptToHead(SYMPHONY_URL . '/assets/js/symphony.js', 60);
-			$this->addScriptToHead(SYMPHONY_URL . '/assets/js/symphony.collapsible.js', 61);
-			$this->addScriptToHead(SYMPHONY_URL . '/assets/js/symphony.orderable.js', 62);
-			$this->addScriptToHead(SYMPHONY_URL . '/assets/js/symphony.selectable.js', 63);
-			$this->addScriptToHead(SYMPHONY_URL . '/assets/js/symphony.duplicator.js', 64);
-			$this->addScriptToHead(SYMPHONY_URL . '/assets/js/symphony.tags.js', 65);
-			$this->addScriptToHead(SYMPHONY_URL . '/assets/js/symphony.suggestions.js', 66);
-			$this->addScriptToHead(SYMPHONY_URL . '/assets/js/symphony.pickable.js', 67);
-			$this->addScriptToHead(SYMPHONY_URL . '/assets/js/symphony.timeago.js', 68);
-			$this->addScriptToHead(SYMPHONY_URL . '/assets/js/symphony.notify.js', 69);
-			$this->addScriptToHead(SYMPHONY_URL . '/assets/js/symphony.drawer.js', 70);
-			$this->addScriptToHead(SYMPHONY_URL . '/assets/js/admin.js', 80);
+			$this->addScriptToHead(APPLICATION_URL . '/assets/js/jquery.js', 50);
+			$this->addScriptToHead(APPLICATION_URL . '/assets/js/symphony.js', 60);
+			$this->addScriptToHead(APPLICATION_URL . '/assets/js/symphony.collapsible.js', 61);
+			$this->addScriptToHead(APPLICATION_URL . '/assets/js/symphony.orderable.js', 62);
+			$this->addScriptToHead(APPLICATION_URL . '/assets/js/symphony.selectable.js', 63);
+			$this->addScriptToHead(APPLICATION_URL . '/assets/js/symphony.duplicator.js', 64);
+			$this->addScriptToHead(APPLICATION_URL . '/assets/js/symphony.tags.js', 65);
+			$this->addScriptToHead(APPLICATION_URL . '/assets/js/symphony.suggestions.js', 66);
+			$this->addScriptToHead(APPLICATION_URL . '/assets/js/symphony.pickable.js', 67);
+			$this->addScriptToHead(APPLICATION_URL . '/assets/js/symphony.timeago.js', 68);
+			$this->addScriptToHead(APPLICATION_URL . '/assets/js/symphony.notify.js', 69);
+			$this->addScriptToHead(APPLICATION_URL . '/assets/js/symphony.drawer.js', 70);
+			$this->addScriptToHead(APPLICATION_URL . '/assets/js/admin.js', 80);
 
 			$this->addElementToHead(
 				new XMLElement(

--- a/symphony/lib/toolkit/class.devkit.php
+++ b/symphony/lib/toolkit/class.devkit.php
@@ -73,7 +73,7 @@
 					'content'		=> 'text/html; charset=UTF-8'
 				)
 			));
-			$this->addStylesheetToHead(SYMPHONY_URL . '/assets/css/devkit.css', 'screen');
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/devkit.css', 'screen');
 		}
 
 		/**

--- a/symphony/template/usererror.database.php
+++ b/symphony/template/usererror.database.php
@@ -9,8 +9,8 @@
 	$Page->Html->setDTD('<!DOCTYPE html>');
 	$Page->Html->setAttribute('xml:lang', 'en');
 	$Page->addElementToHead(new XMLElement('meta', NULL, array('http-equiv' => 'Content-Type', 'content' => 'text/html; charset=UTF-8')), 0);
-	$Page->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.css', 'screen', 30);
-	$Page->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.frames.css', 'screen', 31);
+	$Page->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.css', 'screen', 30);
+	$Page->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.frames.css', 'screen', 31);
 
 	$Page->addHeaderToPage('Status', '500 Internal Server Error', 500);
 	$Page->addHeaderToPage('Content-Type', 'text/html; charset=UTF-8');

--- a/symphony/template/usererror.generic.php
+++ b/symphony/template/usererror.generic.php
@@ -9,8 +9,8 @@
 	$Page->Html->setDTD('<!DOCTYPE html>');
 	$Page->Html->setAttribute('xml:lang', 'en');
 	$Page->addElementToHead(new XMLElement('meta', NULL, array('http-equiv' => 'Content-Type', 'content' => 'text/html; charset=UTF-8')), 0);
-	$Page->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.css', 'screen', 30);
-	$Page->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.frames.css', 'screen', 31);
+	$Page->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.css', 'screen', 30);
+	$Page->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.frames.css', 'screen', 31);
 
 	$Page->addHeaderToPage('Status', '500 Internal Server Error', 500);
 	$Page->addHeaderToPage('Content-Type', 'text/html; charset=UTF-8');

--- a/symphony/template/usererror.missing_extension.php
+++ b/symphony/template/usererror.missing_extension.php
@@ -9,9 +9,9 @@
 	$Page->Html->setDTD('<!DOCTYPE html>');
 	$Page->Html->setAttribute('xml:lang', 'en');
 	$Page->addElementToHead(new XMLElement('meta', NULL, array('http-equiv' => 'Content-Type', 'content' => 'text/html; charset=UTF-8')), 0);
-	$Page->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.css', 'screen', 30);
-	$Page->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.frames.css', 'screen', 31);
-	$Page->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.forms.css', 'screen', 32);
+	$Page->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.css', 'screen', 30);
+	$Page->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.frames.css', 'screen', 31);
+	$Page->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.forms.css', 'screen', 32);
 
 	$Page->addHeaderToPage('Status', '500 Internal Server Error', 500);
 	$Page->addHeaderToPage('Content-Type', 'text/html; charset=UTF-8');

--- a/symphony/template/usererror.xslt.php
+++ b/symphony/template/usererror.xslt.php
@@ -9,8 +9,8 @@
 	$Page->Html->setDTD('<!DOCTYPE html>');
 	$Page->Html->setAttribute('xml:lang', 'en');
 	$Page->addElementToHead(new XMLElement('meta', NULL, array('http-equiv' => 'Content-Type', 'content' => 'text/html; charset=UTF-8')), 0);
-	$Page->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.css', 'screen', 30);
-	$Page->addStylesheetToHead(SYMPHONY_URL . '/assets/css/symphony.frames.css', 'screen', 31);
+	$Page->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.css', 'screen', 30);
+	$Page->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.frames.css', 'screen', 31);
 
 	$Page->addHeaderToPage('Status', '500 Internal Server Error', 500);
 	$Page->addHeaderToPage('Content-Type', 'text/html; charset=UTF-8');


### PR DESCRIPTION
Added a new constant to define the physical folder URL for Symphony. This differentiates the pseudo url to the admin from the physical folder url. We already separate this at htaccess logic level, but it has been overlooked in the core code.

This is in preparation for changing the admin url, as all assets would return a 404 without this.
