### PR TITLE
Issue 1736, wrapped object attributes in quotes for admin.js 

### DIFF
--- a/symphony/assets/js/admin.js
+++ b/symphony/assets/js/admin.js
@@ -400,15 +400,15 @@
 			// Field legend
 			var fieldLegend = contents.find('#fields legend'),
 				fieldExpand = $('<a />', {
-					class: 'expand',
-					text: Symphony.Language.get('Expand all fields')
+					'class': 'expand',
+					'text': Symphony.Language.get('Expand all fields')
 				}),
 				fieldCollapse = $('<a />', {
-					class: 'collapse',
-					text: Symphony.Language.get('Collapse all fields')
+					'class': 'collapse',
+					'text': Symphony.Language.get('Collapse all fields')
 				}),
 				fieldToggle = $('<p />', {
-					class: 'help toggle'
+					'class': 'help toggle'
 				}).append(fieldExpand).append('<br />').append(fieldCollapse),
 				fieldLegendTop, fieldToggleTop;
 


### PR DESCRIPTION
As discussed (briefly) in #1736, this is a minor fix that improves compatibility for admin.js
