### PR TITLE
Use simpler directory path

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,7 +1,7 @@
 <?php
 
 	// Find out where we are:
-	define('DOCROOT', rtrim(dirname(__FILE__), '\\/'));
+	define('DOCROOT', __DIR__);
 
 	// Include the boot script:
 	include DOCROOT . '/symphony/lib/boot/bundle.php';


### PR DESCRIPTION
Since Symphony requires PHP 5.3+ support `__DIR__` will always be available, and will never end with a slash.
