### PR TITLE
Enable output compression

### DIFF
--- a/install/includes/htaccess.txt
+++ b/install/includes/htaccess.txt
@@ -1,8 +1,16 @@
 ### Symphony 2.3.x ###
 Options +FollowSymlinks -Indexes
 
+<IfModule mod_deflate.c>
+
+    SetOutputFilter DEFLATE
+
+</IfModule>
+
 <IfModule !mod_rewrite.c>
+
 	SetEnv HTTP_MOD_REWRITE No
+
 </IfModule>
 
 <IfModule mod_rewrite.c>


### PR DESCRIPTION
Just a suggestion. Not sure if this is something Symphony should enforce by default or if it's the developers responsibility.
