### PR TITLE
Allow email attachment mime type definition

### DIFF
--- a/symphony/lib/toolkit/class.emailgateway.php
+++ b/symphony/lib/toolkit/class.emailgateway.php
@@ -318,6 +318,7 @@ abstract Class EmailGateway
      *      'file' => 'http://example.com/foo.txt',
      *      'filename' => 'bar.txt',
      *      'charset' => 'UTF-8',
+     *      'mime-type' => 'text/csv',
      *   ));
      *   ````
      */
@@ -605,7 +606,7 @@ abstract Class EmailGateway
 
             if ($file_content !== false && !empty($file_content)) {
                 $output .= $this->boundaryDelimiterLine('multipart/mixed')
-                     . $this->contentInfoString(null, $file['file'], $file['filename'], $file['charset'])
+                     . $this->contentInfoString($file['mime-type'], $file['file'], $file['filename'], $file['charset'])
                      . EmailHelper::base64ContentTransferEncode($file_content);
             } else {
                 if (!$tmp_file === false) {
@@ -716,9 +717,14 @@ abstract Class EmailGateway
         } else {
             $charset = '';
         }
+        // if the mime type is not set, try to obtain using the getMimeType
+        if (empty($type)){
+            //assume that the attachment mimetime is appended
+            $type = General::getMimeType($file);
+        } 
         // Return binary description
         return array(
-            'Content-Type'              => General::getMimeType($file).';'.$charset.' name="'.$filename.'"',
+            'Content-Type'              => $type.';'.$charset.' name="'.$filename.'"',
             'Content-Transfer-Encoding' => 'base64',
             'Content-Disposition'       => 'attachment; filename="' .$filename .'"',
         );


### PR DESCRIPTION
Update email gateway to allow the attachment mime type to be pre defined.

The php `finfo_file` is not always accurate, and is at times unable to determine csv types, and similar text types, giving them plain text types. For remote files such as those generated using [Content Type Mappings](http://symphonyextensions.com/extensions/content_type_mappings/) there is also no extension. The only way to properly attach these files is by allowing the developer to set a mime type attribute.

PS. before merging kindly confirm that it does not have any adverse effect on anything else, I don't think so as the other pre-defined mime types should trigger the description.