### PR TITLE
Finding related entries

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -1455,7 +1455,7 @@ class contentPublish extends AdministrationPage
 
                         // get associated entries if entry exists,
                         if ($entry_id) {
-                            $entry_ids = $this->findParentRelatedEntries($as['child_section_field_id'], $entry_id);
+                            $entry_ids = $field->findParentRelatedEntries($as['child_section_field_id'], $entry_id);
 
                             // get prepopulated entry otherwise
                         } elseif (isset($_GET['prepopulate'])) {
@@ -1514,7 +1514,7 @@ class contentPublish extends AdministrationPage
                     $relation_field  = FieldManager::fetch($as['child_section_field_id']);
 
                     // Get entries, using $schema for performance reasons.
-                    $entry_ids = $this->findRelatedEntries($as['child_section_field_id'], $entry_id);
+                    $entry_ids = $relation_field->findRelatedEntries($entry_id);
                     $schema = $visible_field ? array($visible_field->get('element_name')) : array();
                     $where = sprintf(' AND `e`.`id` IN (%s)', implode(', ', $entry_ids));
 
@@ -1596,57 +1596,5 @@ class contentPublish extends AdministrationPage
 
         $drawer = Widget::Drawer('section-associations', __('Show Associations'), $content);
         $this->insertDrawer($drawer, $drawer_position, 'prepend');
-    }
-
-    /**
-     * Find related entries from a linking field's data table. Requires the
-     * column names to be `entry_id` and `relation_id` as with the Select Box Link
-     * @param  integer $field_id
-     * @param  integer $entry_id
-     * @return array
-     */
-    public function findRelatedEntries($field_id = null, $entry_id)
-    {
-        try {
-            $ids = Symphony::Database()->fetchCol('entry_id', sprintf("
-                    SELECT `entry_id`
-                    FROM `tbl_entries_data_%d`
-                    WHERE `relation_id` = %d
-                    AND `entry_id` IS NOT null
-                ",
-                $field_id,
-                $entry_id
-            ));
-        } catch (Exception $e) {
-            return array();
-        }
-
-        return $ids;
-    }
-
-    /**
-     * Find related entries for the current field. Requires the column names
-     * to be `entry_id` and `relation_id` as with the Select Box Link
-     * @param  integer $field_id
-     * @param  integer $entry_id
-     * @return array
-     */
-    public function findParentRelatedEntries($field_id = null, $entry_id)
-    {
-        try {
-            $ids = Symphony::Database()->fetchCol('relation_id', sprintf("
-                    SELECT `relation_id`
-                    FROM `tbl_entries_data_%d`
-                    WHERE `entry_id` = %d
-                    AND `relation_id` IS NOT null
-                ",
-                $field_id,
-                $entry_id
-            ));
-        } catch (Exception $e) {
-            return array();
-        }
-
-        return $ids;
     }
 }

--- a/symphony/lib/toolkit/class.field.php
+++ b/symphony/lib/toolkit/class.field.php
@@ -1551,4 +1551,55 @@ class Field
     {
 
     }
+
+    /**
+     * Find related entries from a linking field's data table. Default implementation uses
+     * column names `entry_id` and `relation_id` as with the Select Box Link
+     * 
+     * @since Symphony 2.4.1
+     * 
+     * @param  integer $entry_id
+     * @return array
+     */
+    public function findRelatedEntries($entry_id) {
+        try {
+            $ids = Symphony::Database()->fetchCol('entry_id', sprintf("
+                SELECT `entry_id`
+                FROM `tbl_entries_data_%d`
+                WHERE `relation_id` = %d
+                AND `entry_id` IS NOT NULL
+            ", $this->get('id'), $entry_id));
+        }
+        catch(Exception $e){
+            return array();
+        }
+
+        return $ids;
+    }
+
+    /**
+     * Find related entries for the current field. Default implementation uses
+     * column names `entry_id` and `relation_id` as with the Select Box Link
+     * 
+     * @since Symphony 2.4.1
+     * 
+     * @param  integer $field_id
+     * @param  integer $entry_id
+     * @return array
+     */
+    public function findParentRelatedEntries($field_id, $entry_id) {
+        try {
+            $ids = Symphony::Database()->fetchCol('relation_id', sprintf("
+                SELECT `relation_id`
+                FROM `tbl_entries_data_%d`
+                WHERE `entry_id` = %d
+                AND `relation_id` IS NOT NULL
+            ", $field_id, $entry_id));
+        }
+        catch(Exception $e){
+            return array();
+        }
+
+        return $ids;
+    }
 }


### PR DESCRIPTION
This as also been discussed in #2085

This proposed change make the fields reponsible for
finding relations. This change takes methods that were
in content.publish.php and moves them to the Field class,
preserving all compatibility.

Reponsability is put in the right container and
Field implementors will now be able to defines their own mecanism
in order to create relationships.

The _right_ way to solve this would be via composition of a class that would handle the two methods. But since Field is already a big monolitic class, this is the way to do, IMHO.
