### PR TITLE
Dynamically fetch event documentation

### DIFF
--- a/symphony/assets/js/admin.js
+++ b/symphony/assets/js/admin.js
@@ -579,7 +579,7 @@
 				var current = dsNameChangeCount = dsNameChangeCount + 1,
 					value = dsName.val();
 
-				if (!!value) {
+				if(!!value) {
 					setTimeout(function fetchDsHandle(dsNameChangeCount, current, dsName, dsParams) {
 						if(dsNameChangeCount == current) {
 							$.ajax({
@@ -698,6 +698,59 @@
 			contents.find('.duplicator:has(.suggestable)').symphonySuggestions();
 		}
 
+	/*--------------------------------------------------------------------------
+		Blueprints - Event Editor
+	--------------------------------------------------------------------------*/
+
+		if(body.is('#blueprints-events')) {
+			var eventContext = $('#event-context'),
+				eventFilters = $('#event-filters'),
+				eventName = contents.find('input[name="fields[name]"]').attr('data-updated', 0),
+				eventNameChangeCount = 0;
+
+			// Update event handle
+			eventName.on('blur.admin input.admin', function updateEventHandle() {
+				var current = eventNameChangeCount = eventNameChangeCount + 1,
+					value = eventName.val();
+
+				if(!!value) {
+					setTimeout(function checkEventHandle(eventNameChangeCount, current) {
+						if(eventNameChangeCount == current) {
+							contents.trigger('update.admin');
+						}
+					}, 500, eventNameChangeCount, current);
+				}
+			});
+
+			// Change context
+			eventContext.on('change.admin', function changeEventContext() {
+				contents.trigger('update.admin');
+			});
+
+			// Change filters
+			eventFilters.on('change.admin', function changeEventFilters() {
+				contents.trigger('update.admin');
+			});
+
+			// Update documentation
+			contents.on('update.admin', function updateEventDocumentation() {
+				$.ajax({
+					type: 'POST',
+					data: { 
+						'section': eventContext.val(),
+						'filters': eventFilters.serializeArray(),
+						'name': eventName.val()
+					},
+					dataType: 'json',
+					url: Symphony.Context.get('root') + '/symphony/ajax/event-documentation/',
+					success: function(documentation) {
+						$('event-documentation').remove();
+						form.append(documentation);
+					}
+				});
+			});
+		}
+	
 	/*--------------------------------------------------------------------------
 		System - Authors
 	--------------------------------------------------------------------------*/

--- a/symphony/content/content.blueprintsevents.php
+++ b/symphony/content/content.blueprintsevents.php
@@ -132,25 +132,13 @@
 				$fieldset->setAttribute('class', 'settings');
 				$fieldset->appendChild(new XMLElement('legend', __('Essentials')));
 
-				$group = new XMLElement('div');
-				$group->setAttribute('class', 'two columns');
-
-			// Name
-				$label = Widget::Label(__('Name'));
-				$label->appendChild(Widget::Input('fields[name]', General::sanitize($fields['name'])));
-
-				$div = new XMLElement('div');
-				$div->setAttribute('class', 'column');
-				if(isset($this->_errors['name'])) {
-					$div->appendChild(Widget::Error($label, $this->_errors['name']));
-				}
-				else {
-					$div->appendChild($label);
-				}
-				$group->appendChild($div);
-
 			// Source
-				$label = Widget::Label(__('Source'));
+				$sources = new XMLElement('div', null, array('class' => 'apply actions'));
+				$div = new XMLElement('div');
+				$label = Widget::Label(__('Source'), null, 'apply-label-left');
+				$sources->appendChild($label);
+				$sources->appendChild($div);
+
 				$sections = SectionManager::fetch(NULL, 'ASC', 'name');
 				$options = array();
 				$section_options = array();
@@ -178,28 +166,37 @@
 					$options[] = $p;
 				}
 
-				$label->appendChild(
+				$div->appendChild(
 					Widget::Select('fields[source]', $options, array('id' => 'event-context'))
 				);
 
+				if(isset($this->_errors['source'])) {
+					$this->Context->prependChild(Widget::Error($sources, $this->_errors['source']));
+				}
+				else {
+					$this->Context->prependChild($sources);
+				}
+
+			// Name
+				$group = new XMLElement('div');
+				$label = Widget::Label(__('Name'));
+				$label->appendChild(Widget::Input('fields[name]', General::sanitize($fields['name'])));
+
 				$div = new XMLElement('div');
 				$div->setAttribute('class', 'column');
-				if(isset($this->_errors['source'])) {
-					$div->appendChild(Widget::Error($label, $this->_errors['source']));
+				if(isset($this->_errors['name'])) {
+					$div->appendChild(Widget::Error($label, $this->_errors['name']));
 				}
 				else {
 					$div->appendChild($label);
 				}
-
 				$group->appendChild($div);
 				$fieldset->appendChild($group);
 				$this->Form->appendChild($fieldset);
 
 				// Filters
 				$fieldset = new XMLElement('fieldset');
-				$fieldset->setAttribute('id', 'sections');
 				$fieldset->setAttribute('class', 'settings pickable');
-				$fieldset->setAttribute('data-relation', 'event-context');
 				$fieldset->appendChild(new XMLElement('legend', __('Filters')));
 				$p = new XMLElement('p',
 					__('Event Filters add additional conditions or actions to an event.')
@@ -230,7 +227,7 @@
 					'options' => &$options
 				));
 
-				$fieldset->appendChild(Widget::Select('fields[filters][]', $options, array('multiple' => 'multiple')));
+				$fieldset->appendChild(Widget::Select('fields[filters][]', $options, array('multiple' => 'multiple', 'id' => 'event-filters')));
 
 				$this->Form->appendChild($fieldset);
 
@@ -291,14 +288,16 @@
 
 			// If we are editing an event, it assumed that the event has documentation
 			if($isEditing && method_exists($existing, 'documentation')) {
-				// Description
+				
+				// Documentation
 				$fieldset = new XMLElement('fieldset');
+				$fieldset->setAttribute('id', 'event-documentation');
 				$fieldset->setAttribute('class', 'settings');
 
 				$doc = $existing->documentation();
 				if($doc) {
 					$fieldset->setValue(
-						'<legend>' . __('Description') . '</legend>' . PHP_EOL .
+						'<legend>' . __('Documentation') . '</legend>' . PHP_EOL .
 						General::tabsToSpaces(is_object($doc) ? $doc->generate(true) : $doc, 2)
 					);
 					$this->Form->appendChild($fieldset);


### PR DESCRIPTION
This is part one to update event documentation dynamically and related to #1873.

The only thing missing is an AJAX page returning the event's documentation based on the given parameters, `section`, `filters` and `name`. The script currently requests that data at `/symphony/ajax/event-documentation/` but that can of course be changed.

Pull request #1888 needs to be pulled first for styling reasons.

/cc @brendo
