### PR TITLE
Fixed issue where empty query is attached to publish URLs

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -1747,7 +1747,7 @@ class contentPublish extends AdministrationPage
      */
     public function getPrepopulateString()
     {
-        $prepopulate_querystring = '?';
+        $prepopulate_querystring = '';
 
         if (isset($_REQUEST['prepopulate'])) {
             foreach ($_REQUEST['prepopulate'] as $field_id => $value) {
@@ -1762,7 +1762,7 @@ class contentPublish extends AdministrationPage
         // $_GET['June'] = ''
         $prepopulate_querystring = preg_replace("/&amp;$/", '', $prepopulate_querystring);
 
-        return $prepopulate_querystring;
+        return $prepopulate_querystring ? '?' . $prepopulate_querystring : null;
     }
 
     /**
@@ -1774,7 +1774,7 @@ class contentPublish extends AdministrationPage
      */
     public function getFilterString()
     {
-        $filter_querystring = '?';
+        $filter_querystring = '';
 
         if (isset($_REQUEST['prepopulate'])) {
             foreach ($_REQUEST['prepopulate'] as $field_id => $value) {
@@ -1790,6 +1790,6 @@ class contentPublish extends AdministrationPage
         // $_GET['June'] = ''
         $filter_querystring = preg_replace("/&amp;$/", '', $filter_querystring);
 
-        return $filter_querystring;
+        return $filter_querystring ? '?' . $filter_querystring : null;
     }
 }


### PR DESCRIPTION
Please review, not sure if this has any effect on other functionality.

Also, the entire filtering looks a bit weird to me, with all the `rawurldecode` (shouldn't that be `rawurlencode` ?) and `&amp;` replacing.
