### PR TITLE
Fixed issue where intval function returned invalid values

### DIFF
--- a/symphony/lib/toolkit/class.general.php
+++ b/symphony/lib/toolkit/class.general.php
@@ -1621,9 +1621,11 @@ class General
      */
     public static function intval($value)
     {
-        if (is_numeric($value) && preg_match('/[0-9]+/i', $value) === 1) {
+        if (is_numeric($value) && preg_match('/^[0-9]+$/i', $value) === 1) {
+
             return intval($value);
         }
+
         return -1;
     }
 }


### PR DESCRIPTION
Not entirely sure about this, but as mentioned [here][1], the `intval` function didn't quite work as described. Please have a look at this.

[1]: https://github.com/symphonycms/symphony-2/issues/2383#issuecomment-84202035