### PR TITLE
A small fix for the tag list prepareImportValue

### DIFF
--- a/symphony/lib/toolkit/fields/field.taglist.php
+++ b/symphony/lib/toolkit/fields/field.taglist.php
@@ -404,12 +404,12 @@ class FieldTagList extends Field implements ExportableField, ImportableField
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if (!is_array($data)) {
-            $data = array($data);
+        if (is_array($data)) {
+            $data = implode(', ', $data);
         }
 
         if ($mode === $modes->getValue) {
-            return implode(', ', $data);
+            return $data;
         } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }


### PR DESCRIPTION
The tag list field was preparing a value for import as an array, then passing it to preg_split which expects a string.

Also, I get the feeling nobody really understands this import/export stuff and that I'm the only one using it. Anyone want to do a Google hangout to talk about it?