### PR TITLE
Entry Associations

### DIFF
--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -12,6 +12,7 @@
 		###### SYMPHONY ######
 		'symphony' => array(
 			'pagination_maximum_rows' => '20',
+            'association_maximum_rows' => '5',
 			'lang' => 'en',
 			'pages_table_nest_children' => 'no',
 			'version' => VERSION,

--- a/install/migrations/2.3.3.php
+++ b/install/migrations/2.3.3.php
@@ -37,6 +37,10 @@
 					"ALTER TABLE `tbl_authors` CHANGE `user_type` `user_type` enum('author', 'manager', 'developer') DEFAULT 'author'",
 					$field
 				));
+
+                if(!Symphony::Configuration()->get('association_maximum_rows', 'symphony')) {
+                    Symphony::Configuration()->set('association_maximum_rows', '5', 'symphony');
+                }
 			}
             return true;
 		}

--- a/symphony/assets/css/symphony.associations.css
+++ b/symphony/assets/css/symphony.associations.css
@@ -1,0 +1,80 @@
+/**
+ * Associations are visualisations of associated entries in Symphony's backend.
+ * They are hidden in Drawers by default and can be expanded on click.
+ *
+ * @since Symphony 2.3
+ */
+
+
+/*-----------------------------------------------------------------------------
+	Horizontal drawers
+-----------------------------------------------------------------------------*/
+
+.association {
+    border-top: 1px solid #D0D0D0;
+    min-height: 30px;
+    color: #666;
+}
+
+.association:first-of-type {
+    margin-top: 20px;
+}
+
+.association:last-of-type {
+    padding-bottom: 15px;
+}
+
+.association a {
+    color: #666;
+}
+
+.association a:hover {
+    color: #323232;
+}
+
+.association header {
+    width: 240px;
+    float: right;
+    padding-top: 6px;
+}
+
+.association header p {
+    margin: 0;
+    padding: 0;
+}
+
+.association header i a {
+    color: rgb(169, 169, 169);
+    border-bottom: none;
+}
+
+.association .association-section {
+    color: #323232;
+}
+
+.association ul {
+    padding: 0 250px 0 0;
+    margin: 0;
+}
+
+.association li {
+    padding-top: 6px;
+    height: 30px;
+    box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.association li:not(:last-of-type) {
+    border-bottom: 1px solid #E6E6E5;
+}
+
+.association:not(.empty) li::before {
+    content: "\2192";
+}
+
+.association.parent li::before {
+    content: "\2190";
+}

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -698,6 +698,9 @@
 				$div->appendChild(Widget::Input('action[save]', __('Create Entry'), 'submit', array('accesskey' => 's')));
 
 				$this->Form->appendChild($div);
+
+				// Create a Drawer for Associated Sections
+				$this->prepareAssociationsDrawer($section);
 			}
 		}
 
@@ -1007,6 +1010,9 @@
 				$div->appendChild($button);
 
 				$this->Form->appendChild($div);
+
+				// Create a Drawer for Associated Sections
+				$this->prepareAssociationsDrawer($section);
 			}
 		}
 
@@ -1125,7 +1131,6 @@
 
 				redirect(SYMPHONY_URL . '/publish/'.$this->_context['section_handle'].'/');
 			}
