### PR TITLE
Fix upload field export

### DIFF
--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -606,16 +606,16 @@
 		public function prepareExportValue($data, $mode, $entry_id = null) {
 			$modes = (object)$this->getExportModes();
 
-			$file = $this->getFilePath($data['file']);
+			$filepath = $this->getFilePath($data['file']);
 
 			// No file, or the file that the entry is meant to have no
 			// longer exists.
-			if (!isset($data['file']) || !is_file($file)) {
+			if (!isset($data['file']) || !is_file($filepath)) {
 				return null;
 			}
 
 			if ($mode === $modes->getFilename) {
-				return $file;
+				return $data['file'];
 			}
 
 			if ($mode === $modes->getObject) {


### PR DESCRIPTION
Make sure that the function does what it says: If I use the export mode `getFilename`, it should return the file's name and not its path. If the file path is needed, a different mode is needed.

This is important for fields like SBL using the export to fetch the related field's values.
