### PR TITLE
Adding some meta data into the extensions html

### DIFF
--- a/symphony/content/content.systemextensions.php
+++ b/symphony/content/content.systemextensions.php
@@ -175,10 +175,10 @@ class contentSystemExtensions extends AdministrationPage
                 }
 
                 $td5 = Widget::TableData($tdAuthors);
-                
+
                 // Create the table row
                 $tr = Widget::TableRow(array($td1, $td2, $td3, $td4, $td5), implode(' ', $trClasses));
-                
+
                 // Add some attributes about the extension
                 $tr->setAttribute('data-handle', $name);
                 $tr->setAttribute('data-installed-version', $installed_version);


### PR DESCRIPTION
I really love when I want to access some data and I do not have
to do crazy parsing of the html to access the real data. This
change continues some past work of rendering values via data-*
attributes.
