### PR TITLE
Update bundle.php

### DIFF
--- a/symphony/lib/boot/bundle.php
+++ b/symphony/lib/boot/bundle.php
@@ -32,7 +32,7 @@
 
 	if (!file_exists(CONFIG)) {
 
-		$bInsideInstaller = (bool)preg_match('%/install/index.php$%', $_SERVER['SCRIPT_FILENAME']);
+		$bInsideInstaller = (bool)preg_match('%(/|\\\\)install(/|\\\\)index.php$%', $_SERVER['SCRIPT_FILENAME']);
 
 		if (!$bInsideInstaller && file_exists(DOCROOT . '/install/index.php')) {
 			header(sprintf('Location: %s/install/', URL));


### PR DESCRIPTION
Install Symphony using IIS on windows doesn't work because windows uses backslashes in $_SERVER['SCRIPT_FILENAME'] instead of forward slashes. The changed preg_match now checks for both.
