### PR TITLE
In section event class, send parameters by reference

### DIFF
--- a/symphony/lib/toolkit/events/class.event.section.php
+++ b/symphony/lib/toolkit/events/class.event.section.php
@@ -368,7 +368,7 @@
 		 * @param integer $entry_id
 		 * @return boolean
 		 */
-		protected function processPreSaveFilters(XMLElement $result, array $fields, XMLElement $post_values, $entry_id = null) {
+		protected function processPreSaveFilters(XMLElement $result, array &$fields, XMLElement &$post_values, $entry_id = null) {
 			$can_proceed = true;
 
 			/**


### PR DESCRIPTION
Currently the parameters are sent by value thus the modifications done by extensions through the PreSaveFilter delegate are not persisted.

This PR fixes this issue.