-
 		}
 
 		/**
@@ -1148,5 +1153,181 @@
 			return $div;
 		}
 
+		/**
+		 * Prepare a Drawer to visualize section associations
+		 *
+		 * @param  Section $section The current Section object
+		 */
+		private function prepareAssociationsDrawer($section){
+			$entry_id = (!is_null($this->_context['entry_id'])) ? $this->_context['entry_id'] : null;
+
+			if(!is_null($entry_id)) {
+				$parent_associations = SectionManager::fetchParentAssociations($section->get('id'), true);
+				$child_associations = SectionManager::fetchChildAssociations($section->get('id'), true);
+
+				$content = null;
+				/**
+				 * Prepare Associations Drawer from an Extension
+				 *
+				 * @since Symphony 2.3.3
+				 * @delegate PrepareAssociationsDrawer
+				 * @param string $context
+				 * '/publish/'
+				 * @param intager $entry_id
+				 *  The entry ID or null
+				 * @param array $parent_associations
+				 *  Array of Sections
+				 * @param array $child_associations
+				 *  Array of Sections
+				 */
+				Symphony::ExtensionManager()->notifyMembers('PrepareAssociationsDrawer', '/publish/', array(
+					'entry_id' => $entry_id,
+					'parent_associations' => $parent_associations,
+					'child_associations' => $child_associations,
+					'content' => $content
+				));
+
+				if(!($content instanceof XMLElement)) {
+					$content = new XMLElement('div', null, array('class' => 'content'));
+					$content->setSelfClosingTag(false);
+
+					// Process Parent Associations
+					if(!is_null($parent_associations) && !empty($parent_associations)) foreach($parent_associations as $as){
+						$entries_ids = $this->findRelatedEntries($as['parent_section_field_id'], $entry_id);
+						$entries = EntryManager::fetch($entries_ids, $as['parent_section_id']);
+
+						$element = new XMLElement('section', null, array('class' => 'association parent'));
+
+						$header = new XMLElement('header');
+						$header->appendChild(new XMLElement('p', __('Linked to') . ' ' . '<a class="association-section" href="' . SYMPHONY_URL . '/publish/' . $as['handle'] . '/">' . $as['name'] . '</a>'));
+						$element->appendChild($header);
+
+						$ul = new XMLElement('ul', null, array(
+							'class' => 'association-links',
+							'data-section-id' => $as['child_section_id'],
+							'data-association-ids' => implode(', ', $entries_ids)
+						));
+
+						foreach($entries as $e) {
+							$f = $e->getData($as['parent_section_field_id']);
+							$li = new XMLElement('li');
+							$a = new XMLElement('a', $f['value']);
+							$a->setAttribute('href', SYMPHONY_URL . '/publish/' . $as['handle'] . '/edit/' . $e->get('id'));
+							$li->appendChild($a);
+							$ul->appendChild($li);
+						}
+
+						$element->appendChild($ul);
+						$content->appendChild($element);
+					}
+
+					// Process Child Associations
+					if(!is_null($child_associations) && !empty($child_associations)) foreach($child_associations as $as){
+						$entries_ids = $this->findRelatedEntries($as['child_section_field_id'], $entry_id);
+						$entries = (!empty($entries_ids)) ? EntryManager::fetch($entries_ids, $as['child_section_id']) : array();
+
+						$child_section = SectionManager::fetch($as['child_section_id']);
+
+						$element = new XMLElement('section', null, array('class' => 'association child'));
+						$header = new XMLElement('header');
+
+						$field_name = FieldManager::fetchHandleFromID($as['child_section_field_id']);
+						$filter = '?filter[' . $field_name . ']=' . $this->_context['entry_id'];
+						$prepopulate = '?prepopulate[' . $as['child_section_field_id'] . ']=' . $this->_context['entry_id'];
+
+						// Create link with filter or prepopulate
+						if(!empty($entries_ids) && !is_null($entries_ids[0])) {
+							$link = SYMPHONY_URL . '/publish/' . $as['handle'] . '/' . $filter;
+						}
+						else {
+							$link = SYMPHONY_URL . '/publish/' . $as['handle'] . '/new/' . $prepopulate;
+						}
+
+						$a = new XMLElement('a', $as['name'], array(
+							'class' => 'association-section',
+							'href' => $link
+						));
+
+						$max = count($entries);
+						$show = ($num = Symphony::Configuration()->get('association_maximum_rows', 'symphony')) ? $num : 5;
+						if($max < $show) {
+							$show = $max;
+						}
+						$i = new XMLElement('i', sprintf(
+							__('%d of %d entries'),
+							$show,
+							$max
+						));
+
+						if($max) {
+							$counts = '<br />' . $i->generate();
+						}
+						else {
+							$countrs = '';
+						}
+
+						$header->appendChild(new XMLElement('p', __('Linked From') . ' ' . $a->generate() . $counts));
+						$element->appendChild($header);
+
+						$ul = new XMLElement('ul', null, array(
+							'class' => 'association-links',
+							'data-section-id' => $as['child_section_id']
+						));
+
+						if(!empty($entries)) {
+							$ul->setAttribute('data-association-ids', implode(', ', $entries_ids));
+
+							foreach($entries as $key => $e) {
+								$f = $e->getData($child_section->getDefaultSortingField());
+								$li = new XMLElement('li');
+								$a = new XMLElement('a', $f['value']);
+								$a->setAttribute('href', SYMPHONY_URL . '/publish/' . $as['handle'] . '/edit/' . $e->get('id') . '/' . $prepopulate);
+								$li->appendChild($a);
+								$ul->appendChild($li);
+							}
+						}
+						else {
+							$ul->setAttribute('data-association-ids', '');
+							$li = new XMLElement('li', __('No linked entries yet.'));
+							$ul->appendChild($li);
+						}
+
+						$element->appendChild($ul);
+						$content->appendChild($element);
+					}
+				}
+			}
+			else {
+				$content = new XMLElement('div', null, array('class' => 'content'));
+				$content->setSelfClosingTag(false);
+
+				$p = new XMLElement('p', __('Please save your entry before you can associate other entries.'));
+				$content->appendChild($p);
+			}
+			$drawer = Widget::Drawer('section-associations', 'Show Associations', $content);
+			$this->insertDrawer($drawer, 'horizontal', 'prepend');
+		}
+
+		/**
+		 * Find related entries from a linking field's data table. Requires the
+		 * column names to be `entry_id` and `relation_id` as with the Select Box Link
+		 * @param  [type] $field_id [description]
+		 * @param  [type] $entry_id [description]
+		 * @return [type]           [description]
+		 */
+		public function findRelatedEntries($field_id = null, $entry_id) {
+			try {
+				$ids = Symphony::Database()->fetchCol('entry_id', sprintf("
+					SELECT `entry_id`
+					FROM `tbl_entries_data_%d`
+					WHERE `relation_id` = %d
+				", $field_id, $entry_id));
+			}
+			catch(Exception $e){
+				return array();
+			}
+
+			return $ids;
+		}
 	}
 

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -159,7 +159,7 @@
 		 * Given a `$message` and an optional `$type`, this function will
 		 * add an Alert instance into this page's `$this->Alert` property.
 		 * Since Symphony 2.3, there may be more than one `Alert` per page.
- 		 * Unless the Alert is an Error, it is required the `$message` be
+		 * Unless the Alert is an Error, it is required the `$message` be
 		 * passed to this function.
 		 *
 		 * @param string $message
@@ -349,8 +349,9 @@
 			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.forms.css', 'screen', 34);
 			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.tables.css', 'screen', 34);
 			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.frames.css', 'screen', 33);
-			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.drawers.css', 'screen', 34);
 			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.tabs.css', 'screen', 34);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.drawers.css', 'screen', 34);
