### PR TITLE
Remove Pragma HTTP response header

### DIFF
--- a/install/lib/class.installerpage.php
+++ b/install/lib/class.installerpage.php
@@ -30,7 +30,6 @@
 			$this->addHeaderToPage('Cache-Control', 'no-cache, must-revalidate, max-age=0');
 			$this->addHeaderToPage('Expires', 'Mon, 12 Dec 1982 06:14:00 GMT');
 			$this->addHeaderToPage('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT');
-			$this->addHeaderToPage('Pragma', 'no-cache');
 
 			$this->setTitle($this->_page_title);
 			$this->addElementToHead(new XMLElement('meta', NULL, array('charset' => 'UTF-8')), 1);

--- a/symphony/lib/boot/func.utilities.php
+++ b/symphony/lib/boot/func.utilities.php
@@ -31,7 +31,6 @@ function redirect ($url)
     header('Expires: Mon, 12 Dec 1982 06:00:00 GMT');
     header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
     header('Cache-Control: no-cache, must-revalidate, max-age=0');
-    header('Pragma: no-cache');
     header("Location: $url");
 
     exit;

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -429,7 +429,6 @@ Class AdministrationPage extends HTMLPage
         $this->addHeaderToPage('Cache-Control', 'no-cache, must-revalidate, max-age=0');
         $this->addHeaderToPage('Expires', 'Mon, 12 Dec 1982 06:14:00 GMT');
         $this->addHeaderToPage('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT');
-        $this->addHeaderToPage('Pragma', 'no-cache');
 
         // If not set by another extension, lock down the backend
         if (!array_key_exists('x-frame-options', $this->headers())) {

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -169,7 +169,6 @@ class FrontendPage extends XSLTPage
         $this->addHeaderToPage('Cache-Control', 'no-cache, must-revalidate, max-age=0');
         $this->addHeaderToPage('Expires', 'Mon, 12 Dec 1982 06:14:00 GMT');
         $this->addHeaderToPage('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT');
-        $this->addHeaderToPage('Pragma', 'no-cache');
 
         if ($this->is_logged_in) {
             /**


### PR DESCRIPTION
The Pragma header is a request header, not a response header.

> When the no-cache directive is present in a request message, an application SHOULD forward the request toward the origin server even if it has a cached copy of what is being requested. [...] Note: because the meaning of "Pragma: no-cache as a response header field is not actually specified, it does not provide a reliable replacement for "Cache-Control: no-cache" in a response”

http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html

> Many people believe that assigning a Pragma: no-cache HTTP header to a representation will make it uncacheable. This is not necessarily true; the HTTP specification does not set any guidelines for Pragma response headers; instead, Pragma request headers (the headers that a browser sends to a server) are discussed. Although a few caches may honor this header, the majority won’t, and it won’t have any effect. Use the headers below instead.”

https://www.mnot.net/cache_docs/#PRAGMA

The Cache-Control header already does what we want.

Any weird old Internet Explorer issues related to the Pragma header not being added to HTTP responses should have ceased to be of concern to Symphony long ago.