### PR TITLE
Make sure $where can really be null

### DIFF
--- a/symphony/lib/toolkit/class.mysql.php
+++ b/symphony/lib/toolkit/class.mysql.php
@@ -650,7 +650,7 @@
 			$sql = "DELETE FROM $table";
 			
 			if (!is_null($where)) {
-				$sql .= "WHERE $where";
+				$sql .= " WHERE $where";
 			}
 			
 			return $this->query($sql);


### PR DESCRIPTION
I stumble across this bug. Read the doc, it was saying that WHERE could be null, but turns out you can't.
This fixes it.
