### PR TITLE
Give package.json name and version which are required

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphonycms",
-  "version": "1.0.0",
+  "version": "2.4",
   "devDependencies": {
     "grunt": "~0.4.3",
     "grunt-autoprefixer": "~0.5.0",


### PR DESCRIPTION
npm at my command line won't install without these, and [they are required](https://www.npmjs.org/doc/json.html#name).

I don't know how you want to work the version number - feel free to change. I believe it should be updated whenever the devDependencies change.

@jensscherbl @nitriques @nilshoerrmann 
