### PR TITLE
Make sure form autocomplete is off on passwords inputs

### DIFF
--- a/symphony/content/content.systemauthors.php
+++ b/symphony/content/content.systemauthors.php
@@ -391,7 +391,7 @@
 				$fieldset->setAttribute('class', 'three columns');
 
 				$label = Widget::Label(NULL, NULL, 'column');
-				$label->appendChild(Widget::Input('fields[old-password]', NULL, 'password', array('placeholder' => __('Old Password'))));
+				$label->appendChild(Widget::Input('fields[old-password]', NULL, 'password', array('placeholder' => __('Old Password'), 'autocomplete' => 'off')));
 				$fieldset->appendChild((isset($this->_errors['old-password']) ? Widget::Error($label, $this->_errors['old-password']) : $label));
 			}
 
@@ -399,12 +399,12 @@
 			$callback = Administration::instance()->getPageCallback();
 			$placeholder = ($callback['context'][0] == 'edit' ? __('New Password') : __('Password'));
 			$label = Widget::Label(NULL, NULL, 'column');
-			$label->appendChild(Widget::Input('fields[password]', NULL, 'password', array('placeholder' => $placeholder)));
+			$label->appendChild(Widget::Input('fields[password]', NULL, 'password', array('placeholder' => $placeholder, 'autocomplete' => 'off')));
 			$fieldset->appendChild((isset($this->_errors['password']) ? Widget::Error($label, $this->_errors['password']) : $label));
 
 			// Confirm password
 			$label = Widget::Label(NULL, NULL, 'column');
-			$label->appendChild(Widget::Input('fields[password-confirmation]', NULL, 'password', array('placeholder' => __('Confirm Password'))));
+			$label->appendChild(Widget::Input('fields[password-confirmation]', NULL, 'password', array('placeholder' => __('Confirm Password'), 'autocomplete' => 'off')));
 			$fieldset->appendChild((isset($this->_errors['password-confirmation']) ? Widget::Error($label, $this->_errors['password']) : $label));
 
 			$group->appendChild($fieldset);

--- a/symphony/lib/toolkit/email-gateways/email.smtp.php
+++ b/symphony/lib/toolkit/email-gateways/email.smtp.php
@@ -357,12 +357,12 @@
 
 			$label = Widget::Label(__('Username'));
 			$label->setAttribute('class', 'column');
-			$label->appendChild(Widget::Input('settings[email_smtp][username]', $this->_user));
+			$label->appendChild(Widget::Input('settings[email_smtp][username]', $this->_user, 'text', array('autocomplete' => 'off')));
 			$div->appendChild($label);
 
 			$label = Widget::Label(__('Password'));
 			$label->setAttribute('class', 'column');
-			$label->appendChild(Widget::Input('settings[email_smtp][password]', $this->_pass, 'password'));
+			$label->appendChild(Widget::Input('settings[email_smtp][password]', $this->_pass, 'password', array('autocomplete' => 'off')));
 			$div->appendChild($label);
 			$group->appendChild($div);
 


### PR DESCRIPTION
This is a proposal to solve a problem I have been having since day one.

I always save my password for the login page, but this make Chrome adding my password BY DEFAULT on the create author and preferences pages.

This made my password visible throught the config.php page... Bummer.

I hope you guys like it. It not, the debate is open!
