### PR TITLE
Fixed accidental output

### DIFF
--- a/install/lib/class.installerpage.php
+++ b/install/lib/class.installerpage.php
@@ -1,4 +1,4 @@
-L10<?php
+<?php
 
 	/**
 	 * @package content


### PR DESCRIPTION
There were some characters before the opening php tag in `../install/lib/class.installerpage.php`, which lead to a _Cannot modify header information_-warning when trying to run the updater for _2.5.2-beta.1_.
