### PR TITLE
Added Page::HTTP_NOT_MODIFIED, needed by jit image manip

### DIFF
--- a/symphony/lib/toolkit/class.page.php
+++ b/symphony/lib/toolkit/class.page.php
@@ -35,7 +35,6 @@
 
 		/**
 		 * Refers to the HTTP status code, 304 Not Modified
-		 * This is used as a temporary redirect
 		 *
 		 * @since Symphony 2.3.2
 		 * @var integer


### PR DESCRIPTION
The title says it all.
I just want to be sure this one goes in first before it PR to jit.
