### PR TITLE
Template path was hardcoded

### DIFF
--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -538,7 +538,7 @@ class FrontendPage extends XSLTPage
         $this->setXML($xml);
         $xsl = '<?xml version="1.0" encoding="UTF-8"?>
         <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-            <xsl:import href="./workspace/pages/' . basename($page['filelocation']).'"/>
+            <xsl:import href="' . PAGES . '/' . basename($page['filelocation']).'"/>
         </xsl:stylesheet>';
 
         $this->setXSL($xsl, false);


### PR DESCRIPTION
Symphony allows for changing the template path via the `PAGES` constant, but the path was still hardcoded for XSL imports.

I was wondering why this is implemented as an empty template importing the actual template instead of using the actual template directly, so here's a little background...

First XSL import is always relative to the executing script. In our case this is `index.php`, so our imports would be relative to the `DOCROOT`. Importing the page template itself changes the context for further imports, so we can import relative to the page template instead of the `DOCROOT` in our templates.
