### PR TITLE
filter string to show string value not id

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -1790,6 +1790,15 @@ class contentPublish extends AdministrationPage
         if (isset($_REQUEST['prepopulate'])) {
             foreach ($_REQUEST['prepopulate'] as $field_id => $value) {
                 $handle = FieldManager::fetchHandleFromID($field_id);
+                
+                //This is in case it is an Association so the filter reads the text value instead of the ID
+                $field = FieldManager::fetch($field_id);
+                if ($field instanceof Field) {
+                    if (method_exists($field, 'fetchValueFromID')) {
+                        $value = $field->fetchValueFromID($value);
+                    }
+                }
+
                 $filter_querystring .= sprintf("filter[%s]=%s&", $handle, rawurldecode($value));
             }
             $filter_querystring = trim($filter_querystring, '&');


### PR DESCRIPTION
This is the inverse to the use of `fetchIDFromValue` when creating a filter string, it does not make sense to show the entry ID when the filtering UI is showing the value. So the ID should be converted back to a string value where applicable.