### PR TITLE
Support for internationalized domain names

### DIFF
--- a/symphony/lib/boot/defines.php
+++ b/symphony/lib/boot/defines.php
@@ -244,7 +244,8 @@ define_safe('__SECURE__',
  * The current domain name.
  * @var string
  */
-define_safe('DOMAIN', rtrim(rtrim($_SERVER['HTTP_HOST'], '\\/') . dirname($_SERVER['PHP_SELF']), '\\/'));
+define_safe('DOMAIN', HTTP_HOST . rtrim(dirname($_SERVER['PHP_SELF']), '\/'));
+
 
 /**
  * The base URL of this Symphony install, minus the symphony path.

--- a/symphony/lib/boot/defines.php
+++ b/symphony/lib/boot/defines.php
@@ -214,7 +214,7 @@ define_safe('HTTPS', getenv('HTTPS'));
  * Returns the current host, ie. google.com
  * @var string
  */
-define_safe('HTTP_HOST', getenv('HTTP_HOST'));
+define_safe('HTTP_HOST', function_exists('idn_to_utf8') ? idn_to_utf8(getenv('HTTP_HOST')) : getenv('HTTP_HOST'));
 
 /**
  * Returns the IP address of the machine that is viewing the current page.


### PR DESCRIPTION
Support for internationalized domain names was [introduced in 2.4][1], but broke again with the `index.php` reshuffling in [2.5.0][2].

Here's a fix to bring it back.

[1]: http://www.getsymphony.com/download/releases/version/2.4/
[2]: http://www.getsymphony.com/download/releases/version/2.5.0/