### PR TITLE
Change to using filename from basename

### DIFF
--- a/symphony/lib/toolkit/class.lang.php
+++ b/symphony/lib/toolkit/class.lang.php
@@ -534,7 +534,7 @@
 			// Use the transliteration table if provided
 			if($apply_transliteration == true){
 				$file = pathinfo($string);
-				$string = self::applyTransliterations($file['basename']) . '.' . $file['extension'];
+				$string = self::applyTransliterations($file['filename']) . '.' . $file['extension'];
 			}
 
 			return General::createFilename($string, $delim);


### PR DESCRIPTION
https://github.com/symphonycms/symphony-2/pull/1975

Swap `basename` for `filename` to avoid files having their extension added to their name on save: filename-jpg.jpg is created if `basename` is used.
