### PR TITLE
Fix deleting entry data when editing an entry.

### DIFF
--- a/symphony/lib/toolkit/class.entrymanager.php
+++ b/symphony/lib/toolkit/class.entrymanager.php
@@ -177,8 +177,8 @@ class EntryManager
             }
 
             try {
-                Symphony::Database()->delete('tbl_entries_data_' . $field_id, sprintf(" `
-                    entry_id` = %d", $entry->get('id')
+                Symphony::Database()->delete('tbl_entries_data_' . $field_id, sprintf("
+                    `entry_id` = %d", $entry->get('id')
                 ));
             } catch (Exception $e) {
                 // Discard?


### PR DESCRIPTION
Fixing a typo which completely breaks editing of entries, introduced in https://github.com/symphonycms/symphony-2/commit/7b74a6e68c89d92c0f7e37daaae821cbe89c3816
