### PR TITLE
Disable multiviews in .htaccess

### DIFF
--- a/install/includes/htaccess.txt
+++ b/install/includes/htaccess.txt
@@ -2,10 +2,18 @@
 Options +FollowSymlinks -Indexes
 
 <IfModule !mod_rewrite.c>
+
 	SetEnv HTTP_MOD_REWRITE No
+
 </IfModule>
 
 <IfModule mod_rewrite.c>
+
+    <IfModule mod_negotiation.c>
+
+        Options -MultiViews
+
+    </IfModule>
 
 	RewriteEngine on
 	RewriteBase /<!-- REWRITE_BASE -->


### PR DESCRIPTION
I just came across a situation where I uploaded a PDF _products.pdf_ to the document root of a Symphony site, and the page _example.com/products/_ wasn't reachable any more.

This can be prevented by [disabling multiviews via .htaccess](https://github.com/laravel/laravel/blob/master/public/.htaccess).
