### PR TITLE
Make sure generate wont fail is the value is an array

### DIFF
--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -337,13 +337,17 @@
 		 * whether the value should be prepended or appended
 		 * to the children.
 		 *
-		 * @param string $value
+		 * @param string|XMLElement|array $value
 		 * @param boolean $prepend (optional)
 		 *  Defaults to true.
 		 */
 		public function setValue($value, $prepend=true){
-			$value = ($value instanceof XMLElement) ? $value->generate(false) : $value;
-
+			if ($value instanceof XMLElement) {
+				$value = $value->generate(false);
+			} else if (is_array($value)) {
+				$value = implode(', ', $value);
+			}
+			
 			if(!$prepend) $this->_placeValueAfterChildElements = true;
 			$this->_value = $value;
 		}


### PR DESCRIPTION
I accidentally passed an array to `XMLElement->setValue` and that made generate when checking `strlen($this->_value) != 0`

I just imploded the array, as we do often in Symphony.

I really think having an imploded value is better than a full crash.
