### PR TITLE
Fixed PHPdoc comments

### DIFF
--- a/symphony/content/class.sortable.php
+++ b/symphony/content/class.sortable.php
@@ -61,24 +61,25 @@
 		 * current sort order, `$order`. If `$extra_url_params` are provided, they are
 		 * appended to the redirect string upon clicking on a table header.
 		 *
-		 *		'label' => 'Column label',
-		 *		'sortable' => (true|false),
-		 *		'handle' => 'handle for the column (i.e. the field ID), used as value for $sort',
-		 *		'attrs' => array(
-		 *			'HTML <a> attribute' => 'value',
-		 *			[...]
-		 *		)
+		 *        'label' => 'Column label',
+		 *        'sortable' => (true|false),
+		 *        'handle' => 'handle for the column (i.e. the field ID), used as value for $sort',
+		 *        'attrs' => array(
+		 *            'HTML <a> attribute' => 'value',
+		 *            [...]
+		 *        )
 		 *
 		 * @param array $columns
-		 *	An array of columns that will be converted into table headers.
+		 *    An array of columns that will be converted into table headers.
 		 * @param string $sort
-		 *	The current field (or axis) the objects are sorted by.
+		 *    The current field (or axis) the objects are sorted by.
 		 * @param string $order
-		 *	The current sort order (i.e. 'asc' or 'desc').
+		 *    The current sort order (i.e. 'asc' or 'desc').
 		 * @param string $extra_url_params (optional)
-		 *	A string of URL parameters that will be appended to the redirect string.
+		 *    A string of URL parameters that will be appended to the redirect string.
+		 * @throws InvalidArgumentException
 		 * @return array
