### PR TITLE
Add protection against sub-query returning more than one row

### DIFF
--- a/symphony/lib/toolkit/fields/field.date.php
+++ b/symphony/lib/toolkit/fields/field.date.php
@@ -607,6 +607,7 @@
 						SELECT %s
 						FROM tbl_entries_data_%d AS `ed`
 						WHERE entry_id = e.id
+						LIMIT 0, 1
 					) %s',
 					'`ed`.date',
 					$this->get('id'),

--- a/symphony/lib/toolkit/fields/field.input.php
+++ b/symphony/lib/toolkit/fields/field.input.php
@@ -331,6 +331,7 @@
 						SELECT %s
 						FROM tbl_entries_data_%d AS `ed`
 						WHERE entry_id = e.id
+						LIMIT 0, 1
 					) %s',
 					'`ed`.value',
 					$this->get('id'),

--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -712,6 +712,7 @@
 						SELECT %s
 						FROM tbl_entries_data_%d AS `ed`
 						WHERE entry_id = e.id
+						LIMIT 0, 1
 					) %s',
 					'`ed`.file',
 					$this->get('id'),


### PR DESCRIPTION
I ran into a bug where I had duplicate data in a data_table. (2 users saving the same entries at the same time)

Sub-query that returns multiple rows make MySQL crash, so I added simple protection against this.

Lots of extensions might need this patch too and I think I have spotted a kind of related bug in Select Box Link Field.
