### PR TITLE
Improved redirect function

### DIFF
--- a/symphony/lib/boot/func.utilities.php
+++ b/symphony/lib/boot/func.utilities.php
@@ -8,7 +8,7 @@
  * Redirects the browser to a specified location. Safer than using a
  * direct header() call
  *
- *  @param string $url
+ *  @param string $location
  *  @param string $status (optional)
  */
 function redirect($location, $status = '302 Found')

--- a/symphony/lib/boot/func.utilities.php
+++ b/symphony/lib/boot/func.utilities.php
@@ -23,7 +23,8 @@ function redirect($location, $status = '302 Found')
 
     // convert idn back to ascii for redirect
     if (function_exists('idn_to_ascii')) {
-        $location = str_replace(HTTP_HOST, idn_to_ascii(HTTP_HOST), $location);
+        $host     = parse_url($location, PHP_URL_HOST);
+        $location = str_replace($host, idn_to_ascii($host), $location);
     }
 
     header('Status: '   . $status);

--- a/symphony/lib/boot/func.utilities.php
+++ b/symphony/lib/boot/func.utilities.php
@@ -13,22 +13,16 @@
  */
 function redirect($location, $status = '302 Found')
 {
+    // throw exception if headers already sent
     if (headers_sent($filename, $line)) {
-
-        // throw exception if headers already sent
-
         throw new SymphonyErrorPage(sprintf(
-
             'Cannot redirect to <a href="%s">%s</a>. Output has already started in %s on line %s.',
-
             $location, $location, $filename, $line
         ));
     }
 
+    // convert idn back to ascii for redirect
     if (function_exists('idn_to_ascii')) {
-
-        // convert idn back to ascii for redirect
-
         $location = str_replace(HTTP_HOST, idn_to_ascii(HTTP_HOST), $location);
     }
 

--- a/symphony/lib/boot/func.utilities.php
+++ b/symphony/lib/boot/func.utilities.php
@@ -9,31 +9,31 @@
  * direct header() call
  *
  *  @param string $url
+ *  @param string $status (optional)
  */
-function redirect ($url)
+function redirect($location, $status = '302 Found')
 {
-    // Just make sure.
-    $url = str_replace('Location:', null, $url);
-
     if (headers_sent($filename, $line)) {
-        echo "<h1>Error: Cannot redirect to <a href=\"$url\">$url</a></h1><p>Output has already started in $filename on line $line</p>";
-        exit;
-    }
 
-    // convert idn back to ascii for redirect
+        // throw exception if headers already sent
+
+        throw new SymphonyErrorPage(sprintf(
+
+            'Cannot redirect to <a href="%s">%s</a>. Output has already started in %s on line %s.',
+
+            $location, $location, $filename, $line
+        ));
+    }
 
     if (function_exists('idn_to_ascii')) {
-        $root = parse_url(URL);
-        $host = $root['host'];
-        $url  = str_replace($host, idn_to_ascii($host), $url);
+
+        // convert idn back to ascii for redirect
+
+        $location = str_replace(HTTP_HOST, idn_to_ascii(HTTP_HOST), $location);
     }
 
-    header('Status: 302 Found');
-    header('Expires: Mon, 12 Dec 1982 06:00:00 GMT');
-    header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
-    header('Cache-Control: no-cache, must-revalidate, max-age=0');
-    header('Pragma: no-cache');
-    header("Location: $url");
+    header('Status: '   . $status);
+    header('Location: ' . $location);
 
     exit;
 }


### PR DESCRIPTION
- Use `SymphonyErrorPage ` exception for nicer error message if headers already sent.
- Simplified idn to ascii conversion.
- Introduced optional `$status` parameter, so developers can use other status codes like [`303 See Other`][1] or `307 Temporary Redirect`.
- Removed caching headers. For redirects, the [status code already indicates the appropriate caching behavior][2].

[1]: http://en.wikipedia.org/wiki/HTTP_303
[2]: https://tools.ietf.org/html/rfc2616#section-10.3