### PR TITLE
Fixes #2139. Caused by setValue which is really appendValue

### DIFF
--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -921,8 +921,8 @@ class FrontendPage extends XSLTPage
                 if ($xml instanceof XMLElement) {
                     $wrapper->appendChild($xml);
                 } else {
-                    $wrapper->setValue(
-                        $wrapper->getValue() . PHP_EOL . '    ' . trim($xml)
+                    $wrapper->appendChild(
+                        '    ' . trim($xml) . PHP_EOL
                     );
                 }
             }


### PR DESCRIPTION
The setValue function appends, it does not overwrite. Used append for clarity
