### PR TITLE
Password cleanValue consistency

### DIFF
--- a/symphony/content/content.login.php
+++ b/symphony/content/content.login.php
@@ -155,10 +155,7 @@
 
 				// Login Attempted
 				if($action == 'login'):
-					$username = Symphony::Database()->cleanValue($_POST['username']);
-					$password = Symphony::Database()->cleanValue($_POST['password']);
-
-					if(empty($username) || empty($password) || !Administration::instance()->login($username, $password)) {
+					if(empty($_POST['username']) || empty($_POST['password']) || !Administration::instance()->login($_POST['username'], $_POST['password'])) {
 						/**
 						 * A failed login attempt into the Symphony backend
 						 *
@@ -169,7 +166,7 @@
 						 * @param string $username
 						 *  The username of the Author who attempted to login.
 						 */
-						Symphony::ExtensionManager()->notifyMembers('AuthorLoginFailure', '/login/', array('username' => $username));
+						Symphony::ExtensionManager()->notifyMembers('AuthorLoginFailure', '/login/', array('username' => Symphony::Database()->cleanValue($username)));
 						$this->failedLoginAttempt = true;
 					}
 
@@ -184,7 +181,7 @@
 						 * @param string $username
 						 *  The username of the Author who logged in.
 						 */
-						Symphony::ExtensionManager()->notifyMembers('AuthorLoginSuccess', '/login/', array('username' => $username));
+						Symphony::ExtensionManager()->notifyMembers('AuthorLoginSuccess', '/login/', array('username' => Symphony::Database()->cleanValue($username)));
 
 						isset($_POST['redirect']) ? redirect($_POST['redirect']) : redirect(SYMPHONY_URL);
 					}

--- a/symphony/content/content.systemauthors.php
+++ b/symphony/content/content.systemauthors.php
@@ -520,7 +520,7 @@
 				$this->_Author->set('first_name', General::sanitize($fields['first_name']));
 				$this->_Author->set('last_name', General::sanitize($fields['last_name']));
 				$this->_Author->set('last_seen', NULL);
-				$this->_Author->set('password', (trim($fields['password']) == '' ? '' : Cryptography::hash($fields['password'])));
+				$this->_Author->set('password', (trim($fields['password']) == '' ? '' : Cryptography::hash(Symphony::Database()->cleanValue($fields['password']))));
 				$this->_Author->set('default_area', $fields['default_area']);
 				$this->_Author->set('auth_token_active', ($fields['auth_token_active'] ? $fields['auth_token_active'] : 'no'));
 				$this->_Author->set('language', isset($fields['language']) ? $fields['language'] : null);
@@ -577,7 +577,7 @@
 				if($fields['email'] != $this->_Author->get('email')) $changing_email = true;
 
 				// Check the old password was correct
-				if(isset($fields['old-password']) && strlen(trim($fields['old-password'])) > 0 && Cryptography::compare(trim($fields['old-password']), $this->_Author->get('password'))) {
+				if(isset($fields['old-password']) && strlen(trim($fields['old-password'])) > 0 && Cryptography::compare(Symphony::Database()->cleanValue(trim($fields['old-password'])), $this->_Author->get('password'))) {
 					$authenticated = true;
 				}
 				// Developers don't need to specify the old password, unless it's their own account
@@ -601,7 +601,7 @@
 				$this->_Author->set('language', isset($fields['language']) ? $fields['language'] : null);
 
 				if(trim($fields['password']) != ''){
-					$this->_Author->set('password', Cryptography::hash($fields['password']));
+					$this->_Author->set('password', Cryptography::hash(Symphony::Database()->cleanValue($fields['password'])));
 					$changing_password = true;
 				}
 


### PR DESCRIPTION
This PR tries to fix the inconstent treatment of passwords. Before this PR the situation was as follows:
- Passwords were being `cleanValue`d during installation [[1]](https://github.com/symphonycms/symphony-2/blob/master/install/lib/class.installer.php#L438)
- Passwords were **double** `cleanValue`d during login [[1]](https://github.com/symphonycms/symphony-2/blob/master/symphony/content/content.login.php#L153) [[2]](https://github.com/symphonycms/symphony-2/blob/master/symphony/lib/core/class.symphony.php#L358)
- Passwords were **not** `cleanValue`d during author editing [[1]](https://github.com/symphonycms/symphony-2/blob/master/symphony/content/content.systemauthors.php#L478) [[2]](https://github.com/symphonycms/symphony-2/blob/master/symphony/content/content.systemauthors.php#L559)

This means that in case a user was using any characters being affected by `Database::cleanValue` he would have locked himself out of the backend.

This PR fixes that:
- Passwords are always `cleanValued` before being hashed. There is no point in doing it really as the hash function will remove the threat that comes from unsanitized strings in queries. It's just to give all variables touching the DB the same treatment.
- `Symphony::login()` should not assume the strings to be sanitized so the cleanValuing should go in there.
