### PR TITLE
Added http-host frontend param

### DIFF
--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -372,6 +372,7 @@ class FrontendPage extends XSLTPage
             'page-title' => $page['title'],
             'root' => URL,
             'workspace' => URL . '/workspace',
+            'http-host' => HTTP_HOST,
             'root-page' => ($root_page ? $root_page : $page['handle']),
             'current-page' => $page['handle'],
             'current-page-id' => $page['id'],


### PR DESCRIPTION
This change add a ~~'current-domain'~~ 'http-host' parameter in the /data/params list of values.

The ~~'current-domain'~~ 'http-host' value is set to be the value of the ~~DOMAIN~~ HTTP_HOST constant.

I was tired of having a DS for that or use crazy xsl parsing.