+			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.associations.css', 'screen', 34);
 			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/symphony.notices.css', 'screen', 34);
 			$this->addStylesheetToHead(APPLICATION_URL . '/assets/css/admin.css', 'screen', 40);
 

--- a/symphony/lib/toolkit/class.section.php
+++ b/symphony/lib/toolkit/class.section.php
@@ -146,8 +146,48 @@
 		 * @return array
 		 */
 		public function fetchAssociatedSections($respect_visibility = false){
-			return SectionManager::fetchAssociatedSections($this->get('id'), $respect_visibility);
+			return SectionManager::fetchChildAssociations($this->get('id'), $respect_visibility);
 		}
+
+        /**
+         * Returns any section associations this section has with other sections
+         * linked using fields, and where this section is the parent in the association.
+         * Has an optional parameter, `$respect_visibility` that
+         * will only return associations that are deemed visible by a field that
+         * created the association. eg. An articles section may link to the authors
+         * section, but the field that links these sections has hidden this association
+         * so an Articles column will not appear on the Author's Publish Index
+         *
+         * @since Symphony 2.4
+         * @param boolean $respect_visibility
+         *  Whether to return all the section associations regardless of if they
+         *  are deemed visible or not. Defaults to false, which will return all
+         *  associations.
+         * @return array
+         */
+        public function fetchChildAssociations($respect_visibility = false){
+            return SectionManager::fetchChildAssociations($this->get('id'), $respect_visibility);
+        }
+
+        /**
+         * Returns any section associations this section has with other sections
+         * linked using fields, and where this section is the child in the association.
+         * Has an optional parameter, `$respect_visibility` that
+         * will only return associations that are deemed visible by a field that
+         * created the association. eg. An articles section may link to the authors
+         * section, but the field that links these sections has hidden this association
+         * so an Articles column will not appear on the Author's Publish Index
+         *
+         * @since Symphony 2.4
+         * @param boolean $respect_visibility
+         *  Whether to return all the section associations regardless of if they
+         *  are deemed visible or not. Defaults to false, which will return all
+         *  associations.
+         * @return array
+         */
+        public function fetchParentAssociations($respect_visibility = false){
+            return SectionManager::fetchParentAssociations($this->get('id'), $respect_visibility);
+        }
 
 		/**
 		 * Returns an array of all the fields in this section that are to be displayed

--- a/symphony/lib/toolkit/class.sectionmanager.php
+++ b/symphony/lib/toolkit/class.sectionmanager.php
@@ -267,17 +267,71 @@
 		 * @return array
 		 */
 		public static function fetchAssociatedSections($section_id, $respect_visibility = false) {
-			return Symphony::Database()->fetch(sprintf("
-					SELECT *
-					FROM `tbl_sections_association` AS `sa`, `tbl_sections` AS `s`
-					WHERE `sa`.`parent_section_id` = %d
-					AND `s`.`id` = `sa`.`child_section_id`
-					%s
-					ORDER BY `s`.`sortorder` ASC
-				",
-				$section_id,
-				($respect_visibility) ? "AND `sa`.`hide_association` = 'no'" : ""
-			));
+			self::fetchChildAssociations($section_id, $respect_visibility);
 		}
