### PR TITLE
Data Source Section: Fixed a bug when the group param is a field that got deleted

### DIFF
--- a/symphony/lib/toolkit/data-sources/class.datasource.section.php
+++ b/symphony/lib/toolkit/data-sources/class.datasource.section.php
@@ -516,7 +516,7 @@
 						$groups = self::$_fieldPool[$this->dsParamGROUP]->groupRecords($entries['records']);
 
 						if (self::$_fieldPool[$this->dsParamGROUP] == NULL) {
-							throw new SymphonyErrorPage(vsprintf("The parameter group '%s' is not valid", $this->dsParamGROUP));
+							throw new SymphonyErrorPage(vsprintf("The field used for grouping '%s' cannot be found.", $this->dsParamGROUP));
 						}
 						
 						foreach($groups as $element => $group){


### PR DESCRIPTION
I just ran into this bug. I deleted a field that was used for DS grouping, but the pages that used this DS crashed with the ugly php error page.

I only added a simple check to see that the group field was found. If not, I throw a `new SymphonyErrorPage`. (class that MUST be renamed by the way). Since the `execute` function is called in a try {} catch () {}, the error page does not show up. Instead, the page load normally and the DS outputs the error in the xml in the error tag, which is pretty neat BTW.
