### PR TITLE
Added XHTML page type and content type

### DIFF
--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -219,6 +219,9 @@ class FrontendPage extends XSLTPage
                 else if(General::in_iarray('JSON', $this->_pageData['type'])) {
                     $this->addHeaderToPage('Content-Type', 'application/json; charset=utf-8');
                 }
+                else if(General::in_iarray('XHTML', $this->_pageData['type'])) {
+                    $this->addHeaderToPage('Content-Type', 'application/xhtml+xml; charset=utf-8');
+                }
                 else{
                     $this->addHeaderToPage('Content-Type', 'text/html; charset=utf-8');
                 }

--- a/symphony/lib/toolkit/class.pagemanager.php
+++ b/symphony/lib/toolkit/class.pagemanager.php
@@ -647,7 +647,7 @@ class PageManager
      */
     public static function fetchAvailablePageTypes()
     {
-        $system_types = array('index', 'XML', 'JSON', 'admin', '404', '403');
+        $system_types = array('index', 'XML', 'JSON', 'XHTML', 'admin', '404', '403');
 
         $types = PageManager::fetchPageTypes();
 


### PR DESCRIPTION
With [IE8 slowly on it's way out][2], is there any reason not to support and encourage proper [XHTML5][1]? Especially since XSLT forces us to write well-formed XML anyway.

In a [perfect world][3], this would be a pull request for a `2.7.x` release, but I guess we [aren't really that strict anyway][4]?

[1]: http://www.xmlplease.com/xhtml/xhtml5polyglot/
[2]: http://caniuse.com/#feat=xhtml
[3]: https://github.com/symphonycms/symphony-2/issues/2398#issuecomment-91020048
[4]: https://github.com/symphonycms/symphony-2/issues/2398#issuecomment-95013766