### PR TITLE
make sure we still pass the entry id even if the data array is empty

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -1182,11 +1182,6 @@
 		private function __wrapFieldWithDiv(Field $field, Entry $entry){
 			$is_hidden = $this->isFieldHidden($field);
 			$data = $entry->getData($field->get('id'));
-			// make sure we still pass the entry id
-			// even if the data array is empty
-			if (!isset($data['entry-id'])) {
-				$data['entry-id'] = $entry->get('id');
-			}
 			$div = new XMLElement('div', NULL, array('id' => 'field-' . $field->get('id'), 'class' => 'field field-'.$field->handle().($field->get('required') == 'yes' ? ' required' : '').($is_hidden == true ? ' irrelevant' : '')));
 			$field->displayPublishPanel(
 				$div, $data,

--- a/symphony/lib/toolkit/class.entry.php
+++ b/symphony/lib/toolkit/class.entry.php
@@ -184,8 +184,12 @@
 		 *  returned.
 		 */
 		public function getData($field_id=null, $asObject=false){
-			$fieldData = isset($this->_data[$field_id]) ? $this->_data[$field_id] : array();
-
+			$fieldData = isset($this->_data[$field_id]) ? 
+				$this->_data[$field_id] :
+				array(
+					'entry-id' => $this->get('id')
+				);
+			
 			if(!$field_id) return $this->_data;
 			return ($asObject == true ? (object)$fieldData : $fieldData);
 		}


### PR DESCRIPTION
The title says it all! I have a couple of field that does not need any data table, but this made the field unaware of it's entry id. This solve the problem.
