### PR TITLE
Changeable admin url (for 2.4)

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,6 +15,14 @@
 		return ($mode == 'administration' ? Administration::instance() : Frontend::instance());
 	}
 
+	// $Configuration is created in bundle.php
+	$adminPath = $Configuration->get('admin-path', 'symphony');
+	if(strpos($_GET['symphony-page'], $adminPath, 0) === 0) {
+		$_GET['symphony-page'] = str_replace($adminPath . '/', '', $_GET['symphony-page']);
+		if($_GET['symphony-page'] == '') unset($_GET['symphony-page']);
+		$_GET['mode'] = 'administration';
+	}
+
 	$renderer = (isset($_GET['mode']) && strtolower($_GET['mode']) == 'administration'
 			? 'administration'
 			: 'frontend');

--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -11,6 +11,7 @@
 
 		###### SYMPHONY ######
 		'symphony' => array(
+			'admin-path' => 'symphony',
 			'pagination_maximum_rows' => '20',
 			'lang' => 'en',
 			'pages_table_nest_children' => 'no',

--- a/install/lib/class.installer.php
+++ b/install/lib/class.installer.php
@@ -364,6 +364,14 @@
 				);
 			}
 
+			// Admin path not entered
+			if(trim($fields['symphony']['admin-path']) == ''){
+				$errors['no-symphony-path']  = array(
+					'msg' => 'No Symphony path entered.',
+					'details' => __('You must enter a path for accessing Symphony, or leave the default. This will be used to access Symphony\'s backend.')
+				);
+			}
+
 			return $errors;
 		}
 

--- a/install/lib/class.installerpage.php
+++ b/install/lib/class.installerpage.php
@@ -241,6 +241,11 @@
 			$this->__appendError(array('general-no-sitename'), $label);
 			$Environment->appendChild($label);
 
+			$label = Widget::label(__('Admin Path'), Widget::Input('fields[symphony][admin-path]', $fields['symphony']['admin-path']));
+
+			$this->__appendError(array('no-symphony-path'), $label);
+			$Environment->appendChild($label);
+
 			$Fieldset = new XMLElement('fieldset', null, array('class' => 'frame'));
 			$Fieldset->appendChild(new XMLElement('legend', __('Date and Time')));
 			$Fieldset->appendChild(new XMLElement('p', __('Customise how Date and Time values are displayed throughout the Administration interface.')));

--- a/install/migrations/2.4.php
+++ b/install/migrations/2.4.php
@@ -1,0 +1,43 @@
+<?php
+
+	Class migration_24 extends Migration{
+
+		static function run($function, $existing_version = null) {
+			self::$existing_version = $existing_version;
+
+			try{
+				$canProceed = self::$function();
+
+				return ($canProceed === false) ? false : true;
+			}
+			catch(DatabaseException $e) {
+				Symphony::Log()->writeToLog('Could not complete upgrading. MySQL returned: ' . $e->getDatabaseErrorCode() . ': ' . $e->getMessage(), E_ERROR, true);
+
+				return false;
+			}
+			catch(Exception $e){
+				Symphony::Log()->writeToLog('Could not complete upgrading because of the following error: ' . $e->getMessage(), E_ERROR, true);
+
+				return false;
+			}
+		}
+
+		static function getVersion(){
+			return '2.4';
+		}
+
+		static function getReleaseNotes(){
+			return 'http://getsymphony.com/download/releases/version/2.4/';
+		}
+
+		static function upgrade(){
+			// 2.3.1
+			if(version_compare(self::$existing_version, '2.3.1', '<=')) {
+				// Add missing config value for index view string length
+				Symphony::Configuration()->set('cell_truncation_length', '75', 'symphony');
+				// Add admin-path to configuration
+				Symphony::Configuration()->set('admin-path', 'symphony', 'symphony');
+			}
+		}
+
+	}

--- a/symphony/lib/boot/bundle.php
+++ b/symphony/lib/boot/bundle.php
@@ -27,6 +27,15 @@
 
 	ini_set('magic_quotes_runtime', 0);
 
+	if(file_exists(DOCROOT . '/manifest/config.php')) {
+		require_once(DOCROOT . '/symphony/lib/core/class.configuration.php');
+		require_once(DOCROOT . '/symphony/lib/toolkit/class.general.php');
+		// Create the $settings var from the config file
+		include(DOCROOT . '/manifest/config.php');
+		$Configuration = new Configuration(true);
+		$Configuration->setArray($settings);
+	}
+
 	require_once(DOCROOT . '/symphony/lib/boot/func.utilities.php');
 	require_once(DOCROOT . '/symphony/lib/boot/defines.php');
 

--- a/symphony/lib/boot/defines.php
+++ b/symphony/lib/boot/defines.php
@@ -241,7 +241,7 @@
 	 * @since Symphony 2.2
 	 * @var string
 	 */
-	define_safe('SYMPHONY_URL', URL . '/symphony');
+	define_safe('SYMPHONY_URL', URL . '/' . $Configuration->get('admin-path', 'symphony'));
 
 	/**
 	 * Returns the folder name for Symphony as an application


### PR DESCRIPTION
**Fixes**

Issue #702

**What this does**

This PR allows the administration URL to be changed via the `symphony => admin-path` setting in the config.php file. The admin path is set initially in the installation process at the top of the configuration list.

**Dependencies that might change**

This PR contains three other PRs to make it work.
- #1544 is a reversion of a previous fix which caused the installation to fail.
- #1542 is a migration file for Symphony 2.4 **Do not upgrade with this migration as it will change and your install will break**.
- #1541 is a new constant for the physical `/symphony` folder, separating from the pseudo admin path for symphony.
