### PR TITLE
Fixes Issue 2312

### DIFF
--- a/install/lib/class.installerpage.php
+++ b/install/lib/class.installerpage.php
@@ -293,6 +293,22 @@
 			$options = DateTimeObj::getTimeFormatsSelectOptions($fields['region']['time_format']);
 			$Fieldset->appendChild(Widget::Label(__('Time Format'), Widget::Select('fields[region][time_format]', $options)));
 
+			// Week offset
+			$options = array();
+			$weekdays = array(
+				__('Sunday'),
+				__('Monday'),
+				__('Tuesday'),
+				__('Wednesday'),
+				__('Thursday'),
+				__('Friday'),
+				__('Saturday'),
+			);
+			foreach ($weekdays as $wday => $option) {
+				$options[] = array($wday, false, $option);
+			}
+			$Fieldset->appendChild(Widget::Label(__('First day of the week'), Widget::Select('fields[region][weekoffset]', $options)));
+
 			$Environment->appendChild($Fieldset);
 			$this->Form->appendChild($Environment);
 

--- a/install/migrations/2.6.0.php
+++ b/install/migrations/2.6.0.php
@@ -38,6 +38,11 @@
 			}
 			catch (Exception $ex) {}
 
+			if(version_compare(self::$existing_version, self::getVersion(), '<=')) {
+				// [#] Add weekoffset to configuration
+				Symphony::Configuration()->set('weekoffset', 0, 'region');
+			}
+
 			// Update the version information
 			return parent::upgrade();
 		}

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -380,6 +380,7 @@ Class AdministrationPage extends HTMLPage
                 'id'       => Symphony::Author()->get('id')
             ),
             'date-formats' => DateTimeObj::getDateFormatMappings(),
+            'weekoffset' => Symphony::Configuration()->get('weekoffset', 'region'),
 
             'env' => array_merge(
 


### PR DESCRIPTION
Implementing the `weekoffset` config value into the installer UI and migration script as per #2312.

0 - Sunday through 6 - Saturday

If you have a better way to get the names of the weekdays then this simple array please tell me.

Every commit is atomic and should be easy to diff.