### PR TITLE
Update email filter template

### DIFF
--- a/symphony/template/email.entrycreated.tpl
+++ b/symphony/template/email.entrycreated.tpl
@@ -1,4 +1,4 @@
 Dear <!-- RECIPIENT NAME -->,
 
-An entry was created or updated in the %1$s section. You can view or edit the entry by going to: %2$s
+An entry in the %1$s section was created or updated. You can view or edit it by going to: %2$s
 


### PR DESCRIPTION
Adds (was created) “or updated” and “view or” (edit the entry...).

Removes “This is a courtesy email to notify you that...”.

Perhaps this file should be be renamed as it isn’t restricted to use with entry creation and is also used on entry edits.
