### PR TITLE
Remove '?' from query string. Fixes #1823

### DIFF
--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -327,7 +327,7 @@
 			$current_path = '/' . ltrim(end($current_path), '/');
 			$split_path = explode('?', $current_path, 3);
 			$current_path = rtrim(current($split_path), '/');
-			$querystring = '?' . next($split_path);
+			$querystring = next($split_path);
 
 			// Get max upload size from php and symphony config then choose the smallest
 			$upload_size_php = ini_size_to_bytes(ini_get('upload_max_filesize'));


### PR DESCRIPTION
This is a breaking change. But technically the query string does not include the question mark. Additionally, template logic can be more straightforward because the parameter will now be empty if there is no query string in the URL.