+
+        /**
+         * Returns any section associations this section has with other sections
+         * linked using fields, and where this section is the parent in the association.
+         * Has an optional parameter, `$respect_visibility` that
+         * will only return associations that are deemed visible by a field that
+         * created the association. eg. An articles section may link to the authors
+         * section, but the field that links these sections has hidden this association
+         * so an Articles column will not appear on the Author's Publish Index
+         *
+         * @since Symphony 2.4
+         * @param integer $section_id
+         *  The ID of the section
+         * @param boolean $respect_visibility
+         *  Whether to return all the section associations regardless of if they
+         *  are deemed visible or not. Defaults to false, which will return all
+         *  associations.
+         * @return array
+         */
+        public static function fetchChildAssociations($section_id, $respect_visibility = false) {
+            return Symphony::Database()->fetch(sprintf("
+                    SELECT *
+                    FROM `tbl_sections_association` AS `sa`, `tbl_sections` AS `s`
+                    WHERE `sa`.`parent_section_id` = %d
+                    AND `s`.`id` = `sa`.`child_section_id`
+                    %s
+                    ORDER BY `s`.`sortorder` ASC
+                ",
+                $section_id,
+                ($respect_visibility) ? "AND `sa`.`hide_association` = 'no'" : ""
+            ));
+        }
+
+        /**
+         * Returns any section associations this section has with other sections
+         * linked using fields, and where this section is the child in the association.
+         * Has an optional parameter, `$respect_visibility` that
+         * will only return associations that are deemed visible by a field that
+         * created the association. eg. An articles section may link to the authors
+         * section, but the field that links these sections has hidden this association
+         * so an Articles column will not appear on the Author's Publish Index
+         *
+         * @since Symphony 2.4
+         * @param integer $section_id
+         *  The ID of the section
+         * @param boolean $respect_visibility
+         *  Whether to return all the section associations regardless of if they
+         *  are deemed visible or not. Defaults to false, which will return all
+         *  associations.
+         * @return array
+         */
+        public static function fetchParentAssociations($section_id, $respect_visibility = false) {
+            return Symphony::Database()->fetch(sprintf("
+                    SELECT *
+                    FROM `tbl_sections_association` AS `sa`, `tbl_sections` AS `s`
+                    WHERE `sa`.`child_section_id` = %d
+                    AND `s`.`id` = `sa`.`parent_section_id`
+                    %s
+                    ORDER BY `s`.`sortorder` ASC
+                ",
+                $section_id,
+                ($respect_visibility) ? "AND `sa`.`hide_association` = 'no'" : ""
+            ));
+        }
 
 	}


### PR DESCRIPTION
This is the first step towards a customisable visualisation of associations.
#### What This PR Does

This Pull Request creates a Drawer to visualise incoming and outgoing associations between sections and entries using the in built methods within Symphony. If the entry is in the process of being created, a message is shown.
#### What This PR Does Not Do

~~This doesn't allow for customising the drawer contents, as this is only the first step. After this is implemented and tested thoroughly, we can address how to customise this properly.~~
#### Thanks (like an oscar acceptance speech)

Thanks go to @brendo for his insight into this, and to @nilshoerrmann for his help with the HTML and CSS, and also for the long conversations about how we tackle this.
