### PR TITLE
Regex fix for DS filter operation

### DIFF
--- a/symphony/lib/toolkit/class.datasource.php
+++ b/symphony/lib/toolkit/class.datasource.php
@@ -194,7 +194,7 @@
 		 *  DataSource::FILTER_OR or DataSource::FILTER_AND
 		 */
 		public function __determineFilterType($value){
-			return preg_match('/\s*\+\s*/', $value) ? DataSource::FILTER_AND : DataSource::FILTER_OR;
+			return preg_match('/\s+\+\s+/', $value) ? DataSource::FILTER_AND : DataSource::FILTER_OR;
 		}
 
 		/**


### PR DESCRIPTION
Fix regex to allow 0 or more spaces either side of the `+` operator in DS filters. This is more in keeping with the original code.

Addresses issue #1715
