### PR TITLE
Simplify PHP version check

### DIFF
--- a/symphony/lib/boot/bundle.php
+++ b/symphony/lib/boot/bundle.php
@@ -9,11 +9,7 @@
     require_once CORE . '/class.symphony.php';
 
     // Set appropriate error reporting:
-    error_reporting(
-        PHP_VERSION_ID >= 50300
-            ? E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT
-            : E_ALL & ~E_NOTICE
-    );
+    error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
 
     // Turn off old-style magic:
     ini_set('magic_quotes_runtime', false);


### PR DESCRIPTION
Symphony requires PHP 5.3+ so we can simplify this.

On another note, why are `E_DEPRECATED` and `E_STRICT` being turned off? These levels alert for things that will almost certainly be guaranteed to be changed or removed in the future.

Also, sorry for the newline diff; the github editor added it.
