### PR TITLE
Error when removing associated section or field

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -392,13 +392,21 @@
 			$toggable_fields = $section->fetchToggleableFields();
 
 			if (is_array($toggable_fields) && !empty($toggable_fields)) {
+
 				$index = 2;
 
 				foreach ($toggable_fields as $field) {
-					$options[$index] = array('label' => __('Set %s', array($field->get('label'))), 'options' => array());
 
-					foreach ($field->getToggleStates() as $value => $state) {
-						$options[$index]['options'][] = array('toggle-' . $field->get('id') . '-' . $value, false, $state);
+					$toggle_states = $field->getToggleStates();
+
+					if (is_array($toggle_states)) {
+
+						$options[$index] = array('label' => __('Set %s', array($field->get('label'))), 'options' => array());
+
+						foreach ($toggle_states as $value => $state) {
+
+							$options[$index]['options'][] = array('toggle-' . $field->get('id') . '-' . $value, false, $state);
+						}
 					}
 
 					$index++;


### PR DESCRIPTION
Symphony throws an error on accessing a section's publish interface when an associated section or field has been removed.
