### PR TITLE
Change autocomplete value to new-password

### DIFF
--- a/symphony/lib/toolkit/email-gateways/email.smtp.php
+++ b/symphony/lib/toolkit/email-gateways/email.smtp.php
@@ -396,7 +396,7 @@ class SMTPGateway extends EmailGateway
 
         $label = Widget::Label(__('Password'));
         $label->setAttribute('class', 'column');
-        $label->appendChild(Widget::Input('settings[email_smtp][password]', $this->_pass, 'password', array('autocomplete' => 'off')));
+        $label->appendChild(Widget::Input('settings[email_smtp][password]', $this->_pass, 'password', array('autocomplete' => 'new-password')));
         $div->appendChild($label);
         $group->appendChild($div);
 


### PR DESCRIPTION
This was a breaking change in Chrome M34 that has been fixed in M37: The password manager would completely ignore the autocomplete="off" directive and would still fill up the first input[type=password] it could find.

This was making me nervous since I spotted my password getting saved in plain text in the config file.

The only was to fix (without any hacks) is to use the new value "new-password" (See https://code.google.com/p/chromium/issues/detail?id=370363#c8 and http://lists.whatwg.org/htdig.cgi/whatwg-whatwg.org/2014-March/253895.html)

I've only changed the password field and left the username field untouched.

I've tested it in Chrome and Firefox (both do well).

This would need testing in Safari.