### PR TITLE
Set a proper HTTP Status on XSLT error

### DIFF
--- a/symphony/lib/toolkit/class.xsltpage.php
+++ b/symphony/lib/toolkit/class.xsltpage.php
@@ -167,6 +167,7 @@ class XSLTPage extends Page
         $result = $this->Proc->process($this->_xml, $this->_xsl, $this->_param, $this->_registered_php_functions);
 
         if ($this->Proc->isErrors()) {
+            $this->setHttpStatus(Page::HTTP_STATUS_ERROR);
             return false;
         }
 


### PR DESCRIPTION
This is required for multiple reasons, but the best two I can think of are:

1. Prevent Google from indexing the error message
2. Ping tools will pick up the error.

@michael-e What do you think about this?

@brendo I would really like it if this could make it in 2.6.0. Thanks!