### PR TITLE
Fix file rename issues.

### DIFF
--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -433,6 +433,9 @@
 			$abs_path = DOCROOT . '/' . trim($this->get('destination'), '/');
 			$rel_path = str_replace('/workspace', '', $this->get('destination'));
 
+			// Sanitize the filename
+			$data['name'] = Lang::createFilename($data['name']);
+
 			// If a file already exists, then rename the file being uploaded by
 			// adding `_1` to the filename. If `_1` already exists, the logic
 			// will keep adding 1 until a filename is available (#672)
@@ -451,8 +454,6 @@
 				$data['name'] = str_replace($abs_path . '/', '', $renamed_file);
 			}
 
-			// Sanitize the filename
-			$data['name'] = Lang::createFilename($data['name']);
 			$file = rtrim($rel_path, '/') . '/' . trim($data['name'], '/');
 
 			// Attempt to upload the file:


### PR DESCRIPTION
If filename is anything but a valid `Lang::createFilename()`, the algorithm fails to correctly rename duplicate files.

Example on current code:

```
File #1: "foo bar.jpg"
Does "path/to/images/foo bar.jpg" exist? No. Continue.
Create file handle => "foo-bar.jpg"
...

File #2: "foo bar.jpg"
Does "path/to/images/foo bar.jpg" exist? No. Continue.
Create file handle => "foo-bar.jpg"
=> file duplication not detected
...
```

Example with patched code:

```
File #1: "foo bar.jpg"
Create file handle => "foo-bar.jpg"
Does "path/to/images/foo-bar.jpg" exist? No. Continue.
...

File #2: "foo bar.jpg"
Create file handle => "foo-bar.jpg"
Does "path/to/images/foo-bar.jpg" exist? Yes. Run duplicate file algorithm. Continue.
=> file duplication fixed
...
```
