### PR TITLE
Added the IF EXISTS clause on the delete from entries data table

### DIFF
--- a/symphony/lib/toolkit/class.fieldmanager.php
+++ b/symphony/lib/toolkit/class.fieldmanager.php
@@ -182,7 +182,7 @@
 			Symphony::Database()->delete('tbl_fields_'.$existing->handle(), " `field_id` = '$id'");
 			SectionManager::removeSectionAssociation($id);
 
-			Symphony::Database()->query('DROP TABLE `tbl_entries_data_'.$id.'`');
+			Symphony::Database()->query('DROP TABLE IF EXISTS `tbl_entries_data_'.$id.'`');
 
 			return true;
 		}


### PR DESCRIPTION
I have an extension that provides a field that does not create any entries data. 

But since the FieldManager tries to delete the table when we remove the field from a section, I have to create an empty data table just to make sure that the FieldManager won't crash.

@nickdunn did the same thing in is "Publish Tabs" extension.

So adding the IF EXISTS to the drop SQL command will make this work better.
