### PR TITLE
Fixing array syntax for PHP 5.3

### DIFF
--- a/symphony/lib/core/class.administration.php
+++ b/symphony/lib/core/class.administration.php
@@ -192,7 +192,7 @@ class Administration extends Symphony
                 $this->Page = new contentLogin;
 
                 // Include the query string for the login, RE: #2324
-                if ($queryString = $this->Page->__buildQueryString(['symphony-page', 'mode'], FILTER_SANITIZE_STRING)) {
+                if ($queryString = $this->Page->__buildQueryString(array('symphony-page', 'mode'), FILTER_SANITIZE_STRING)) {
                     $page .= '?' . $queryString;
                 }
                 $this->Page->build(array('redirect' => $page));


### PR DESCRIPTION
This bug was introduce in 4d18be1ab1b3af0e91ce694210bae81c8ec03478 and uses a PHP 5.4+ compatible only syntax.

This reverts to the old array() syntax.

//cc @michael-e 