### PR TITLE
Do not allow mixture of forward and backslashes in install path match

### DIFF
--- a/symphony/lib/boot/bundle.php
+++ b/symphony/lib/boot/bundle.php
@@ -13,7 +13,7 @@
     // Redirect to installer if it exists
     if (!file_exists(CONFIG))
     {
-        $bInsideInstaller = (bool)preg_match('%(/|\\\\)install(/|\\\\)index.php$%', $_SERVER['SCRIPT_FILENAME']);
+        $bInsideInstaller = (bool)preg_match('/(\/|\\\\)install\1index\.php$/', $_SERVER['SCRIPT_FILENAME']);
 
         if (!$bInsideInstaller && Symphony::isInstallerAvailable()) {
             header(sprintf('Location: %s/install/', URL));


### PR DESCRIPTION
If this idea is correct. Just an idea review.

Also, I was not sure about the `\\\\` pattern part, in which environments does it match, and if its ok also like `\\install\\index.php` . If not, a `\\{1,2}` pattern would be fine I think. Well, initially I was thinking about to use only a `\\`, but this syntax was throwing errors in my local tests (I don't understand why), while on online testers it was fine.