### PR TITLE
replaced FollowSymlinks with SymLinksIfOwnerMatch

### DIFF
--- a/install/includes/htaccess.txt
+++ b/install/includes/htaccess.txt
@@ -1,5 +1,5 @@
 ### Symphony 2.3.x ###
-Options +FollowSymlinks -Indexes
+Options +SymLinksIfOwnerMatch -Indexes
 
 <IfModule !mod_rewrite.c>
 


### PR DESCRIPTION
For security reasons, followsymlinks is disabled on some (shared) servers and leads to an Error 500. Using SymLinksIfOwnerMatches fixes that issue.