-		 *	An array of table headers that can be directly passed to `Widget::TableHead`.
+		 *    An array of table headers that can be directly passed to `Widget::TableHead`.
 		 */
 		public static function buildTableHeaders($columns, $sort, $order, $extra_url_params = null) {
 			$aTableHead = array();

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -1364,6 +1364,8 @@
 		 * Prepare a Drawer to visualize section associations
 		 *
 		 * @param  Section $section The current Section object
+		 * @throws InvalidArgumentException
+		 * @throws Exception
 		 */
 		private function prepareAssociationsDrawer($section){
 			$entry_id = (!is_null($this->_context['entry_id'])) ? $this->_context['entry_id'] : null;

--- a/symphony/lib/core/class.administration.php
+++ b/symphony/lib/core/class.administration.php
@@ -95,6 +95,8 @@
 		 * @param string $page
 		 *  The URL path after the root of the Symphony installation, including a starting
 		 *  slash, such as '/login/'
+		 * @throws SymphonyErrorPage
+		 * @throws Exception
 		 * @return HTMLPage
 		 */
 		private function __buildPage($page){
@@ -445,6 +447,8 @@
 		 * @param string $page
 		 *  The result of getCurrentPage, which returns the $_GET['symphony-page']
 		 *  variable.
+		 * @throws Exception
+		 * @throws SymphonyErrorPage
 		 * @return string
 		 *  The HTML of the page to return
 		 */

--- a/symphony/lib/core/class.cacheable.php
+++ b/symphony/lib/core/class.cacheable.php
@@ -26,7 +26,7 @@
 		 * The constructor for the Cacheable takes an instance of the
 		 * MySQL class and assigns it to `$this->Database`
 		 *
-		 * @param iCache $Database
+		 * @param iCache $cacheProvider
 		 *  An instance of the MySQL class to store the cached
 		 *  data in.
 		 */

--- a/symphony/lib/core/class.cookie.php
+++ b/symphony/lib/core/class.cookie.php
@@ -98,6 +98,7 @@
 		 * @param boolean $httpOnly
 		 *  Whether this cookie can be read by Javascript. By default the cookie
 		 *  cannot be read by Javascript
+		 * @throws Exception
 		 */
 		public function __construct($index, $timeout = 0, $path = '/', $domain = NULL, $httpOnly = true) {
 			$this->_index = $index;
@@ -113,6 +114,7 @@
 		/**
 		 * Initialises a new Session instance using this cookie's params
 		 *
+		 * @throws Exception
 		 * @return Session
 		 */
 		private function __init() {

--- a/symphony/lib/core/class.datetimeobj.php
+++ b/symphony/lib/core/class.datetimeobj.php
@@ -149,7 +149,7 @@
 		 * @link http://www.php.net/manual/en/book.datetime.php
 		 * @param string $format
 		 *  A valid PHP date format
-		 * @param integer $timestamp (optional)
+		 * @param null|string $timestamp (optional)
 		 *  A unix timestamp to format. 'now' or omitting this parameter will
 		 *  result in the current time being used
 		 * @param string $timezone (optional)
@@ -272,7 +272,7 @@
 		 *
 		 * @param string $format
 		 *  A valid PHP date format
-		 * @param integer $timestamp (optional)
+		 * @param null|string $timestamp (optional)
 		 *  A unix timestamp to format. Omitting this parameter will
 		 *  result in the current time being used
 		 * @return string

--- a/symphony/lib/core/class.errorhandler.php
+++ b/symphony/lib/core/class.errorhandler.php
@@ -29,7 +29,7 @@
 		/**
 		 * Initialise will set the error handler to be the `__CLASS__::handler` function.
 		 *
-		 * @param Log $log
+		 * @param Log $Log
 		 *  An instance of a Symphony Log object to write errors to
 		 */
 		public static function initialise(Log $Log = null){
@@ -382,6 +382,7 @@
 		 *  The file that holds the logic that caused the error. Defaults to null
 		 * @param integer $line
 		 *  The line where the error occurred.
+		 * @throws ErrorException
 		 * @return string
 		 *  Usually a string of HTML that will displayed to a user
 		 */

--- a/symphony/lib/core/class.frontend.php
+++ b/symphony/lib/core/class.frontend.php
@@ -83,6 +83,8 @@
 		 * @see boot.getCurrentPage()
 		 * @param string $page
 		 *  The result of getCurrentPage, which returns the `$_GET['symphony-page']`
+		 * @throws FrontendPageNotFoundException
+		 * @throws SymphonyErrorPage
 		 * @return string
 		 *  The HTML of the page to return
 		 */
@@ -148,6 +150,8 @@
 		 *
 		 * @param Exception $e
 		 *  The Exception object
+		 * @throws FrontendPageNotFoundException
+		 * @throws SymphonyErrorPage
 		 * @return string
 		 *  An HTML string
 		 */

--- a/symphony/lib/core/class.log.php
+++ b/symphony/lib/core/class.log.php
@@ -275,6 +275,7 @@
 		 * @param integer $mode
 		 *  The file mode used to apply to the archived log, by default this is 0777. Note that this
 		 *  parameter is modified using PHP's intval function with base 8.
+		 * @throws Exception
 		 * @return integer
 		 *  Returns 1 if the log was overwritten, or 2 otherwise.
 		 */

--- a/symphony/lib/core/class.session.php
+++ b/symphony/lib/core/class.session.php
@@ -46,6 +46,7 @@
 		 * @param boolean $secure
 		 *  Whether this cookie should only be sent on secure servers. By default this is
 		 *  false, which means the cookie can be sent over HTTP and HTTPS
+		 * @throws Exception
 		 * @return string|boolean
 		 *  Returns the Session ID on success, or false on error.
 		 */
@@ -142,6 +143,7 @@
 		 * @param string $data
 		 *  The Session information, usually a serialized object of
 		 * `$_SESSION[Cookie->_index]`
+		 * @throws DatabaseException
 		 * @return boolean
 		 *  True if the Session information was saved successfully, false otherwise
 		 */
@@ -220,6 +222,7 @@
 		 *
 		 * @param string $id
 		 *  The identifier for the Session to destroy
+		 * @throws DatabaseException
 		 * @return boolean
 		 *  True if the Session was deleted successfully, false otherwise
 		 */
@@ -239,6 +242,7 @@
 		 *
 		 * @param integer $max
 		 *  The max session lifetime.
+		 * @throws DatabaseException
 		 * @return boolean
 		 *  True on Session deletion, false if an error occurs
 		 */

--- a/symphony/lib/core/class.symphony.php
+++ b/symphony/lib/core/class.symphony.php
@@ -149,12 +149,13 @@
 		}
 
 		/**
-		* Accessor for the Symphony instance, whether it be Frontend
-		* or Administration
-		*
-		* @since Symphony 2.2
-		* @return Symphony
-		*/
+		 * Accessor for the Symphony instance, whether it be Frontend
+		 * or Administration
+		 *
+		 * @since Symphony 2.2
+		 * @throws Exception
+		 * @return Symphony
+		 */
 		public static function Engine() {
 			if(class_exists('Administration')) {
 				return Administration::instance();
@@ -212,6 +213,8 @@
 		 *
 		 * @param string $filename (optional)
 		 *  The file to write the log to, if omitted this will default to `ACTIVITY_LOG`
+		 * @throws Exception
+		 * @return bool|void
 		 */
 		public function initialiseLog($filename = null) {
 			if(self::$Log instanceof Log && self::$Log->getLogPath() == $filename) return true;
@@ -322,6 +325,7 @@
 		 * using the connection details provided in the Symphony configuration. If any
 		 * errors occur whilst doing so, a Symphony Error Page is displayed.
 		 *
+		 * @throws SymphonyErrorPage
 		 * @return boolean
 		 *  This function will return true if the `$Database` was
 		 *  initialised successfully.
@@ -388,6 +392,7 @@
 		 * @param boolean $isHash
 		 *  If the password provided is already hashed, setting this parameter to
 		 *  true will stop it becoming rehashed. By default it is false.
+		 * @throws DatabaseException
 		 * @return boolean
 		 *  True if the Author was logged in, false otherwise
 		 */
@@ -437,6 +442,7 @@
 		 * @param string $token
 		 *  The Author token, which is a portion of the hashed string concatenation
 		 *  of the Author's username and password
+		 * @throws DatabaseException
 		 * @return boolean
 		 *  True if the Author is logged in, false otherwise
 		 */
@@ -611,6 +617,7 @@
 		 * @param array $additional
 		 *  Allows custom information to be passed to the Symphony Error Page
 		 *  that the template may want to expose, such as custom Headers etc.
+		 * @throws SymphonyErrorPage
 		 */
 		public function customError($heading, $message, $template='generic', array $additional=array()){
 			$this->throwCustomError($message, $heading, Page::HTTP_STATUS_ERROR, $template, $additional);
@@ -627,7 +634,7 @@
 		 *  or as an XMLElement.
 		 * @param string $heading
 		 *  A heading for the error page
-		 * @param integer $status
+		 * @param int $status
 		 *  Properly sets the HTTP status code for the response. Defaults to
 		 *  `Page::HTTP_STATUS_ERROR`. Use `Page::HTTP_STATUS_XXX` to set this value.
 		 * @param string $template
@@ -637,6 +644,7 @@
 		 * @param array $additional
 		 *  Allows custom information to be passed to the Symphony Error Page
 		 *  that the template may want to expose, such as custom Headers etc.
+		 * @throws SymphonyErrorPage
 		 */
 		public function throwCustomError($message, $heading='Symphony Fatal Error', $status=Page::HTTP_STATUS_ERROR, $template='generic', array $additional=array()){
 			GenericExceptionHandler::$enabled = true;

--- a/symphony/lib/interface/interface.datasource.php
+++ b/symphony/lib/interface/interface.datasource.php
@@ -90,11 +90,11 @@
 		 * Given the settings and any existing datasource parameters, return
 		 * the contents of this datasource so that can be saved to the file system.
 		 *
-		 * @param array $settings
+		 * @param array $fields
 		 *  An associative array of settings for this datasource, where the key
 		 *  is the name of the setting. These are user defined through the Datasource
 		 *  Editor.
-		 * @param array $params
+		 * @param array $parameters
 		 *  An associative array of parameters for this datasource, where the key
 		 *  is the name of the parameter.
 		 * @param string $template

--- a/symphony/lib/interface/interface.event.php
+++ b/symphony/lib/interface/interface.event.php
@@ -90,11 +90,11 @@
 		 * Given the settings and any existing event parameters, return the contents
 		 * of this event that can be saved to the filesystem.
 		 *
-		 * @param array $settings
+		 * @param array $fields
 		 *  An associative array of settings for this event, where the key
 		 *  is the name of the setting. These are user defined through the event
 		 *  Editor.
-		 * @param array $params
+		 * @param array $parameters
 		 *  An associative array of parameters for this event, where the key
 		 *  is the name of the parameter.
 		 * @param string $template
@@ -129,9 +129,6 @@
 		 * event as an `XMLElement` so that the `FrontendPage` class can add to
 		 * a page's XML.
 		 *
-		 * @param array $param_pool
-		 *  An associative array of parameters that have been evaluated prior to
-		 *  this event's execution.
 		 * @return XMLElement
 		 *  This event should return an `XMLElement` object.
 		 */

--- a/symphony/lib/toolkit/cache/cache.database.php
+++ b/symphony/lib/toolkit/cache/cache.database.php
@@ -102,6 +102,7 @@
 		 * @param integer $ttl
 		 *  A integer representing how long the data should be valid for in minutes.
 		 *  By default this is null, meaning the data is valid forever
+		 * @throws DatabaseException
 		 * @return boolean
 		 *  If an error occurs, this function will return false otherwise true
 		 */
@@ -134,6 +135,7 @@
 		 * @see core.Cacheable#optimise()
 		 * @param string $hash
 		 *  The hash of the Cached object, as defined by the user
+		 * @throws DatabaseException
 		 */
 		public function delete($hash = null) {
 			if(!is_null($hash)) {

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -169,6 +169,7 @@
 		 *  `Alert::SUCCESS`. The differing types will show the error
 		 *  in a different style in the backend. If omitted, this defaults
 		 *  to `Alert::NOTICE`.
+		 * @throws Exception
 		 */
 		public function pageAlert($message = null, $type = Alert::NOTICE){
 			if(is_null($message) && $type == Alert::ERROR){
@@ -297,6 +298,7 @@
 		 *  to the interface. Accepts 'prepend' or 'append' values, which will
 		 *  add the button before or after existing buttons. Defaults to `prepend`.
 		 *  If any other value is passed, no button will be added.
+		 * @throws InvalidArgumentException
 		 */
 		public function insertDrawer(XMLElement $drawer, $position = 'horizontal', $button = 'append') {
 			$drawer->addClass($position);
@@ -327,6 +329,8 @@
 		 *  can include the section handle, the current entry_id, the page
 		 *  name and any flags such as 'saved' or 'created'. This list is not exhaustive
 		 *  and extensions can add their own keys to the array.
+		 * @throws InvalidArgumentException
+		 * @throws SymphonyErrorPage
 		 */
 		public function build(array $context = array()){
 			$this->_context = $context;
@@ -477,7 +481,7 @@
 			if(
 				$page_limit == 'author'
 				or ($page_limit == 'developer' && Administration::instance()->Author->isDeveloper())
-                or ($page_limit == 'manager' && (Administration::instance()->Author->isManager() || Administration::instance()->Author->isDeveloper()))
+				or ($page_limit == 'manager' && (Administration::instance()->Author->isManager() || Administration::instance()->Author->isDeveloper()))
 				or ($page_limit == 'primary' && Administration::instance()->Author->isPrimaryAccount())
 			) {
 				return true;
@@ -496,6 +500,7 @@
 		 * into strings ready for output.
 		 *
 		 * @see core.HTMLPage#generate()
+		 * @param null $page
 		 * @return string
 		 */
 		public function generate($page = null) {
@@ -616,6 +621,7 @@
 		 *
 		 * @param string $type
 		 *  Either 'view' or 'action', by default this will be 'view'
+		 * @throws SymphonyErrorPage
 		 */
 		public function __switchboard($type='view'){
 
@@ -899,6 +905,8 @@
 		 *
 		 * @param array $nav
 		 *  The navigation array that will receive nav nodes
+		 * @throws Exception
+		 * @throws SymphonyErrorPage
 		 */
 		private function buildExtensionsNavigation(&$nav) {
 			// Loop over all the installed extensions to add in other navigation items

--- a/symphony/lib/toolkit/class.authormanager.php
+++ b/symphony/lib/toolkit/class.authormanager.php
@@ -28,6 +28,7 @@
 		 *
 		 * @param array $fields
 		 *  Associative array of field names => values for the Author object
+		 * @throws DatabaseException
 		 * @return integer|boolean
 		 *  Returns an Author ID of the created Author on success, false otherwise.
 		 */
@@ -48,6 +49,7 @@
 		 *  Associative array of field names => values for the Author object
 		 *  This array does need to contain every value for the author object, it
 		 *  can just be the changed values.
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public static function edit($id, array $fields) {
@@ -61,6 +63,7 @@
 		 *
 		 * @param integer $id
 		 *  The ID of the Author that should be deleted
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public static function delete($id) {
@@ -86,6 +89,7 @@
 		 *  Any custom WHERE clauses. The `tbl_authors` alias is `a`
 		 * @param string $joins
 		 *  Any custom JOIN's
+		 * @throws DatabaseException
 		 * @return array
 		 *  An array of Author objects. If no Authors are found, an empty array is returned.
 		 */
@@ -133,6 +137,7 @@
 		 *
 		 * @param integer|array $id
 		 *  A single ID or an array of ID's
+		 * @throws DatabaseException
 		 * @return mixed
 		 *  If `$id` is an integer, the result will be an Author object,
 		 *  otherwise an array of Author objects will be returned. If no
@@ -227,6 +232,7 @@
 		 *
 		 * @param integer $author_id
 		 *  The Author ID to allow to use their authentication token.
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public static function activateAuthToken($author_id) {
@@ -244,6 +250,7 @@
 		 *
 		 * @param integer $author_id
 		 *  The Author ID to allow to use their authentication token.
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public static function deactivateAuthToken($author_id) {

--- a/symphony/lib/toolkit/class.cryptography.php
+++ b/symphony/lib/toolkit/class.cryptography.php
@@ -45,11 +45,12 @@
 		 * @see cryptography.PBKDF2#compare()
 		 *
 		 * @param string $input
-		 * the cleartext password
+		 *  the cleartext password
 		 * @param string $hash
-		 * the hash the password should be checked against
+		 *  the hash the password should be checked against
+		 * @param bool $isHash
 		 * @return boolean
-		 * the result of the comparison
+		 *  the result of the comparison
 		 */
 		public static function compare($input, $hash, $isHash=false){
 			$version = substr($hash, 0, 8);

--- a/symphony/lib/toolkit/class.datasource.php
+++ b/symphony/lib/toolkit/class.datasource.php
@@ -87,6 +87,7 @@
 		 * @param boolean $process_params
 		 *  If set to true, `Datasource::processParameters` will be called. By default
 		 *  this is true
+		 * @throws FrontendPageNotFoundException
 		 */
 		public function __construct(array $env = null, $process_params=true){
 			// Support old the __construct (for the moment anyway).
@@ -266,6 +267,7 @@
 		 * @param array $env
 		 *  The environment variables from the Frontend class which includes
 		 *  any params set by Symphony or Events or by other Datasources
+		 * @throws FrontendPageNotFoundException
 		 */
 		public function processParameters(array $env = null){
 			

--- a/symphony/lib/toolkit/class.datasourcemanager.php
+++ b/symphony/lib/toolkit/class.datasourcemanager.php
@@ -184,6 +184,7 @@
 		 *  The environment variables from the Frontend class which includes
 		 *  any params set by Symphony or Events or by other Datasources
 		 * @param boolean $process_params
+		 * @throws Exception
 		 * @return Datasource
 		 */
 		public static function create($handle, array $env = null, $process_params=true){

--- a/symphony/lib/toolkit/class.devkit.php
+++ b/symphony/lib/toolkit/class.devkit.php
@@ -81,7 +81,8 @@
 		 * `<h1>` with an anchor to this query string
 		 *
 		 * @param XMLElement $wrapper
-		 *	The parent `XMLElement` to add the header to
+		 *    The parent `XMLElement` to add the header to
+		 * @throws InvalidArgumentException
 		 */
 		protected function buildHeader(XMLElement $wrapper) {
 			$this->setTitle(__(
@@ -110,7 +111,8 @@
 		 *
 		 * @uses ManipulateDevKitNavigation
 		 * @param XMLElement $wrapper
-		 *	The parent XMLElement to add the navigation to
+		 *    The parent XMLElement to add the navigation to
+		 * @throws InvalidArgumentException
 		 */
 		protected function buildNavigation(XMLElement $wrapper) {
 			$xml = new DOMDocument();
@@ -187,12 +189,13 @@
 		/**
 		 *
 		 * @param string $name
-		 *	The name of the jump
+		 *    The name of the jump
 		 * @param string $link
-		 *	The link for this jump item
+		 *    The link for this jump item
 		 * @param boolean $active
-		 *	Whether this is the active link, if true, this will add an
-		 *	active class to the link built. By default this is false
+		 *    Whether this is the active link, if true, this will add an
+		 *    active class to the link built. By default this is false
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		protected function buildJumpItem($name, $link, $active = false) {
@@ -257,6 +260,7 @@
 		 * generate function
 		 *
 		 * @see toolkit.HTMLPage#generate()
+		 * @throws InvalidArgumentException
 		 * @return string
 		 */
 		public function build() {

--- a/symphony/lib/toolkit/class.email.php
+++ b/symphony/lib/toolkit/class.email.php
@@ -24,9 +24,10 @@
 		 * Calling this function multiple times will return unique objects.
 		 *
 		 * @param string $gateway
-		 * 	The name of the gateway to use. Please only supply if specific 
+		 *    The name of the gateway to use. Please only supply if specific
 		 *  gateway functions are being used.
 		 *  If the gateway is not found, it will throw an EmailException
+		 * @throws Exception
 		 * @return EmailGateway
 		 */
 		function create($gateway = null){

--- a/symphony/lib/toolkit/class.emailgateway.php
+++ b/symphony/lib/toolkit/class.emailgateway.php
@@ -17,7 +17,6 @@
 		 * @param Exception $previous
 		 *  The previous exception, if nested. See
 		 *  http://www.php.net/manual/en/language.exceptions.extending.php
-		 * @return void
 		 */
 		public function __construct($message, $code = 0, $previous = null){
 			$trace = parent::getTrace();
@@ -132,6 +131,7 @@
 		 *  The email-address emails will be sent from.
 		 * @param string $name
 		 *  The name the emails will be sent from.
+		 * @throws EmailValidationException
 		 * @return void
 		 */
 		public function setFrom($email, $name){
@@ -190,6 +190,7 @@
 		 *
 		 * @param string|array $email
 		 *  The email-address(es) to send the email to.
+		 * @throws EmailValidationException
 		 * @return void
 		 */
 		public function setRecipients($email){
@@ -393,7 +394,7 @@
 		 * Every gateway should extend this method to add their own settings.
 		 *
 		 * @throws EmailValidationException
-		 * @param array $configuration
+		 * @param array $config
 		 * @since Symphony 2.3.1
 		 *  All configuration entries stored in a single array. The array should have the format of the $_POST array created by the preferences HTML.
 		 * @return boolean
@@ -426,6 +427,7 @@
 		 *
 		 * @param array $header_array
 		 *  The header fields. Examples are From, X-Sender and Reply-to.
+		 * @throws EmailGatewayException
 		 * @return void
 		 */
 		public function appendHeaderFields(array $header_array = array()){
@@ -472,6 +474,7 @@
 		 * gateway itself.
 		 *
 		 * @throws EmailGatewayException
+		 * @throws Exception
 		 * @return boolean
 		 */
 		protected function prepareMessageBody(){
@@ -546,6 +549,8 @@
 		 * Will return a string containing the section. Can be used to send to
 		 * an email server directly.
 		 *
+		 * @throws EmailGatewayException
+		 * @throws Exception
 		 * @return string
 		 */
 		protected function getSectionAttachments() {
@@ -647,10 +652,10 @@
 		 *
 		 * Can be used to send to an email server directly.
 		 *
-		 * @param $type optional mime-type
-		 * @param $file optional the path of the attachment
-		 * @param $filename optional the name of the attached file
-		 * @param $charset optional the charset of the attached file
+		 * @param string $type optional mime-type
+		 * @param string $file optional the path of the attachment
+		 * @param string $filename optional the name of the attached file
+		 * @param string $charset optional the charset of the attached file
 		 *
 		 * @return array
 		 */
@@ -701,9 +706,9 @@
 		/**
 		 * Creates the properly formatted InfoString based on the InfoArray.
 		 *
-		 * @see `EmailGateway::contentInfoArray()`
+		 * @see EmailGateway::contentInfoArray()
 		 *
-		 * @return string
+		 * @return string|null
 		 */
 		protected function contentInfoString($type = NULL, $file = NULL, $filename = NULL, $charset = NULL) {
 			$data = $this->contentInfoArray($type, $file, $filename, $charset);
@@ -717,6 +722,7 @@
 		 * Returns the bondary based on the $type parameter
 		 *
 		 * @param string $type the multipart type
+		 * @return string|void
 		 */
 		protected function getBoundary($type) {
 			switch ($type) {
@@ -759,6 +765,7 @@
 		 *  The property name.
 		 * @param string $value
 		 *  The property value;
+		 * @throws EmailGatewayException
 		 * @return void|boolean
 		 */
 		public function __set($name, $value){

--- a/symphony/lib/toolkit/class.emailgatewaymanager.php
+++ b/symphony/lib/toolkit/class.emailgatewaymanager.php
@@ -179,6 +179,7 @@
 		 *
 		 * @param string $name
 		 *  The gateway to look for
+		 * @throws Exception
 		 * @return EmailGateway
 		 *  If the gateway is found, an instantiated object is returned.
 		 *  If the gateway is not found, an error is triggered.

--- a/symphony/lib/toolkit/class.entry.php
+++ b/symphony/lib/toolkit/class.entry.php
@@ -73,6 +73,7 @@
 		 * Entry ID using `getInsertID()`.
 		 *
 		 * @see toolkit.MySQL#getInsertID()
+		 * @throws DatabaseException
 		 * @return integer
 		 */
 		public function assignEntryId() {
@@ -124,6 +125,8 @@
 		 *  useful if the input form only contains a couple of the fields for this Entry.
 		 *  Defaults to false, which will set Fields to their default values if they are not
 		 *  provided in the $data
+		 * @throws DatabaseException
+		 * @throws Exception
 		 * @return integer
 		 *  Either `__ENTRY_OK__` or `__ENTRY_FIELD_ERROR__`
 		 */
@@ -200,13 +203,15 @@
 		 * @param array $data
 		 *  An associative array of the data for this entry where they key is the
 		 *  Field's handle for this Section and the value is the data from the form
-		 * @param array $error
-		 *  An array of errors, by reference. Defaults to empty
+		 * @param null|array $errors
+		 *  An array of errors, by reference. Defaults to empty*  An array of errors, by reference.
+		 *  Defaults to empty
 		 * @param boolean $ignore_missing_fields
 		 *  This parameter allows Entries to be updated, rather than replaced. This is
 		 *  useful if the input form only contains a couple of the fields for this Entry.
 		 *  Defaults to false, which will check all Fields even if they are not
 		 *  provided in the $data
+		 * @throws Exception
 		 * @return integer
 		 *  Either `__ENTRY_OK__` or `__ENTRY_FIELD_ERROR__`
 		 */
@@ -263,6 +268,7 @@
 		 * is used.
 		 *
 		 * @see toolkit.Entry#findDefaultData()
+		 * @throws Exception
 		 * @return boolean
 		 *  true if the commit was successful, false otherwise.
 		 */
@@ -279,6 +285,7 @@
 		 * @param array $associated_sections
 		 *  An associative array of sections to return the Entry counts from. Defaults to
 		 *  null, which will fetch all the associations of this Entry.
+		 * @throws Exception
 		 * @return array
 		 *  An associative array with the key being the associated Section's ID and the
 		 *  value being the number of entries associated with this Entry.

--- a/symphony/lib/toolkit/class.entrymanager.php
+++ b/symphony/lib/toolkit/class.entrymanager.php
@@ -91,6 +91,7 @@
 		 *
 		 * @param Entry $entry
 		 *  An Entry object to insert into the database
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public static function add(Entry $entry) {
@@ -137,6 +138,7 @@
 		 *
 		 * @param Entry $entry
 		 *  An Entry object
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public static function edit(Entry $entry) {
@@ -202,6 +204,8 @@
 		 *  If possible, the `$section_id` of the the `$entries`. This parameter
 		 *  should be left as null if the `$entries` array contains entry_id's for
 		 *  multiple sections.
+		 * @throws DatabaseException
+		 * @throws Exception
 		 * @return boolean
 		 */
 		public static function delete($entries, $section_id = null){
@@ -306,9 +310,6 @@
 		 *  Any custom JOIN's
 		 * @param boolean $group
 		 *  Whether the entries need to be grouped by Entry ID or not
-		 * @param boolean $records_only
-		 *  If this is set to true, an array of Entry objects will be returned
-		 *  without any basic pagination information. Defaults to false
 		 * @param boolean $buildentries
 		 *  Whether to return an array of entry ID's or Entry objects. Defaults to
 		 *  true, which will return Entry objects
@@ -318,6 +319,7 @@
 		 *  from all fields in a section.
 		 * @param boolean $enable_sort
 		 *  Defaults to true, if false this function will not apply any sorting
+		 * @throws Exception
 		 * @return array
 		 *  If `$buildentries` is true, this function will return an array of Entry objects,
 		 *  otherwise it will return an associative array of Entry data from `tbl_entries`
@@ -404,6 +406,7 @@
 		 *  Choose whether to get data from a subset of fields or all fields in a section,
 		 *  by providing an array of field names. Defaults to null, which will load data
 		 *  from all fields in a section.
+		 * @throws DatabaseException
 		 * @return array
 		 *  An array of Entry objects
 		 */
@@ -580,6 +583,7 @@
 		 *  Choose whether to get data from a subset of fields or all fields in a section,
 		 *  by providing an array of field names. Defaults to null, which will load data
 		 *  from all fields in a section.
+		 * @throws Exception
 		 * @return array
 		 *  Either an array of Entry objects, or an associative array containing
 		 *  the total entries, the start position, the entries per page and the

--- a/symphony/lib/toolkit/class.eventmanager.php
+++ b/symphony/lib/toolkit/class.eventmanager.php
@@ -178,6 +178,7 @@
 		 * @param array $env
 		 *  The environment variables from the Frontend class which includes
 		 *  any params set by Symphony or Datasources or by other Events
+		 * @throws Exception
 		 * @return Event
 		 */
 		public static function create($handle, array $env = null){

--- a/symphony/lib/toolkit/class.extension.php
+++ b/symphony/lib/toolkit/class.extension.php
@@ -51,7 +51,7 @@
 		 * tables.
 		 *
 		 * @see toolkit.ExtensionManager#update()
-		 * @param string $previousVersion
+		 * @param bool|string $previousVersion
 		 *  The currently installed version of this extension from the
 		 *  `tbl_extensions` table. The current version of this extension is
 		 *  provided by the about() method.

--- a/symphony/lib/toolkit/class.extensionmanager.php
+++ b/symphony/lib/toolkit/class.extensionmanager.php
@@ -116,6 +116,8 @@
 		 *
 		 * @param string $name
 		 *  The name of the Extension Class minus the extension prefix.
+		 * @throws SymphonyErrorPage
+		 * @throws Exception
 		 * @return Extension
 		 */
 		public static function getInstance($name){
@@ -132,6 +134,7 @@
 		 * @param boolean $update
 		 *  Updates the `ExtensionManager::$_extensions` array even if it was
 		 *  populated, defaults to false.
+		 * @throws DatabaseException
 		 */
 		private static function __buildExtensionList($update=false) {
 			if (empty(self::$_extensions) || $update) {
@@ -209,6 +212,8 @@
 		 * @param string $type
 		 *  This will only return Providers of this type. If null, which is
 		 *  default, all providers will be returned.
+		 * @throws Exception
+		 * @throws SymphonyErrorPage
 		 * @return array
 		 *  An array of objects
 		 */
@@ -310,6 +315,8 @@
 		 * @see toolkit.ExtensionManager#__canUninstallOrDisable()
 		 * @param string $name
 		 *  The name of the Extension Class minus the extension prefix.
+		 * @throws SymphonyErrorPage
+		 * @throws Exception
 		 * @return boolean
 		 */
 		public static function enable($name){
@@ -366,6 +373,9 @@
 		 * @see toolkit.ExtensionManager#__canUninstallOrDisable()
 		 * @param string $name
 		 *  The name of the Extension Class minus the extension prefix.
+		 * @throws DatabaseException
+		 * @throws SymphonyErrorPage
+		 * @throws Exception
 		 * @return boolean
 		 */
 		public static function disable($name){
@@ -405,6 +415,10 @@
 		 * @see toolkit.ExtensionManager#__canUninstallOrDisable()
 		 * @param string $name
 		 *  The name of the Extension Class minus the extension prefix.
+		 * @throws Exception
+		 * @throws SymphonyErrorPage
+		 * @throws DatabaseException
+		 * @throws Exception
 		 * @return boolean
 		 */
 		public static function uninstall($name) {
@@ -436,6 +450,8 @@
 		 *
 		 * @param string $name
 		 *  The name of the Extension Class minus the extension prefix.
+		 * @throws Exception
+		 * @throws SymphonyErrorPage
 		 * @return integer
 		 *  The Extension ID
 		 */
@@ -512,6 +528,8 @@
 		 *
 		 * @param Extension $obj
 		 *  An extension object
+		 * @throws SymphonyErrorPage
+		 * @throws Exception
 		 * @return boolean
 		 */
 		private static function __canUninstallOrDisable(Extension $obj){
@@ -587,10 +605,13 @@
 		 *  called. eg.
 		 *
 		 * array(
-		 *		'parent' =>& $this->Parent,
-		 *		'page' => $page,
-		 *		'delegate' => $delegate
-		 *	);
+		 *        'parent' =>& $this->Parent,
+		 *        'page' => $page,
+		 *        'delegate' => $delegate
+		 *    );
+		 * @throws Exception
+		 * @throws SymphonyErrorPage
+		 * @return null|void
 		 */
 		public static function notifyMembers($delegate, $page, array $context=array()){
 			// Make sure $page is an array
@@ -653,6 +674,8 @@
 		 * @param string $filter
 		 *  Allows a regular expression to be passed to return only extensions whose
 		 *  folders match the filter.
+		 * @throws SymphonyErrorPage
+		 * @throws Exception
 		 * @return array
 		 *  An associative array with the key being the extension folder and the value
 		 *  being the extension's about information
@@ -677,6 +700,7 @@
 		 *
 		 * @param array $a
 		 * @param array $b
+		 * @param int $i
 		 * @return integer
 		 */
 		private static function sortByAuthor($a, $b, $i = 0) {
@@ -708,6 +732,8 @@
 		 * @param string $order_by (optional)
 		 *  Allows a developer to return the extensions in a particular order. The syntax is the
 		 *  same as other `fetch` methods. If omitted this will return resources ordered by `name`.
+		 * @throws Exception
+		 * @throws SymphonyErrorPage
 		 * @return array
 		 *  An associative array of Extension information, formatted in the same way as the
 		 *  listAll() method.
@@ -784,6 +810,8 @@
 		 *  DOMDocument of representation of the given extension's `extension.meta.xml`
 		 *  file. If the file is not available, the extension will return the normal
 		 *  `about()` results. By default this is false.
+		 * @throws Exception
+		 * @throws SymphonyErrorPage
 		 * @return array
 		 *  An associative array describing this extension
 		 */
@@ -912,6 +940,8 @@
 		 *
 		 * @param string $name
 		 *  The name of the Extension Class minus the extension prefix.
+		 * @throws Exception
+		 * @throws SymphonyErrorPage
 		 * @return Extension
 		 */
 		public static function create($name){

--- a/symphony/lib/toolkit/class.field.php
+++ b/symphony/lib/toolkit/class.field.php
@@ -170,7 +170,7 @@
 		 *	 the data to toggle.
 		 * @param string $newState
 		 *	 the new value to set
-         * @param integer $entry_id (optional)
+		 * @param integer $entry_id (optional)
 		 *   an optional entry ID for more intelligent processing. defaults to null
 		 * @return array
 		 *	 the toggled data.
@@ -422,9 +422,10 @@
 		 *
 		 * @see buildSummaryBlock()
 		 * @param XMLElement $wrapper
-		 *	the input XMLElement to which the display of this will be appended.
-		 * @param mixed errors (optional)
-		 *	the input error collection. this defaults to null.
+		 *    the input XMLElement to which the display of this will be appended.
+		 * @param mixed $errors
+		 *  the input error collection. this defaults to null.
+		 * @throws InvalidArgumentException
 		 */
 		public function displaySettingsPanel(XMLElement &$wrapper, $errors = null){
 
@@ -450,9 +451,10 @@
 		 *
 		 * @see buildLocationSelect()
 		 * @param array $errors (optional)
-		 *	an array to append html formatted error messages to. this defaults to null.
+		 *    an array to append html formatted error messages to. this defaults to null.
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
-		 *	the root XML element of the html display of this.
+		 *    the root XML element of the html display of this.
 		 */
 		public function buildSummaryBlock($errors = null){
 			$div = new XMLElement('div');
@@ -489,15 +491,16 @@
 		 * whether this field will appear in the main content column or in the sidebar
 		 * when creating a new entry.
 		 *
-		 * @param string $selection (optional)
-		 *	the currently selected location, if there is one. this defaults to null.
+		 * @param string|null $selected (optional)
+		 *    the currently selected location, if there is one. this defaults to null.
 		 * @param string $name (optional)
-		 *	the name of this field. this is optional and defaults to `fields[location]`.
+		 *    the name of this field. this is optional and defaults to `fields[location]`.
 		 * @param string $label_value (optional)
-		 *	any predefined label for this widget. this is an optional argument that defaults
-		 *	to null.
+		 *    any predefined label for this widget. this is an optional argument that defaults
+		 *    to null.
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
-		 *	An XMLElement representing a `<select>` field containing the options.
+		 *    An XMLElement representing a `<select>` field containing the options.
 		 */
 		public function buildLocationSelect($selected = null, $name = 'fields[location]', $label_value = null) {
 			if (!$label_value) $label_value = __('Placement');
@@ -518,16 +521,17 @@
 		 * Construct the html widget for selecting a text formatter for this field.
 		 *
 		 * @param string $selected (optional)
-		 *	the currently selected text formatter name if there is one. this defaults
-		 *	to null.
+		 *    the currently selected text formatter name if there is one. this defaults
+		 *    to null.
 		 * @param string $name (optional)
-		 *	the name of this field in the form. this is optional and defaults to
-		 *	"fields[format]".
+		 *    the name of this field in the form. this is optional and defaults to
+		 *    "fields[format]".
 		 * @param string $label_value
-		 *	the default label for the widget to construct. if null is passed in then
-		 *	this defaults to the localization of "Formatting".
+		 *    the default label for the widget to construct. if null is passed in then
+		 *    this defaults to the localization of "Formatting".
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
-		 *	An XMLElement representing a `<select>` field containing the options.
+		 *    An XMLElement representing a `<select>` field containing the options.
 		 */
 		public function buildFormatterSelect($selected = null, $name='fields[format]', $label_value){
 
@@ -561,18 +565,19 @@
 		 * and does not return anything.
 		 *
 		 * @param XMLElement $wrapper
-		 *	the parent element to append the XMLElement of the Validation select to,
+		 *    the parent element to append the XMLElement of the Validation select to,
 		 *  passed by reference.
 		 * @param string $selected (optional)
-		 *	the current validator selection if there is one. defaults to null if there
-		 *	isn't.
+		 *    the current validator selection if there is one. defaults to null if there
+		 *    isn't.
 		 * @param string $name (optional)
-		 *	the form element name of this field. this defaults to "fields[validator]".
+		 *    the form element name of this field. this defaults to "fields[validator]".
 		 * @param string $type (optional)
-		 *	the type of input for the validation to apply to. this defaults to 'input'
-		 *	but also accepts 'upload'.
+		 *    the type of input for the validation to apply to. this defaults to 'input'
+		 *    but also accepts 'upload'.
 		 * @param array $errors (optional)
-		 *	an associative array of errors
+		 *    an associative array of errors
+		 * @throws InvalidArgumentException
 		 */
 		public function buildValidationSelect(XMLElement &$wrapper, $selected = null, $name='fields[validator]', $type='input', array $errors = null) {
 
@@ -608,8 +613,9 @@
 		 * field is set as a required field.
 		 *
 		 * @param XMLElement $wrapper
-		 *	the parent XML element to append the constructed html checkbox to if
-		 *	necessary.
+		 *    the parent XML element to append the constructed html checkbox to if
+		 *    necessary.
+		 * @throws InvalidArgumentException
 		 */
 		public function appendRequiredCheckbox(XMLElement &$wrapper) {
 			if (!$this->_required) return;
@@ -635,7 +641,8 @@
 		 * displays a column in the entries table or not.
 		 *
 		 * @param XMLElement $wrapper
-		 *	the parent XML element to append the checkbox to.
+		 *    the parent XML element to append the checkbox to.
+		 * @throws InvalidArgumentException
 		 */
 		public function appendShowColumnCheckbox(XMLElement &$wrapper) {
 			if (!$this->_showcolumn) return;
@@ -661,7 +668,8 @@
 		 * Displays the required and show column checkboxes.
 		 *
 		 * @param XMLElement $wrapper
-		 *	the parent XML element to append the checkbox to.
+		 *    the parent XML element to append the checkbox to.
+		 * @throws InvalidArgumentException
 		 */
 		public function appendStatusFooter(XMLElement &$wrapper) {
 			$fieldset = new XMLElement('fieldset');
@@ -681,9 +689,10 @@
 		 * section.
 		 *
 		 * @param XMLElement $wrapper
-		 *	the parent XML element to append the checkbox to.
+		 *    the parent XML element to append the checkbox to.
 		 * @param string $help (optional)
-		 *	a help message to show below the checkbox.
+		 *    a help message to show below the checkbox.
+		 * @throws InvalidArgumentException
 		 */
 		public function appendShowAssociationCheckbox(XMLElement &$wrapper, $help = null) {
 			if(!$this->_showassociation) return;
@@ -814,7 +823,7 @@
 		 * @param array $parent_association
 		 *   An array containing information about the parent
 		 *
-		 * return XMLElement
+		 * @return XMLElement
 		 *   The XMLElement must be a li node, since it will be added an ul node.
 		 */
 		public function prepareAssociationsDrawerXMLElement(Entry $e, array $parent_association) {
@@ -846,7 +855,7 @@
 		 * @param string $fieldnamePrefix (optional)
 		 *	the string to be prepended to the display of the name of this field.
 		 *	this defaults to null.
-		 * @param string $fieldnameSuffix (optional)
+		 * @param string $fieldnamePostfix (optional)
 		 *	the string to be appended to the display of the name of this field.
 		 *	this defaults to null.
 		 * @param integer $entry_id (optional)
@@ -917,15 +926,16 @@
 		 * Display the default data-source filter panel.
 		 *
 		 * @param XMLElement $wrapper
-		 *	the input XMLElement to which the display of this will be appended.
+		 *    the input XMLElement to which the display of this will be appended.
 		 * @param mixed $data (optional)
-		 *	the input data. this defaults to null.
-		 * @param mixed errors (optional)
-		 *	the input error collection. this defaults to null.
-		 * @param string $fieldNamePrefix
+		 *    the input data. this defaults to null.
+		 * @param null $errors
+		 *  the input error collection. this defaults to null.
+		 * @param string $fieldnamePrefix
 		 *  the prefix to apply to the display of this.
-		 * @param string $fieldNameSuffix
+		 * @param string $fieldnamePostfix
 		 *  the suffix to apply to the display of this.
+		 * @throws InvalidArgumentException
 		 */
 		public function displayDatasourceFilterPanel(XMLElement &$wrapper, $data = null, $errors = null, $fieldnamePrefix = null, $fieldnamePostfix = null){
 			$wrapper->appendChild(new XMLElement('header', '<h4>' . $this->get('label') . '</h4> <span>' . $this->name() . '</span>', array(
@@ -1177,6 +1187,7 @@
 		 * and serves as a basic guide for how markup should be constructed on the
 		 * `Frontend` to save this field
 		 *
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 *  a label widget containing the formatted field element name of this.
 		 */
@@ -1224,6 +1235,7 @@
 		 * to overload this method to create a table structure that contains
 		 * additional columns to store the specific data created by the field.
 		 *
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public function createTable(){
@@ -1243,12 +1255,13 @@
 		 * Remove the entry data of this field from the database.
 		 *
 		 * @param integer|array $entry_id
-		 *	the ID of the entry, or an array of entry ID's to delete.
+		 *    the ID of the entry, or an array of entry ID's to delete.
 		 * @param array $data (optional)
-		 *	The entry data provided for fields to do additional cleanup
+		 *    The entry data provided for fields to do additional cleanup
 		 *  This is an optional argument and defaults to null.
+		 * @throws DatabaseException
 		 * @return boolean
-		 *	Returns true after the cleanup has been completed
+		 *    Returns true after the cleanup has been completed
 		 */
 		public function entryDataCleanup($entry_id, $data=NULL){
 			$where = is_array($entry_id)

--- a/symphony/lib/toolkit/class.fieldmanager.php
+++ b/symphony/lib/toolkit/class.fieldmanager.php
@@ -55,7 +55,7 @@
 		 * any fields folders in the installed extensions. The function returns
 		 * the path to the folder where the field class resides.
 		 *
-		 * @param string $name
+		 * @param string $type
 		 *  The field handle, that is, `field.{$handle}.php`
 		 * @return string
 		 */
@@ -103,6 +103,7 @@
 		 *
 		 * @param array $fields
 		 *  Associative array of field names => values for the Field object
+		 * @throws DatabaseException
 		 * @return integer|boolean
 		 *  Returns a Field ID of the created Field on success, false otherwise.
 		 */
@@ -128,6 +129,7 @@
 		 * @param array $settings
 		 *  An associative array of settings, where the key is the column name
 		 *  and the value is the value.
+		 * @throws DatabaseException
 		 * @return boolean
 		 *  True on success, false on failure
 		 */
@@ -156,6 +158,7 @@
 		 *  Associative array of field names => values for the Field object
 		 *  This array does need to contain every value for the field object, it
 		 *  can just be the changed values.
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public static function edit($id, array $fields){
@@ -172,6 +175,8 @@
 		 *
 		 * @param integer $id
 		 *  The ID of the Field that should be deleted
+		 * @throws DatabaseException
+		 * @throws Exception
 		 * @return boolean
 		 */
 		public static function delete($id) {
@@ -213,10 +218,12 @@
 		 * @param string $where
 		 *  Allows a custom where query to be included. Must be valid SQL. The tbl_fields alias
 		 *  is t1
-		 * @param string $restrict
+		 * @param int|string $restrict
 		 *  Only return fields if they match one of the Field Constants. Available values are
 		 *  `__TOGGLEABLE_ONLY__`, `__UNTOGGLEABLE_ONLY__`, `__FILTERABLE_ONLY__`,
 		 *  `__UNFILTERABLE_ONLY__` or `__FIELD_ALL__`. Defaults to `__FIELD_ALL__`
+		 * @throws DatabaseException
+		 * @throws Exception
 		 * @return array
 		 *  An array of Field objects. If no Field are found, null is returned.
 		 */
@@ -370,6 +377,7 @@
 		 *  a mode as well, eg. `title: formatted`.
 		 * @param integer $section_id
 		 *  The section that this field belongs too
+		 * @throws DatabaseException
 		 * @return mixed
 		 *  The field ID, or an array of field ID's
 		 */
@@ -459,6 +467,7 @@
 		 *
 		 * @since Symphony 2.3
 		 * @param integer $section_id
+		 * @throws DatabaseException
 		 * @return array
 		 *  An associative array that contains four keys, `id`, `element_name`,
 		 * `type` and `location`
@@ -513,6 +522,7 @@
 		 *
 		 * @param string $type
 		 *  The handle of the Field to create (which is it's handle)
+		 * @throws Exception
 		 * @return Field
 		 */
 		public static function create($type){

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -147,6 +147,9 @@
 		 * @see __buildPage()
 		 * @param string $page
 		 * The URL of the current page that is being Rendered as returned by getCurrentPage
+		 * @throws Exception
+		 * @throws FrontendPageNotFoundException
+		 * @throws SymphonyErrorPage
 		 * @return string
 		 * The page source after the XSLT has transformed this page's XML. This would be
 		 * exactly the same as the 'view-source' from your browser
@@ -538,6 +541,7 @@
 		 * The URL of the current page that is being Rendered as returned by `getCurrentPage()`.
 		 * If no URL is provided, Symphony assumes the Page with the type 'index' is being
 		 * requested.
+		 * @throws SymphonyErrorPage
 		 * @return array
 		 *  An associative array of page details
 		 */
@@ -676,6 +680,7 @@
 		 *  The XMLElement to append the Events results to. Event results are
 		 *  contained in a root XMLElement that is the handlised version of
 		 *  their name.
+		 * @throws Exception
 		 */
 		private function processEvents($events, XMLElement &$wrapper){
 			/**
@@ -786,6 +791,7 @@
 		 *  Any params to automatically add to the `$env` pool, by default this
 		 *  is an empty array. It looks like Symphony does not utilise this parameter
 		 *  at all
+		 * @throws Exception
 		 */
 		public function processDatasources($datasources, XMLElement &$wrapper, array $params = array()) {
 			if (trim($datasources) == '') return;

--- a/symphony/lib/toolkit/class.general.php
+++ b/symphony/lib/toolkit/class.general.php
@@ -433,6 +433,7 @@
 		 * @param boolean $silent (optional)
 		 *  true if an exception should be raised if an error occurs, false
 		 *  otherwise. this defaults to true.
+		 * @throws Exception
 		 * @return boolean
 		 */
 		public static function realiseDirectory($path, $mode = 0755, $silent = true){
@@ -466,6 +467,7 @@
 		 * @param boolean $silent (optional)
 		 *  true if an exception should be raised if an error occurs, false
 		 *  otherwise. this defaults to true.
+		 * @throws Exception
 		 * @return boolean
 		 */
 		public static function deleteDirectory($dir, $silent = true) {
@@ -664,7 +666,7 @@
 		 *  the array to filter.
 		 * @param boolean $ignore_case
 		 *  true if the case of the values in the array should be ignored, false otherwise.
-		 * @return
+		 * @return array
 		 *  a new array containing only the unique elements of the input array.
 		 */
 		public static function array_remove_duplicates(array $array, $ignore_case=false){
@@ -846,6 +848,7 @@
 		 * @param boolean $silent (optional)
 		 *  true if an exception should be raised if an error occurs, false
 		 *  otherwise. this defaults to true.
+		 * @throws Exception
 		 * @return boolean
 		 *  true if the file is successfully unlinked, if the unlink fails and
 		 *  silent is set to true then an exception is thrown. if the unlink

--- a/symphony/lib/toolkit/class.htmlpage.php
+++ b/symphony/lib/toolkit/class.htmlpage.php
@@ -95,6 +95,7 @@
 		 * generate function which generates a HTML DOM from all the
 		 * XMLElement children.
 		 *
+		 * @param null $page
 		 * @return string
 		 */
 		public function generate($page = null){
@@ -195,10 +196,9 @@
 		}
 
 		/**
-		 * Determines if two elements are duplicates based on an attribute
-		 * and value
+		 * Determines if two elements are duplicates based on an attribute and value
 		 *
-		 * @param string $value
+		 * @param string $path
 		 *  The value of the attribute
 		 * @param string $attribute
 		 *  The attribute to check

--- a/symphony/lib/toolkit/class.jsonpage.php
+++ b/symphony/lib/toolkit/class.jsonpage.php
@@ -50,6 +50,7 @@
 		 * before calling the parent generate function and generating
 		 * the `$this->_Result` json string
 		 *
+		 * @param null $page
 		 * @return string
 		 */
 		public function generate($page = null) {

--- a/symphony/lib/toolkit/class.lang.php
+++ b/symphony/lib/toolkit/class.lang.php
@@ -1,38 +1,38 @@
 <?php
-	/**
-	 * @package toolkit
-	 */
-	/**
-	 * The translation function accepts an English string and returns its translation
-	 * to the active system language. If the given string is not available in the
-	 * current dictionary the original English string will be returned. Given an optional
-	 * `$inserts` array, the function will replace translation placeholders using `vsprintf()`.
-	 * Since Symphony 2.3, it is also possible to have multiple translation of the same string
-	 * according to the page namespace (i.e. the value returned by Symphony's `getPageNamespace()`
-	 * method). In your lang file, use the `$dictionary` key as namespace and its value as an array
-	 * of context-aware translations, as shown below:
-	 *
-	 * $dictionary = array(
-	 * 		[...]
-	 *
-	 * 		'Create new' => 'Translation for Create New',
-	 *
-	 * 		'/blueprints/datasources' => array(
-	 * 			'Create new' =>
-	 * 			'If we are inside a /blueprints/datasources/* page, this translation will be returned for the string'
-	 * 		),
-	 *
-	 * 		[...]
-	 *  );
-	 *
-	 * @see core.Symphony#getPageNamespace()
-	 * @param string $string
-	 *  The string that should be translated
-	 * @param array $inserts (optional)
-	 *  Optional array used to replace translation placeholders, defaults to NULL
-	 * @return
-	 *  Returns the translated string
-	 */
+/**
+ * @package toolkit
+ */
+/**
+ * The translation function accepts an English string and returns its translation
+ * to the active system language. If the given string is not available in the
+ * current dictionary the original English string will be returned. Given an optional
+ * `$inserts` array, the function will replace translation placeholders using `vsprintf()`.
+ * Since Symphony 2.3, it is also possible to have multiple translation of the same string
+ * according to the page namespace (i.e. the value returned by Symphony's `getPageNamespace()`
+ * method). In your lang file, use the `$dictionary` key as namespace and its value as an array
+ * of context-aware translations, as shown below:
+ *
+ * $dictionary = array(
+ *        [...]
+ *
+ *        'Create new' => 'Translation for Create New',
+ *
+ *        '/blueprints/datasources' => array(
+ *            'Create new' =>
+ *            'If we are inside a /blueprints/datasources/* page, this translation will be returned for the string'
+ *        ),
+ *
+ *        [...]
+ *  );
+ *
+ * @see core.Symphony#getPageNamespace()
+ * @param string $string
+ *  The string that should be translated
+ * @param array $inserts (optional)
+ *  Optional array used to replace translation placeholders, defaults to NULL
+ * @return string
+ *  Returns the translated string
+ */
 	function __($string, $inserts=NULL) {
 		return Lang::translate($string, $inserts);
 	}
@@ -547,7 +547,7 @@
 		 * @since Symphony 2.3
 		 * @param string $string
 		 *  The string that should be cleaned-up
-		 * @return
+		 * @return mixed
 		 *  Returns the transliterated string
 		 */
 		private static function applyTransliterations($string) {

--- a/symphony/lib/toolkit/class.mysql.php
+++ b/symphony/lib/toolkit/class.mysql.php
@@ -264,6 +264,8 @@
 		 *  Defaults to null
 		 * @param string $port
 		 *  Defaults to 3306.
+		 * @param null $database
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public function connect($host = null, $user = null, $password = null, $port ='3306', $database = null) {
@@ -324,6 +326,7 @@
 		 * @link http://dev.mysql.com/doc/refman/5.0/en/charset-connection.html
 		 * @param string $set
 		 *  The character encoding to use, by default this 'utf8'
+		 * @throws DatabaseException
 		 */
 		public function setCharacterSet($set='utf8'){
 			$this->query("SET character_set_connection = '$set', character_set_database = '$set', character_set_server = '$set'");
@@ -339,6 +342,7 @@
 		 * @param string $timezone
 		 *  Timezone will be a offset, `+10:00`, as not all MySQL installations will
 		 *  have the humanreadable timezone database available
+		 * @throws DatabaseException
 		 */
 		public function setTimeZone($timezone = null) {
 			if(is_null($timezone)) return;
@@ -399,6 +403,7 @@
 		 * REPLACE, ALTER, DELETE, UPDATE, OPTIMIZE, TRUNCATE or DROP. Anything else is
 		 * considered to be a read operation which are subject to query caching.
 		 *
+		 * @param string $query
 		 * @return integer
 		 *  `MySQL::__WRITE_OPERATION__` or `MySQL::__READ_OPERATION__`
 		 */
@@ -421,6 +426,7 @@
 		 *  Whether to return the result as objects or associative array. Defaults
 		 *  to OBJECT which will return objects. The other option is ASSOC. If $type
 		 *  is not either of these, it will return objects.
+		 * @throws DatabaseException
 		 * @return boolean
 		 *  True if the query executed without errors, false otherwise
 		 */
@@ -556,6 +562,7 @@
 		 *  If set to true, data will updated if any key constraints are found that cause
 		 *  conflicts. By default this is set to false, which will not update the data and
 		 *  would return an SQL error
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public function insert(array $fields, $table, $updateOnDuplicate=false){
@@ -606,6 +613,7 @@
 		 * @param string $where
 		 *  A WHERE statement for this UPDATE statement, defaults to null
 		 *  which will update all rows in the $table
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public function update($fields, $table, $where = null) {
@@ -630,6 +638,7 @@
 		 * @param string $where
 		 *  A WHERE statement for this DELETE statement, defaults to null,
 		 *  which will delete all rows in the $table
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public function delete($table, $where = null){
@@ -655,6 +664,7 @@
 		 *  the result by. If this is omitted (and it is by default), an
 		 *  array of associative arrays is returned, with the key being the
 		 *  column names
+		 * @throws DatabaseException
 		 * @return array
 		 *  An associative array with the column names as the keys
 		 */
@@ -695,6 +705,7 @@
 		 * @param string $query
 		 *  The full SQL query to execute. Defaults to null, which will
 		 *  use the `$this->_lastResult`
+		 * @throws DatabaseException
 		 * @return array
 		 *  If there is no row at the specified `$offset`, an empty array will be returned
 		 *  otherwise an associative array of that row will be returned.
@@ -713,6 +724,7 @@
 		 * @param string $query
 		 *  The full SQL query to execute. Defaults to null, which will
 		 *  use the `$this->_lastResult`
+		 * @throws DatabaseException
 		 * @return array
 		 *  If there is no results for the `$query`, an empty array will be returned
 		 *  otherwise an array of values for that given `$column` will be returned
@@ -743,6 +755,7 @@
 		 * @param string $query
 		 *  The full SQL query to execute. Defaults to null, which will
 		 *  use the `$this->_lastResult`
+		 * @throws DatabaseException
 		 * @return string|null
 		 *  Returns the value of the given column, if it doesn't exist, null will be
 		 *  returned
@@ -761,6 +774,7 @@
 		 *  The table name
 		 * @param string $field
 		 *  The field name
+		 * @throws DatabaseException
 		 * @return boolean
 		 *  True if `$table` contains `$field`, false otherwise
 		 */
@@ -777,6 +791,7 @@
 		 * @since Symphony 2.3.4
 		 * @param string $table
 		 *  The table name
+		 * @throws DatabaseException
 		 * @return boolean
 		 *  True if `$table` exists, false otherwise
 		 */
@@ -849,6 +864,7 @@
 		 * error and debug. If no type is given, the entire log is returned,
 		 * otherwise only log messages for that type are returned
 		 *
+		 * @param null|string $type
 		 * @return array
 		 *  An array of associative array's. Log entries of the error type
 		 *  return the query the error occurred on and the error number and
@@ -899,6 +915,8 @@
 		 *  If set to true, this will set MySQL's default storage engine to MyISAM.
 		 *  Defaults to false, which will use MySQL's default storage engine when
 		 *  tables don't explicitly define which engine they should be created with
+		 * @throws DatabaseException
+		 * @throws Exception
 		 * @return boolean
 		 *  If one of the queries fails, false will be returned and no further queries
 		 *  will be executed, otherwise true will be returned.

--- a/symphony/lib/toolkit/class.page.php
+++ b/symphony/lib/toolkit/class.page.php
@@ -156,7 +156,7 @@
 		 *
 		 * @since Symphony 2.3.2
 		 *
-		 * @param integer $res_code
+		 * @param int $status_code
 		 *  The HTTP Status code to get the value for
 		 * @return string
 		 *  The formatted HTTP Status string

--- a/symphony/lib/toolkit/class.pagemanager.php
+++ b/symphony/lib/toolkit/class.pagemanager.php
@@ -21,6 +21,7 @@
 		 *
 		 * @param array $fields
 		 *  Associative array of field names => values for the Page
+		 * @throws DatabaseException
 		 * @return integer|boolean
 		 *  Returns the Page ID of the created Page on success, false otherwise.
 		 */
@@ -80,6 +81,7 @@
 		 *  The Page ID to add the Types to
 		 * @param array $types
 		 *  An array of page types
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public static function addPageTypesToPage($page_id = null, array $types) {
@@ -145,6 +147,7 @@
 		 * @param string $old_handle (optional)
 		 *  This parameter is only required when renaming a Page. It should be the 'old
 		 *  handle' before the Page was renamed.
+		 * @throws Exception
 		 * @return boolean
 		 *  True when the page files have been created successfully, false otherwise.
 		 */
@@ -264,6 +267,7 @@
 		 *  The path of the Page, which is the handles of the Page parents. If the
 		 *  page has multiple parents, they will be separated by a forward slash.
 		 *  eg. article/read. If a page has no parents, this parameter should be null.
+		 * @throws Exception
 		 * @return boolean
 		 */
 		public static function editPageChildren($page_id = null, $page_path = null) {
@@ -304,6 +308,8 @@
 		 * @param boolean $delete_files
 		 *  If true, this parameter will remove the Page's templates from the
 		 *  the filesystem. By default this is true.
+		 * @throws DatabaseException
+		 * @throws Exception
 		 * @return boolean
 		 */
 		public static function delete($page_id = null, $delete_files = true) {
@@ -344,6 +350,7 @@
 		 *
 		 * @param integer $page_id
 		 *  The ID of the Page that should be deleted.
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public static function deletePageTypes($page_id = null) {
@@ -363,6 +370,7 @@
 		 *  eg. article/read. If a page has no parents, this parameter should be null.
 		 * @param string $handle
 		 *  A Page handle, generated using `PageManager::createHandle`.
+		 * @throws Exception
 		 * @return boolean
 		 */
 		public static function deletePageFiles($page_path, $handle) {
@@ -614,6 +622,7 @@
 		/**
 		 * Fetch an associated array with Page ID's and the types they're using.
 		 *
+		 * @throws DatabaseException
 		 * @return array
 		 *  A 2-dimensional associated array where the key is the page ID.
 		 */
@@ -649,7 +658,7 @@
 		 * This function takes a `$path` and `$handle` and generates a flattened
 		 * string for use as a filename for a Page's template.
 		 *
-		 * @param string $page_path
+		 * @param string $path
 		 *  The path of the Page, which is the handles of the Page parents. If the
 		 *  page has multiple parents, they will be separated by a forward slash.
 		 *  eg. article/read. If a page has no parents, this parameter should be null.
@@ -764,6 +773,7 @@
 		 * @param mixed $page_id
 		 *  The ID of the Page that currently being viewed, or the handle of the
 		 *  current Page
+		 * @param string $column
 		 * @return array
 		 *  An array of the current Page, containing the `$column`
 		 *  requested. The current page will be the last item the array, as all

--- a/symphony/lib/toolkit/class.profiler.php
+++ b/symphony/lib/toolkit/class.profiler.php
@@ -196,7 +196,7 @@
 
 	}
 
-    /**
+	/**
 	 * Defines a constant for when the Profiler should be a complete snapshot of
 	 * the page load, from the very start, to the very end.
 	 * @var integer

--- a/symphony/lib/toolkit/class.resourcemanager.php
+++ b/symphony/lib/toolkit/class.resourcemanager.php
@@ -132,6 +132,8 @@
 		 * @param string $order_by (optional)
 		 *  Allows a developer to return the resources in a particular order. The syntax is the
 		 *  same as other `fetch` methods. If omitted this will return resources ordered by `name`.
+		 * @throws SymphonyErrorPage
+		 * @throws Exception
 		 * @return array
 		 *  An associative array of resource information, formatted in the same way as the resource's
 		 *  manager `listAll()` method.
@@ -242,6 +244,7 @@
 		 *  The resource type, either `RESOURCE_TYPE_EVENT` or `RESOURCE_TYPE_DS`
 		 * @param string $r_handle
 		 *  The handle of the resource.
+		 * @throws Exception
 		 * @return string
 		 *  The extension handle.
 		 */
@@ -367,7 +370,7 @@
 		 *  The resource type, either `RESOURCE_TYPE_EVENT` or `RESOURCE_TYPE_DS`
 		 * @param string $r_handle
 		 *  The handle of the resource.
-		 * @param array $page_id
+		 * @param array $pages
 		 *  An array of Page ID's to attach this resource to.
 		 * @return boolean
 		 */

--- a/symphony/lib/toolkit/class.resourcespage.php
+++ b/symphony/lib/toolkit/class.resourcespage.php
@@ -35,6 +35,8 @@
 		 * @param array $params
 		 *  An associative array of params (usually populated from the URL) that this
 		 *  function uses. The current implementation will use `type` and `unsort` keys
+		 * @throws Exception
+		 * @throws SymphonyErrorPage
 		 * @return array
 		 *  An associative of the resource as determined by `ResourceManager::fetch`
 		 */
@@ -95,6 +97,7 @@
 		 *
 		 * @param integer $resource_type
 		 *  Either `RESOURCE_TYPE_EVENT` or `RESOURCE_TYPE_DATASOURCE`
+		 * @throws InvalidArgumentException
 		 */
 		public function __viewIndex($resource_type){
 			$manager = ResourceManager::getManagerFromType($resource_type);
@@ -313,6 +316,7 @@
 		 *
 		 * @param integer $resource_type
 		 *  Either `RESOURCE_TYPE_EVENT` or `RESOURCE_TYPE_DATASOURCE`
+		 * @throws Exception
 		 */
 		public function __actionIndex($resource_type){
 			$manager = ResourceManager::getManagerFromType($resource_type);

--- a/symphony/lib/toolkit/class.section.php
+++ b/symphony/lib/toolkit/class.section.php
@@ -35,13 +35,14 @@
 
 		/**
 		 * An accessor function for this Section's settings. If the
-		 * $setting param is omitted, an array of all setting will
-		 * be returned, otherwise it will return the data for
-		 * the setting given
+		 * $setting param is omitted, an array of all settings will
+		 * be returned. Otherwise it will return the data for
+		 * the setting given.
 		 *
+		 * @param null|string $setting
 		 * @return array|string
-		 *	If setting is provided, returns a string, if setting is omitted
-		 *	returns an associative array of this Section's settings
+		 *    If setting is provided, returns a string, if setting is omitted
+		 *    returns an associative array of this Section's settings
 		 */
 		public function get($setting = null){
 			if(is_null($setting)) return $this->_data;
@@ -56,8 +57,9 @@
 		 * 'id' is returned instead.
 		 *
 		 * @since Symphony 2.3
+		 * @throws Exception
 		 * @return string
-		 *	Either the field ID or the string 'id'.
+		 *    Either the field ID or the string 'id'.
 		 */
 		public function getDefaultSortingField(){
 			$fields = $this->fetchVisibleColumns();
@@ -77,8 +79,9 @@
 		 * contain any settings for that Section.
 		 *
 		 * @since Symphony 2.3
+		 * @throws Exception
 		 * @return string
-		 *	Either the field ID or the string 'id'.
+		 *    Either the field ID or the string 'id'.
 		 */
 		public function getSortingField(){
 			$result = Symphony::Configuration()->get('section_' . $this->get('handle') . '_sortby', 'sorting');
@@ -194,6 +197,7 @@
 		 * on the entries table page ordered by the order in which they appear
 		 * in the Section Editor interface
 		 *
+		 * @throws Exception
 		 * @return array
 		 */
 		public function fetchVisibleColumns(){
@@ -205,10 +209,11 @@
 		 * the field type or it's location within the section.
 		 *
 		 * @param string $type
-		 *	The field type (it's handle as returned by `$field->handle()`)
+		 *    The field type (it's handle as returned by `$field->handle()`)
 		 * @param string $location
-		 *	The location of the fields in the entry creator, whether they are
-		 *	'main' or 'sidebar'
+		 *    The location of the fields in the entry creator, whether they are
+		 *    'main' or 'sidebar'
+		 * @throws Exception
 		 * @return array
 		 */
 		public function fetchFields($type = null, $location = null){
@@ -219,8 +224,9 @@
 		 * Returns an array of all the fields that can be filtered.
 		 *
 		 * @param string $location
-		 *	The location of the fields in the entry creator, whether they are
-		 *	'main' or 'sidebar'
+		 *    The location of the fields in the entry creator, whether they are
+		 *    'main' or 'sidebar'
+		 * @throws Exception
 		 * @return array
 		 */
 		public function fetchFilterableFields($location = null){
@@ -233,8 +239,9 @@
 		 * Index pages
 		 *
 		 * @param string $location
-		 *	The location of the fields in the entry creator, whether they are
-		 *	'main' or 'sidebar'
+		 *    The location of the fields in the entry creator, whether they are
+		 *    'main' or 'sidebar'
+		 * @throws Exception
 		 * @return array
 		 */
 		public function fetchToggleableFields($location = null){

--- a/symphony/lib/toolkit/class.sectionmanager.php
+++ b/symphony/lib/toolkit/class.sectionmanager.php
@@ -27,10 +27,11 @@
 		 * as the Section ID.
 		 *
 		 * @param array $settings
-		 *	An associative of settings for a section with the key being
-		 *	a column name from `tbl_sections`
+		 *    An associative of settings for a section with the key being
+		 *    a column name from `tbl_sections`
+		 * @throws DatabaseException
 		 * @return integer
-		 *	The newly created Section's ID
+		 *    The newly created Section's ID
 		 */
 		public static function add(array $settings){
 			if(!Symphony::Database()->insert($settings, 'tbl_sections')) return false;
@@ -45,10 +46,11 @@
 		 * prior to updating the Section
 		 *
 		 * @param integer $section_id
-		 *	The ID of the Section to edit
+		 *    The ID of the Section to edit
 		 * @param array $settings
-		 *	An associative of settings for a section with the key being
-		 *	a column name from `tbl_sections`
+		 *    An associative of settings for a section with the key being
+		 *    a column name from `tbl_sections`
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public static function edit($section_id, array $settings){
@@ -62,9 +64,11 @@
 		 * Section and any Section Associations in that order
 		 *
 		 * @param integer $section_id
-		 *	The ID of the Section to delete
+		 *    The ID of the Section to delete
+		 * @throws DatabaseException
+		 * @throws Exception
 		 * @return boolean
-		 *	Returns true when completed
+		 *    Returns true when completed
 		 */
 		public static function delete($section_id){
 			$details = Symphony::Database()->fetchRow(0, "SELECT `sortorder` FROM tbl_sections WHERE `id` = '$section_id'");
@@ -101,15 +105,16 @@
 		 * their name
 		 *
 		 * @param integer|array $section_id
-		 *	The ID of the section to return, or an array of ID's. Defaults to null
+		 *    The ID of the section to return, or an array of ID's. Defaults to null
 		 * @param string $order
-		 *	If `$section_id` is omitted, this is the sortorder of the returned
-		 *	objects. Defaults to ASC, other options id DESC
+		 *    If `$section_id` is omitted, this is the sortorder of the returned
+		 *    objects. Defaults to ASC, other options id DESC
 		 * @param string $sortfield
-		 *	The name of the column in the `tbl_sections` table to sort
-		 *	on. Defaults to name
+		 *    The name of the column in the `tbl_sections` table to sort
+		 *    on. Defaults to name
+		 * @throws DatabaseException
 		 * @return Section|array
-		 *	A Section object or an array of Section objects
+		 *    A Section object or an array of Section objects
 		 */
 		public static function fetch($section_id = null, $order = 'ASC', $sortfield = 'name'){
 			$returnSingle = false;
@@ -203,16 +208,18 @@
 		 *
 		 * @since Symphony 2.3
 		 * @param integer $parent_section_id
-		 *	The linked section id.
+		 *    The linked section id.
 		 * @param integer $child_field_id
-		 *	The field ID of the field that is creating the association
+		 *    The field ID of the field that is creating the association
 		 * @param integer $parent_field_id (optional)
-		 *	The field ID of the linked field in the linked section
+		 *    The field ID of the linked field in the linked section
 		 * @param boolean $show_association (optional)
-		 *	Whether of not the link should be shown on the entries table of the
-		 *	linked section. This defaults to true.
+		 *    Whether of not the link should be shown on the entries table of the
+		 *    linked section. This defaults to true.
+		 * @throws DatabaseException
+		 * @throws Exception
 		 * @return boolean
-		 *	true if the association was successfully made, false otherwise.
+		 *    true if the association was successfully made, false otherwise.
 		 */
 		public static function createSectionAssociation($parent_section_id = null, $child_field_id = null, $parent_field_id = null, $show_association = true){
 
@@ -242,7 +249,8 @@
 		 *
 		 * @since Symphony 2.3
 		 * @param integer $field_id
-		 *	the field ID of the linked section's linked field.
+		 *    the field ID of the linked section's linked field.
+		 * @throws DatabaseException
 		 * @return boolean
 		 */
 		public static function removeSectionAssociation($field_id) {
@@ -284,11 +292,12 @@
 		 *
 		 * @since Symphony 2.3.3
 		 * @param integer $section_id
-		 *	The ID of the section
+		 *    The ID of the section
 		 * @param boolean $respect_visibility
-		 *	Whether to return all the section associations regardless of if they
-		 *	are deemed visible or not. Defaults to false, which will return all
-		 *	associations.
+		 *    Whether to return all the section associations regardless of if they
+		 *    are deemed visible or not. Defaults to false, which will return all
+		 *    associations.
+		 * @throws DatabaseException
 		 * @return array
 		 */
 		public static function fetchChildAssociations($section_id, $respect_visibility = false) {
@@ -316,11 +325,12 @@
 		 *
 		 * @since Symphony 2.3.3
 		 * @param integer $section_id
-		 *	The ID of the section
+		 *    The ID of the section
 		 * @param boolean $respect_visibility
-		 *	Whether to return all the section associations regardless of if they
-		 *	are deemed visible or not. Defaults to false, which will return all
-		 *	associations.
+		 *    Whether to return all the section associations regardless of if they
+		 *    are deemed visible or not. Defaults to false, which will return all
+		 *    associations.
+		 * @throws DatabaseException
 		 * @return array
 		 */
 		public static function fetchParentAssociations($section_id, $respect_visibility = false) {

--- a/symphony/lib/toolkit/class.smtp.php
+++ b/symphony/lib/toolkit/class.smtp.php
@@ -52,11 +52,12 @@
 		 *  When no ssl is used, and ini_get returns no value, defaults to 25.
 		 * @param array $options
 		 *  Currently supports 3 values:
-		 *  	$options['secure'] can be ssl, tls or null.
-		 *  	$options['username'] the username used to login to the server. Leave empty for no authentication.
-		 *  	$options['password'] the password used to login to the server. Leave empty for no authentication.
-		 *  	$options['local_ip'] the ip address used in the ehlo/helo commands. Only ip's are accepted.
-		 * @return void
+		 *    $options['secure'] can be ssl, tls or null.
+		 *    $options['username'] the username used to login to the server. Leave empty for no authentication.
+		 *    $options['password'] the password used to login to the server. Leave empty for no authentication.
+		 *    $options['local_ip'] the ip address used in the ehlo/helo commands. Only ip's are accepted.
+		 * @throws SMTPException
+		 * @return \SMTP
 		 */
 		public function __construct($host = '127.0.0.1', $port = null, $options = array()){
 			if ($options['secure'] !== null) {
@@ -128,6 +129,8 @@
 		 * @param string $subject
 		 *  The subject to send the email to.
 		 * @param string $message
+		 * @throws SMTPException
+		 * @throws Exception
 		 * @return boolean
 		 */
 		public function sendMail($from, $to, $subject, $message){
@@ -163,6 +166,7 @@
 		 * Initiates the ehlo/helo requests.
 		 *
 		 * @throws SMTPException
+		 * @throws Exception
 		 * @return void
 		 */
 		public function helo(){
@@ -280,6 +284,7 @@
 		/**
 		 * Resets the current session. This 'undoes' all rcpt, mail, etc calls.
 		 *
+		 * @throws SMTPException
 		 * @return void
 		 */
 		public function rset(){
@@ -295,6 +300,7 @@
 		/**
 		 * Disconnects to the server.
 		 *
+		 * @throws SMTPException
 		 * @return void
 		 */
 		public function quit(){
@@ -332,6 +338,7 @@
 		 * Calls the EHLO function.
 		 * This is the HELO function for more modern servers.
 		 *
+		 * @throws SMTPException
 		 * @return void
 		 */
 		protected function _ehlo(){
@@ -343,6 +350,7 @@
 		 * Initiates the connection by calling the HELO function.
 		 * This function should only be used if the server does not support the HELO function.
 		 *
+		 * @throws SMTPException
 		 * @return void
 		 */
 		protected function _helo(){
@@ -353,6 +361,7 @@
 		/**
 		 * Encrypts the current session with TLS.
 		 *
+		 * @throws SMTPException
 		 * @return void
 		 */
 		protected function _tls(){
@@ -370,6 +379,7 @@
 		 * Send a request to the host, appends the request with a line break.
 		 *
 		 * @param string $request
+		 * @throws SMTPException
 		 * @return boolean|integer number of characters written.
 		 */
 		protected function _send($request){
@@ -385,9 +395,10 @@
 		/**
 		 * Get a line from the stream.
 		 *
-		 * @param integer $timeout 
-		 *  Per-request timeout value if applicable. Defaults to null which 
+		 * @param integer $timeout
+		 *  Per-request timeout value if applicable. Defaults to null which
 		 *  will not set a timeout.
+		 * @throws SMTPException
 		 * @return string
 		 */
 		protected function _receive($timeout = null) {
@@ -459,9 +470,11 @@
 		/**
 		 * Connect to the host, and perform basic functions like helo and auth.
 		 *
-		 * @throws SMTPException
+		 *
 		 * @param string $host
 		 * @param integer $port
+		 * @throws SMTPException
+		 * @throws Exception
 		 * @return void
 		 */
 		protected function _connect($host, $port){

--- a/symphony/lib/toolkit/class.textformattermanager.php
+++ b/symphony/lib/toolkit/class.textformattermanager.php
@@ -152,7 +152,8 @@
 		 * to the `$_pool` array with the key being the handle.
 		 *
 		 * @param string $handle
-		 *	The handle of the Text Formatter to create
+		 *    The handle of the Text Formatter to create
+		 * @throws Exception
 		 * @return TextFormatter
 		 */
 		public static function create($handle){

--- a/symphony/lib/toolkit/class.textpage.php
+++ b/symphony/lib/toolkit/class.textpage.php
@@ -62,6 +62,7 @@
 		 * this `TextPage`, before calling the parent generate function and
 		 * returning the `$this->_Result` string
 		 *
+		 * @param null $page
 		 * @return string
 		 */
 		public function generate($page = null) {

--- a/symphony/lib/toolkit/class.widget.php
+++ b/symphony/lib/toolkit/class.widget.php
@@ -26,6 +26,7 @@
 		 *  the key being the name and the value being the value of the attribute.
 		 *  Attributes set from this array will override existing attributes
 		 *  set by previous params.
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public static function Label($name = null, XMLElement $child = null, $class = null, $id = null, array $attributes = null){
@@ -63,6 +64,7 @@
 		 *  the key being the name and the value being the value of the attribute.
 		 *  Attributes set from this array will override existing attributes
 		 *  set by previous params.
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public static function Input($name, $value = null, $type = 'text', array $attributes = null){
@@ -102,6 +104,7 @@
 		 *  the key being the name and the value being the value of the attribute.
 		 *  Attributes set from this array will override existing attributes
 		 *  set by previous params.
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public static function Textarea($name, $rows = 15, $cols = 50, $value = null, array $attributes = null){
@@ -145,6 +148,7 @@
 		 *  the key being the name and the value being the value of the attribute.
 		 *  Attributes set from this array will override existing attributes
 		 *  set by previous params.
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public static function Anchor($value, $href, $title = null, $class = null, $id = null, array $attributes = null){
@@ -186,6 +190,7 @@
 		 *  the key being the name and the value being the value of the attribute.
 		 *  Attributes set from this array will override existing attributes
 		 *  set by previous params.
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public static function Form($action = null, $method = 'post', $class = null, $id = null, array $attributes = null){
@@ -229,6 +234,7 @@
 		 *  the key being the name and the value being the value of the attribute.
 		 *  Attributes set from this array will override existing attributes
 		 *  set by previous params.
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public static function Table(XMLElement $header = null, XMLElement $footer = null, XMLElement $body = null, $class = null, $id = null, Array $attributes = null){
@@ -321,6 +327,7 @@
 		 *  the key being the name and the value being the value of the attribute.
 		 *  Attributes set from this array will override existing attributes
 		 *  set by previous params.
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public static function TableBody(array $rows, $class = null, $id = null, array $attributes = null){
@@ -360,6 +367,7 @@
 		 *  the key being the name and the value being the value of the attribute.
 		 *  Attributes set from this array will override existing attributes
 		 *  set by previous params.
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public static function TableRow(array $cells, $class = null, $id = null, $rowspan = null, Array $attributes = null){
@@ -401,6 +409,7 @@
 		 *  the key being the name and the value being the value of the attribute.
 		 *  Attributes set from this array will override existing attributes
 		 *  set by previous params.
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public static function TableData($value, $class = null, $id = null, $colspan = null, Array $attributes = null){
@@ -475,12 +484,12 @@
 		 *  `<select>` XMLElement is returned.
 		 *  `
 		 *   array(
-		 *  	array($value, $selected, $desc, $class, $id, $attr)
+		 *    array($value, $selected, $desc, $class, $id, $attr)
 		 *   )
 		 *   array(
-		 *  	array('label' => 'Optgroup', 'data-label' => 'optgroup', 'options' = array(
-		 *  		array($value, $selected, $desc, $class, $id, $attr)
-		 *  	)
+		 *    array('label' => 'Optgroup', 'data-label' => 'optgroup', 'options' = array(
+		 *        array($value, $selected, $desc, $class, $id, $attr)
+		 *    )
 		 *   )
 		 *  `
 		 * @param array $attributes (optional)
@@ -488,6 +497,7 @@
 		 *  the key being the name and the value being the value of the attribute.
 		 *  Attributes set from this array will override existing attributes
 		 *  set by previous params.
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public static function Select($name, array $options = null, array $attributes = null){
@@ -604,14 +614,15 @@
 		 *  `<select>` XMLElement is returned.
 		 *  `
 		 *   array(
-		 *  	array($value, $selected, $desc, $class, $id, $attr)
+		 *    array($value, $selected, $desc, $class, $id, $attr)
 		 *   )
 		 *   array(
-		 *  	array('label' => 'Optgroup', 'options' = array(
-		 *  		array($value, $selected, $desc, $class, $id, $attr)
-		 *  	)
+		 *    array('label' => 'Optgroup', 'options' = array(
+		 *        array($value, $selected, $desc, $class, $id, $attr)
+		 *    )
 		 *   )
 		 *  `
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public static function Apply(array $options = null){
@@ -639,6 +650,7 @@
 		 * @param string $message
 		 *  The text for this error. This will be appended after the $element,
 		 *  but inside the wrapping `<div>`
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public static function Error(XMLElement $element, $message) {
@@ -671,6 +683,7 @@
 		 * @param string $default_state
 		 *  This parameter defines whether the drawer will be open or closed by
 		 *  default. It defaults to closed.
+		 * @param string $context
 		 * @param array $attributes (optional)
 		 *  Any additional attributes can be included in an associative array with
 		 *  the key being the name and the value being the value of the attribute.

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -218,6 +218,7 @@
 		 *
 		 * @since Symphony 2.3
 		 * @param string $name
+		 * @param int $position
 		 * @return XMLElement
 		 */
 		public function getChildByName($name, $position) {
@@ -306,7 +307,7 @@
 		 * XML declaration or not. This normally is only set to
 		 * true for the parent `XMLElement`, eg. 'html'.
 		 *
-		 * @param string $value (optional)
+		 * @param bool|string $value (optional)
 		 *  Defaults to false
 		 */
 		public function setIncludeHeader($value = false){
@@ -316,7 +317,7 @@
 		/**
 		 * Sets whether this `XMLElement` is self closing or not.
 		 *
-		 * @param string $value (optional)
+		 * @param bool|string $value (optional)
 		 *  Defaults to true
 		 */
 		public function setSelfClosingTag($value = true){
@@ -327,7 +328,7 @@
 		 * Specifies whether attributes need to have a value
 		 * or if they can be shorthand on this `XMLElement`.
 		 *
-		 * @param string $value (optional)
+		 * @param bool|string $value (optional)
 		 *  Defaults to true
 		 */
 		public function setAllowEmptyAttributes($value = true){
@@ -742,6 +743,7 @@
 		 * object and return the result.
 		 *
 		 * @since Symphony 2.4
+		 * @param string $root_element
 		 * @param string $xml
 		 *  A string of XML
 		 * @return XMLElement
@@ -758,6 +760,7 @@
 		 * object and return the result.
 		 *
 		 * @since Symphony 2.4
+		 * @param string $root_element
 		 * @param DOMDOcument $doc
 		 * @return XMLElement
 		 */

--- a/symphony/lib/toolkit/class.xmlpage.php
+++ b/symphony/lib/toolkit/class.xmlpage.php
@@ -51,6 +51,7 @@
 		 * before calling the parent generate function and generating
 		 * the `$this->_Result` XMLElement
 		 *
+		 * @param null $page
 		 * @return string
 		 */
 		public function generate($page = null) {

--- a/symphony/lib/toolkit/class.xsltpage.php
+++ b/symphony/lib/toolkit/class.xsltpage.php
@@ -150,6 +150,7 @@
 		 * the page headers and a string containing the transformed result
 		 * is result.
 		 *
+		 * @param null $page
 		 * @return string
 		 */
 		public function generate($page = null){

--- a/symphony/lib/toolkit/class.xsltprocess.php
+++ b/symphony/lib/toolkit/class.xsltprocess.php
@@ -39,8 +39,6 @@
 		 *  The XML for the transformation to be applied to
 		 * @param string $xsl
 		 *  The XSL for the transformation
-		 * @return boolean
-		 *  True if there is an existing `XsltProcessor` class, false otherwise
 		 */
 		public function __construct($xml=null, $xsl=null){
 

--- a/symphony/lib/toolkit/cryptography/class.md5.php
+++ b/symphony/lib/toolkit/cryptography/class.md5.php
@@ -45,6 +45,7 @@
 		 * the cleartext password
 		 * @param string $hash
 		 * the hash the password should be checked against
+		 * @param bool $isHash
 		 * @return bool
 		 * the result of the comparison
 		 */

--- a/symphony/lib/toolkit/cryptography/class.pbkdf2.php
+++ b/symphony/lib/toolkit/cryptography/class.pbkdf2.php
@@ -82,11 +82,12 @@
 		 * from the hash.
 		 *
 		 * @param string $input
-		 * the cleartext password
+		 *  the cleartext password
 		 * @param string $hash
-		 * the hash the password should be checked against
+		 *  the hash the password should be checked against
+		 * @param bool $isHash
 		 * @return boolean
-		 * the result of the comparison
+		 *  the result of the comparison
 		 */
 		public static function compare($input, $hash, $isHash=false){
 			$salt = self::extractSalt($hash);

--- a/symphony/lib/toolkit/cryptography/class.sha1.php
+++ b/symphony/lib/toolkit/cryptography/class.sha1.php
@@ -44,6 +44,7 @@
 		 * the cleartext password
 		 * @param string $hash
 		 * the hash the password should be checked against
+		 * @param bool $isHash
 		 * @return boolean
 		 * the result of the comparison
 		 */

--- a/symphony/lib/toolkit/data-sources/class.datasource.section.php
+++ b/symphony/lib/toolkit/data-sources/class.datasource.section.php
@@ -82,6 +82,7 @@
 		 * @param array $group
 		 *  An associative array of the group data, includes `attr`, `records`
 		 *  and `groups` keys.
+		 * @throws Exception
 		 * @return XMLElement
 		 */
 		public function processRecordGroup($element, array $group){
@@ -122,6 +123,7 @@
 		 * by this datasource to the parameter pool.
 		 *
 		 * @param Entry $entry
+		 * @throws Exception
 		 * @return XMLElement|boolean
 		 *  Returns boolean when only parameters are to be returned.
 		 */
@@ -187,6 +189,7 @@
 		 *  be set on
 		 * @param Entry $entry
 		 *  The current entry object
+		 * @throws Exception
 		 */
 		public function setAssociatedEntryCounts(XMLElement &$xEntry, Entry $entry) {
 			$associated_entry_counts = $entry->fetchAllAssociatedEntryCounts($this->_associated_sections);
@@ -294,6 +297,7 @@
 		 * @param string $where
 		 * @param string $joins
 		 * @param boolean $group
+		 * @throws Exception
 		 */
 		public function processFilters(&$where, &$joins, &$group) {
 			if(!is_array($this->dsParamFILTERS) || empty($this->dsParamFILTERS)) return;

--- a/symphony/lib/toolkit/email-gateways/email.sendmail.php
+++ b/symphony/lib/toolkit/email-gateways/email.sendmail.php
@@ -27,7 +27,7 @@
 		/**
 		 * Constructor. Sets basic default values based on preferences.
 		 *
-		 * @return void
+		 * @throws EmailValidationException
 		 */
 		public function __construct(){
 			parent::__construct();
@@ -46,6 +46,8 @@
 		 * or base64) to make non-US-ASCII text work with the widest range
 		 * of email transports and clients.
 		 *
+		 * @throws EmailGatewayException
+		 * @throws EmailValidationException
 		 * @return bool
 		 */
 		public function send() {
@@ -126,7 +128,7 @@
 		 * Sets all configuration entries from an array.
 		 *
 		 * @throws EmailValidationException
-		 * @param array $configuration
+		 * @param array $config
 		 * @since 2.3.1
 		 *  All configuration entries stored in a single array. The array should have the format of the $_POST array created by the preferences HTML.
 		 * @return void
@@ -138,6 +140,7 @@
 		/**
 		 * Builds the preferences pane, shown in the symphony backend.
 		 *
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public function getPreferencesPane() {

--- a/symphony/lib/toolkit/email-gateways/email.smtp.php
+++ b/symphony/lib/toolkit/email-gateways/email.smtp.php
@@ -40,7 +40,7 @@
 		/**
 		 * Constructor. Sets basic default values based on preferences.
 		 *
-		 * @return void
+		 * @throws EmailValidationException
 		 */
 		public function __construct(){
 			parent::__construct();
@@ -50,6 +50,9 @@
 		/**
 		 * Send an email using an SMTP server
 		 *
+		 * @throws EmailGatewayException
+		 * @throws EmailValidationException
+		 * @throws Exception
 		 * @return boolean
 		 */
 		public function send(){
@@ -168,6 +171,7 @@
 		/**
 		 * Sets the host to connect to.
 		 *
+		 * @param null|string $host (optional)
 		 * @return void
 		 */
 		public function setHost($host = null){
@@ -185,6 +189,7 @@
 		/**
 		 * Sets the port, used in the connection.
 		 *
+		 * @param null|int $port
 		 * @return void
 		 */
 		public function setPort($port = null){
@@ -251,6 +256,8 @@
 		 * Sets the envelope_from address. This is only available via the API, as it is an expert-only feature.
 		 *
 		 * @since 2.3.1
+		 * @param null $envelope_from
+		 * @throws EmailValidationException
 		 * @return void
 		 */
 		public function setEnvelopeFrom($envelope_from = null){
@@ -263,10 +270,11 @@
 		/**
 		 * Sets all configuration entries from an array.
 		 *
+		 * @param array $config
+		 *  All configuration entries stored in a single array.
+		 *  The array should have the format of the $_POST array created by the preferences HTML.
 		 * @throws EmailValidationException
-		 * @param array $configuration
 		 * @since 2.3.1
-		 *  All configuration entries stored in a single array. The array should have the format of the $_POST array created by the preferences HTML.
 		 * @return void
 		 */
 		public function setConfiguration($config){
@@ -289,6 +297,7 @@
 		/**
 		 * Builds the preferences pane, shown in the Symphony backend.
 		 *
+		 * @throws InvalidArgumentException
 		 * @return XMLElement
 		 */
 		public function getPreferencesPane(){

--- a/symphony/lib/toolkit/events/class.event.section.php
+++ b/symphony/lib/toolkit/events/class.event.section.php
@@ -69,6 +69,7 @@
 		 * @param array $fields
 		 * @param array $errors
 		 * @param object $post_values
+		 * @throws Exception
 		 * @return XMLElement
 		 */
 		public static function appendErrors(XMLElement $result, array $fields, $errors, $post_values) {
@@ -176,6 +177,7 @@
 		 * determine if the user should be redirected to a URL, or to just return
 		 * the XML.
 		 *
+		 * @throws Exception
 		 * @return XMLElement|void
 		 *  If `$_REQUEST{'redirect']` is set, and the Event executed successfully,
 		 *  the user will be redirected to the given location. If `$_REQUEST['redirect']`
@@ -262,6 +264,7 @@
 		 * @param integer $entry_id
 		 *  If this Event is editing an existing entry, that Entry ID will
 		 *  be passed to this function.
+		 * @throws Exception
 		 * @return XMLElement
 		 *  The result of the Event
 		 */
@@ -385,7 +388,7 @@
 		 *
 		 * @param XMLElement $result
 		 * @param array $fields
-		 * @param array $post_values
+		 * @param XMLElement $post_values
 		 * @param integer $entry_id
 		 * @return boolean
 		 */
@@ -570,14 +573,14 @@
 		 * @param XMLElement $result
 		 *  The XMLElement of the XML that is going to be returned as part
 		 *  of this event to the page.
-		 * @param array $send_mail
-		 *  Associative array of `send-mail` parameters.
+		 * @param array $send_email
+		 *  Associative array of `send-mail` parameters.*  Associative array of `send-mail` parameters.
 		 * @param array $fields
 		 *  Array of post data to extract the values from
 		 * @param Section $section
-		 *  This Section for this event
-		 * @param Section $section
 		 *  This current Entry that has just been updated or created
+		 * @param Entry $entry
+		 * @throws Exception
 		 * @return XMLElement
 		 *  The modified `$result` with the results of the filter.
 		 */

--- a/symphony/lib/toolkit/fields/field.author.php
+++ b/symphony/lib/toolkit/fields/field.author.php
@@ -122,7 +122,7 @@
 			$types = $this->get('author_types');
 			$options = array(
 				array('author', empty($types) ? true : in_array('author', $types), __('Author')),
-                array('manager', empty($types) ? true : in_array('manager', $types), __('Manager')),
+				array('manager', empty($types) ? true : in_array('manager', $types), __('Manager')),
 				array('developer', empty($types) ? true : in_array('developer', $types), __('Developer'))
 			);
 			$label->appendChild(


### PR DESCRIPTION
As reported by PhpStorm. I let it add the @throw lines (183) automatically. The changes to the @param and @return lines (63) I went through manually to make sure they're correct.

I did not change any actual code, so it's safe from that POV. With tabs this time.
