### PR TITLE
Removing pointer cursor from selectable table td

### DIFF
--- a/symphony/assets/css/symphony.tables.css
+++ b/symphony/assets/css/symphony.tables.css
@@ -122,10 +122,6 @@ table.selectable input {
 	display: none;
 }
 
-table.selectable td {
-	cursor: pointer;
-}
-
 tr.selected td {
 	background-color: #668abe;
 	background-image: -webkit-linear-gradient(top, #668abe, #5c83ba);


### PR DESCRIPTION
Re. #1216

I tried using background colour to signal select-ability instead, but it seemed overkill and distracting. I think the pattern of selecting rows is easily learned without a visual indicator, and that I should never have added the pointer cursor in the first place.

@nickdunn @nilshoerrmann
