### PR TITLE
array type throwing error

### DIFF
--- a/symphony/lib/core/class.administration.php
+++ b/symphony/lib/core/class.administration.php
@@ -199,7 +199,7 @@
 				if(is_array($extensions) && !empty($extensions) && $this->__canAccessAlerts()) {
 					foreach($extensions as $name) {
 						try {
-							$about = Symphony::ExtensionManager()->about($name);
+							$about = (array)Symphony::ExtensionManager()->about($name);
 						}
 						catch (Exception $ex) {
 							// The extension cannot be found, show an error message and let the user remove
@@ -332,7 +332,7 @@
 				else {
 					$context = array();
 				}
-				
+
 				$callback = array(
 					'driver' => 'login',
 					'driver_location' => CONTENT . '/content.login.php',


### PR DESCRIPTION
This fixes the following error (after update from 2.3.3RC1 to 2.4RC1)

```
Symphony Warning: array_key_exists() expects parameter 2 to be array, null given
An error occurred in /var/www/oliberal/symphony/lib/core/class.administration.php around line 237
```

```
232                             else {
233                                 throw $ex;
234                             }
235                         }
236
237                         if(array_key_exists('status', $about) && in_array(EXTENSION_REQUIRES_UPDATE, $about['status'])) {
238                             $this->Page->pageAlert(
239                                 __('An extension requires updating.') . ' <a href="' . SYMPHONY_URL . '/system/extensions/">' . __('View extensions') . '</a>'
240                             );
241                             break;
```
