### PR TITLE
Introducing `AdminPagePreBuild` delegate

### DIFF
--- a/symphony/lib/core/class.administration.php
+++ b/symphony/lib/core/class.administration.php
@@ -455,6 +455,7 @@ class Administration extends Symphony
      * AdminPagePostGenerate. This function runs the Profiler for the page build
      * process.
      *
+     * @uses AdminPagePreBuild
      * @uses AdminPagePreGenerate
      * @uses AdminPagePostGenerate
      * @see core.Symphony#__buildPage()
@@ -470,6 +471,19 @@ class Administration extends Symphony
     public function display($page)
     {
         Symphony::Profiler()->sample('Page build process started');
+
+        /**
+         * Immediately before building the admin page. Provided with the page parameter
+         * @delegate AdminPagePreBuild
+         * @since Symphony 2.6.0
+         * @param string $context
+         *  '/backend/'
+         * @param string $page
+         *  The result of getCurrentPage, which returns the $_GET['symphony-page']
+         *  variable.
+         */
+        Symphony::ExtensionManager()->notifyMembers('AdminPagePreBuild', '/backend/', array('page' => $page));
+
         $this->__buildPage($page);
 
         // Add XSRF token to form's in the backend


### PR DESCRIPTION
This delegate is needed in some cases in order for extensions to do things before the content pages (JSON/XML/...) are instantiated. Using `AdminPagePreGenerate` was not working in some cases because the `view()` method (where most of the code for content page goes) is called by the `build()` method called in `__buildPage()`.

I've marked it as @since 2.6.0 but please tell me to change it if that's not ok. (Is there a 2.5.3 planned?)
