### PR TITLE
Xml element: prevent any element from being a child of itself.

### DIFF
--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -456,6 +456,7 @@ class XMLElement implements IteratorAggregate
      * A convenience method that encapsulate validation of a child node.
      * This should prevent generate errors by catching them earlier.
      *
+     * @since Symphony 2.4.1
      * @param XMLElement $child
      *  The child to validate
      *


### PR DESCRIPTION
I do this error often (shame on copy/paste) and it makes php crash with a white page (since it creates an infinite loop).

Trying to catch errors as early as possible is a good thing IMHO. And a pointer check should not degrade performance.
