### PR TITLE
Remove superfluous parameter, fixes #2216

### DIFF
--- a/symphony/lib/toolkit/class.smtp.php
+++ b/symphony/lib/toolkit/class.smtp.php
@@ -134,7 +134,7 @@ class SMTP
      * @throws Exception
      * @return boolean
      */
-    public function sendMail($from, $to, $subject, $message)
+    public function sendMail($from, $to, $message)
     {
         $this->_connect($this->_host, $this->_port);
         $this->mail($from);

--- a/symphony/lib/toolkit/email-gateways/email.smtp.php
+++ b/symphony/lib/toolkit/email-gateways/email.smtp.php
@@ -135,7 +135,7 @@ class SMTPGateway extends EmailGateway
             }
 
             // Send the email command. If the envelope from variable is set, use that for the MAIL command. This improves bounce handling.
-            $this->_SMTP->sendMail(is_null($this->_envelope_from)?$this->_sender_email_address:$this->_envelope_from, $this->_recipients, $this->_subject, $this->_body);
+            $this->_SMTP->sendMail(is_null($this->_envelope_from)?$this->_sender_email_address:$this->_envelope_from, $this->_recipients, $this->_body);
 
             if ($this->_keepalive == false) {
                 $this->closeConnection();


### PR DESCRIPTION
This cleans up the low-level sendmail function (as proposed by scrutinizer).
