### PR TITLE
Fixed string "0" being omitted in event post data

### DIFF
--- a/symphony/lib/toolkit/class.general.php
+++ b/symphony/lib/toolkit/class.general.php
@@ -874,7 +874,7 @@ class General
     public static function array_to_xml(XMLElement $parent, array $data, $validate = false)
     {
         foreach ($data as $element_name => $value) {
-            if (!is_numeric($value) and empty($value)) {
+            if (!is_numeric($value) && empty($value)) {
                 continue;
             }
 


### PR DESCRIPTION
When sending value `0` through a form, it is omitted in event post data XML.

The patch fixes this by ignoring numeric values from exclusion.
