### PR TITLE
Fix for permissions of config file after saving

### DIFF
--- a/symphony/lib/core/class.configuration.php
+++ b/symphony/lib/core/class.configuration.php
@@ -198,8 +198,8 @@
 		 * @return boolean
 		 */
 		public function write($file = null, $permissions = null) {
-			if(is_null($permissions) && isset($this->_properties['write_mode']['file'])) {
-				$permissions = $this->_properties['write_mode']['file'];
+			if(is_null($permissions) && isset($this->_properties['file']['write_mode'])) {
+				$permissions = $this->_properties['file']['write_mode'];
 			}
 
 			if(is_null($file)) {


### PR DESCRIPTION
When saving the config file, Symphony always refused to set the correct permissions. Not anymore. Fortunately, the fix was pretty simple. :-)
