### PR TITLE
Enforce edge rendering for Internet Explorer

### DIFF
--- a/install/includes/htaccess.txt
+++ b/install/includes/htaccess.txt
@@ -1,8 +1,16 @@
 ### Symphony 2.3.x ###
 Options +FollowSymlinks -Indexes
 
+<IfModule mod_headers.c>
+
+    Header set X-UA-Compatible "IE=edge"
+
+</IfModule>
+
 <IfModule !mod_rewrite.c>
+
 	SetEnv HTTP_MOD_REWRITE No
+
 </IfModule>
 
 <IfModule mod_rewrite.c>


### PR DESCRIPTION
Just a suggestion. Not sure if this is something Symphony should enforce by default or if it's the developers responsibility.
