### PR TITLE
Added configurable content types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,27 +1,46 @@
 {
-    "name": "symphonycms/symphony-2",
-    "version": "2.6.1",
-    "description": "Symphony is a PHP & MySQL based CMS that utilises XML and XSLT as its core technologies.",
-    "homepage": "http://www.getsymphony.com",
-    "license": "MIT",
-    "authors": [
+    "name"        : "symphonycms/symphony-2",
+    "version"     : "2.6.1",
+    "description" : "Symphony is a PHP & MySQL based CMS that utilises XML and XSLT as its core technologies.",
+    "homepage"    : "http://www.getsymphony.com",
+    "license"     : "MIT",
+    "authors"     : [
+
         {
-            "name": "Symphony Team",
-            "email": "team@getsymphony.com"
+            "name"  : "Symphony Team",
+            "email" : "team@getsymphony.com"
         }
     ],
-    "support": {
-      "forum": "http://www.getsymphony.com/discuss/",
-      "issues": "https://github.com/symphonycms/symphony-2/issues",
-      "wiki": "https://github.com/symphonycms/symphony-2/wiki"
+
+    "support" : {
+
+        "forum"  : "http://www.getsymphony.com/discuss/",
+        "issues" : "https://github.com/symphonycms/symphony-2/issues",
+        "wiki"   : "https://github.com/symphonycms/symphony-2/wiki"
     },
-    "minimum-stability": "stable",
-    "autoload": {
-      "classmap": ["symphony/content", "symphony/lib", "symphony/template", "install"],
-      "files": [
-        "symphony/lib/boot/func.utilities.php",
-        "symphony/lib/boot/defines.php",
-        "symphony/lib/toolkit/util.validators.php"
-      ]
+
+    "minimum-stability" : "stable",
+
+    "autoload" : {
+
+        "classmap" : [
+
+            "symphony/content",
+            "symphony/lib",
+            "symphony/template",
+            "install"
+        ],
+
+        "files" : [
+
+            "symphony/lib/boot/func.utilities.php",
+            "symphony/lib/boot/defines.php",
+            "symphony/lib/toolkit/util.validators.php"
+        ]
+    },
+
+    "require" : {
+
+        "aura/accept" : "2.2.*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,79 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "878e6a5827844ab0ef81b652b3f94a4e",
+    "packages": [
+        {
+            "name": "aura/accept",
+            "version": "2.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/auraphp/Aura.Accept.git",
+                "reference": "1c40bc38333a7899b95823a4d85ab758f7c618b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/auraphp/Aura.Accept/zipball/1c40bc38333a7899b95823a4d85ab758f7c618b2",
+                "reference": "1c40bc38333a7899b95823a4d85ab758f7c618b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "aura/di": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "aura": {
+                    "type": "library",
+                    "config": {
+                        "common": "Aura\\Accept\\_Config\\Common"
+                    }
+                },
+                "branch-alias": {
+                    "dev-develop-2": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Aura\\Accept\\": "src/",
+                    "Aura\\Accept\\_Config\\": "config/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aura.Accept Contributors",
+                    "homepage": "https://github.com/auraphp/Aura.Accept/contributors"
+                }
+            ],
+            "description": "Provides content-negotiation tools using Accept* headers.",
+            "homepage": "https://github.com/auraphp/Aura.Accept",
+            "keywords": [
+                "accept",
+                "accept-charset",
+                "accept-encoding",
+                "accept-language",
+                "content negotiation",
+                "content type",
+                "media type"
+            ],
+            "time": "2015-03-27 17:05:44"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -91,4 +91,15 @@
 			'default' => 'database',
 		),
 		########
+
+
+		###### CONTENT TYPES ######
+		'content_types' => array(
+			'html'  => 'text/html; charset=utf-8',
+			'json'  => 'application/json; charset=utf-8',
+			'text'  => 'text/plain; charset=utf-8',
+			'xhtml' => 'application/xhtml+xml; charset=utf-8',
+			'xml'   => 'text/xml; charset=utf-8',
+		),
+		########
 	);

--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -93,13 +93,13 @@
 		########
 
 
-		###### CONTENT TYPES ######
+		###### CONTENT_TYPES ######
 		'content_types' => array(
-			'html'  => 'text/html; charset=utf-8',
-			'json'  => 'application/json; charset=utf-8',
-			'text'  => 'text/plain; charset=utf-8',
-			'xhtml' => 'application/xhtml+xml; charset=utf-8',
-			'xml'   => 'text/xml; charset=utf-8',
+			'html'  => 'text/html',
+			'json'  => 'application/json',
+			'text'  => 'text/plain',
+			'xhtml' => 'application/xhtml+xml',
+			'xml'   => 'text/xml',
 		),
 		########
 	);

--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -97,7 +97,7 @@
 		'content_types' => array(
 			'html'  => 'text/html',
 			'json'  => 'application/json',
-			'text'  => 'text/plain',
+			'txt'   => 'text/plain',
 			'xhtml' => 'application/xhtml+xml',
 			'xml'   => 'text/xml',
 		),

--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -99,7 +99,7 @@
 			'json'  => 'application/json',
 			'txt'   => 'text/plain',
 			'xhtml' => 'application/xhtml+xml',
-			'xml'   => 'text/xml',
+			'xml'   => 'application/xml',
 		),
 		########
 	);

--- a/install/migrations/2.7.0.php
+++ b/install/migrations/2.7.0.php
@@ -1,0 +1,34 @@
+<?php
+
+Class migration_270 extends Migration
+{
+
+    static function getVersion()
+    {
+        return '2.7.0';
+    }
+
+    static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.7.0/';
+    }
+
+    static function upgrade()
+    {
+        // Add content types to configuration
+        Symphony::Configuration()->setArray(array(
+
+            'content_types' => array(
+
+                'html'  => 'text/html; charset=utf-8',
+                'json'  => 'application/json; charset=utf-8',
+                'text'  => 'text/plain; charset=utf-8',
+                'xhtml' => 'application/xhtml+xml; charset=utf-8',
+                'xml'   => 'text/xml; charset=utf-8'
+            )
+        ));
+
+        // Update the version information
+        return parent::upgrade();
+    }
+}

--- a/install/migrations/2.7.0.php
+++ b/install/migrations/2.7.0.php
@@ -20,11 +20,11 @@ Class migration_270 extends Migration
 
             'content_types' => array(
 
-                'html'  => 'text/html; charset=utf-8',
-                'json'  => 'application/json; charset=utf-8',
-                'text'  => 'text/plain; charset=utf-8',
-                'xhtml' => 'application/xhtml+xml; charset=utf-8',
-                'xml'   => 'text/xml; charset=utf-8'
+                'html'  => 'text/html',
+                'json'  => 'application/json',
+                'text'  => 'text/plain',
+                'xhtml' => 'application/xhtml+xml',
+                'xml'   => 'text/xml'
             )
         ));
 

--- a/install/migrations/2.7.0.php
+++ b/install/migrations/2.7.0.php
@@ -24,7 +24,7 @@ Class migration_270 extends Migration
                 'json'  => 'application/json',
                 'txt'   => 'text/plain',
                 'xhtml' => 'application/xhtml+xml',
-                'xml'   => 'text/xml'
+                'xml'   => 'application/xml'
             )
         ));
 

--- a/install/migrations/2.7.0.php
+++ b/install/migrations/2.7.0.php
@@ -22,7 +22,7 @@ Class migration_270 extends Migration
 
                 'html'  => 'text/html',
                 'json'  => 'application/json',
-                'text'  => 'text/plain',
+                'txt'   => 'text/plain',
                 'xhtml' => 'application/xhtml+xml',
                 'xml'   => 'text/xml'
             )

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -216,7 +216,7 @@ class FrontendPage extends XSLTPage
                 $page_types   = $this->_pageData['type'];
                 $content_type = $this->getContentType($page_types);
 
-                $this->addHeaderToPage('Content-Type', $content_type);
+                $this->addHeaderToPage('Content-Type', $content_type . '; charset=utf-8');
 
                 if (in_array('attachment', $page_types)) {
                     $this->addHeaderToPage('Content-Disposition', 'attachment; filename=' . $this->getFilename($content_type));

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -216,8 +216,6 @@ class FrontendPage extends XSLTPage
                 $page_types   = $this->_pageData['type'];
                 $content_type = $this->getContentType($page_types);
 
-                var_dump($content_type); exit;
-
                 $this->addHeaderToPage('Content-Type', $content_type . '; charset=utf-8');
 
                 if (in_array('attachment', $page_types)) {

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -213,20 +213,20 @@ class FrontendPage extends XSLTPage
             ));
 
             if (is_null($devkit)) {
-                if(General::in_iarray('XML', $this->_pageData['type'])) {
-                    $this->addHeaderToPage('Content-Type', 'text/xml; charset=utf-8');
-                }
-                else if(General::in_iarray('JSON', $this->_pageData['type'])) {
-                    $this->addHeaderToPage('Content-Type', 'application/json; charset=utf-8');
-                }
-                else{
-                    $this->addHeaderToPage('Content-Type', 'text/html; charset=utf-8');
+                $page_types   = $this->_pageData['type'];
+                $content_type = $this->getContentType($page_types);
+
+                $this->addHeaderToPage('Content-Type', $content_type);
+
+                if (in_array('attachment', $page_types)) {
+                    $this->addHeaderToPage('Content-Disposition', 'attachment; filename=' . $this->getFilename($content_type));
                 }
 
-                if(in_array('404', $this->_pageData['type'])){
+                if (in_array('404', $page_types)) {
                     $this->setHttpStatus(self::HTTP_STATUS_NOT_FOUND);
                 }
-                else if(in_array('403', $this->_pageData['type'])){
+
+                if (in_array('403', $page_types)) {
                     $this->setHttpStatus(self::HTTP_STATUS_FORBIDDEN);
                 }
             }
@@ -1033,5 +1033,72 @@ class FrontendPage extends XSLTPage
     public static function sanitizeParameter($parameter)
     {
         return XMLElement::stripInvalidXMLCharacters($parameter);
+    }
+
+    /**
+     * Given an array of page types, this function will determine the
+     * appropriate content type for the page based on supported content
+     * types from the configuration file.
+     *
+     * @since Symphony 2.7.0
+     * @param array $page_types
+     *  This pages page types
+     * @return string
+     *  This pages content type
+     */
+    private function getContentType(array $page_types)
+    {
+        $content_types = Symphony::Configuration()->get('content_types');
+        $content_type  = 'text/html; charset=utf-8';
+
+        if (empty($page_types)) {
+            return $content_type;
+        }
+
+        if (empty($content_types)) {
+            return $content_type;
+        }
+
+        foreach ($page_types as $page_type) {
+            $page_type = strtolower($page_type);
+            if (array_key_exists($page_type, $content_types)) {
+                $content_type = $content_types[$page_type];
+            }
+        }
+
+        return $content_type;
+    }
+
+    /**
+     * Given a pages content type, this function will return
+     * a filename for the page based on the pages path and
+     * content type.
+     *
+     * @since Symphony 2.7.0
+     * @param string $content_type
+     *  This pages content type
+     * @return string
+     *  This pages filename
+     */
+    private function getFilename($content_type)
+    {
+        $content_types = Symphony::Configuration()->get('content_types');
+
+        if (empty($content_types)) {
+            return;
+        }
+
+        $file_type = array_search($content_type, $content_types);
+        $file_name = trim(str_replace('/', '_', $this->_param['current-path']), '_');
+
+        if (empty($file_type)) {
+            $file_type = 'html';
+        }
+
+        if (empty($file_name)) {
+            $file_name = $this->_param['current-page'];
+        }
+
+        return $file_name . '.' . $file_type;
     }
 }

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -1060,7 +1060,6 @@ class FrontendPage extends XSLTPage
         }
 
         // get available content types based on page types
-
         $page_types    = array_map('strtolower', $page_types);
         $content_types = array_filter($content_types, function ($key) use ($page_types) {
 
@@ -1069,7 +1068,6 @@ class FrontendPage extends XSLTPage
         }, ARRAY_FILTER_USE_KEY);
 
         // negotiate content type based on accept header
-
         $accept       = new Aura\Accept\AcceptFactory($_SERVER);
         $content_type = $accept->newInstance()->negotiateMedia($content_types)->getValue();
 

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -1051,27 +1051,25 @@ class FrontendPage extends XSLTPage
         $content_types = Symphony::Configuration()->get('content_types');
         $default_type  = 'text/html';
 
-        if (empty($page_types)) {
-            return $default_type;
-        }
-
         if (empty($content_types)) {
             return $default_type;
         }
 
-        // get available content types based on page types
-        $page_types    = array_map('strtolower', $page_types);
-        $content_types = array_filter($content_types, function ($key) use ($page_types) {
+        $page_types = array_map('strtolower', $page_types);
+        $page_types = array_filter($content_types, function ($key) use ($page_types) {
 
             return in_array($key, $page_types);
 
         }, ARRAY_FILTER_USE_KEY);
 
-        // negotiate content type based on accept header
-        $accept       = new Aura\Accept\AcceptFactory($_SERVER);
-        $content_type = $accept->newInstance()->negotiateMedia($content_types)->getValue();
+        if (empty($page_types)) {
+            return $default_type;
+        }
 
-        return $content_type ? $content_type : $default_type;
+        $accept_factory = new Aura\Accept\AcceptFactory($_SERVER);
+        $accept_type    = $accept_factory->newInstance()->negotiateMedia($page_types);
+
+        return $accept_type ? $accept_type->getValue() : $default_type;
     }
 
     /**

--- a/symphony/lib/toolkit/class.pagemanager.php
+++ b/symphony/lib/toolkit/class.pagemanager.php
@@ -636,7 +636,7 @@ class PageManager
 
     /**
      * Returns all the page types that exist in this Symphony install.
-     * There are 6 default system page types, and new types can be added
+     * There are 5 default system page types, and new types can be added
      * by Developers via the Page Editor.
      *
      * @since Symphony 2.3 introduced the JSON type.
@@ -647,11 +647,23 @@ class PageManager
      */
     public static function fetchAvailablePageTypes()
     {
-        $system_types = array('index', 'XML', 'JSON', 'admin', '404', '403');
+        $system_types  = array('index', 'admin', 'attachment', '404', '403');
+        $content_types = Symphony::Configuration()->get('content_types');
+        $custom_types  = PageManager::fetchPageTypes();
 
-        $types = PageManager::fetchPageTypes();
+        if (empty($content_types) && empty($custom_types)) {
+            return $system_types;
+        }
 
-        return (!empty($types) ? General::array_remove_duplicates(array_merge($system_types, $types)) : $system_types);
+        if (!empty($content_types)) {
+           $system_types = array_merge($system_types, array_keys($content_types));
+        }
+
+        if (!empty($custom_types)) {
+            $system_types = array_merge($system_types, $custom_types);
+        }
+
+        return General::array_remove_duplicates($system_types, true);
     }
 
     /**

--- a/vendor/aura/accept/.gitignore
+++ b/vendor/aura/accept/.gitignore
@@ -1,0 +1,4 @@
+/tests/container/vendor
+/tests/container/composer.*
+/composer.lock
+/vendor

--- a/vendor/aura/accept/.scrutinizer.yml
+++ b/vendor/aura/accept/.scrutinizer.yml
@@ -1,0 +1,10 @@
+filter:
+    paths: ["src/*"]
+tools:
+    external_code_coverage: true
+    php_code_coverage: true
+    php_sim: true
+    php_mess_detector: true
+    php_pdepend: true
+    php_analyzer: true
+    php_cpd: true

--- a/vendor/aura/accept/.travis.yml
+++ b/vendor/aura/accept/.travis.yml
@@ -1,0 +1,16 @@
+language: php
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+  - 7
+before_script:
+  - composer self-update
+  - composer install
+script:
+  - phpunit --coverage-clover=coverage.clover
+after_script:
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/vendor/aura/accept/CHANGES.md
+++ b/vendor/aura/accept/CHANGES.md
@@ -1,0 +1,3 @@
+This is a hygiene release to update the documentation and support files.
+This release modifies the testing structure and updates other support files.
+

--- a/vendor/aura/accept/CONTRIBUTING.md
+++ b/vendor/aura/accept/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+We are happy to review any contributions you want to make. When contributing, please follow the rules outlined at <http://auraphp.com/contributing>.
+
+The time between submitting a contribution and its review one may be extensive; do not be discouraged if there is not immediate feedback.
+
+Thanks!

--- a/vendor/aura/accept/LICENSE
+++ b/vendor/aura/accept/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2011-2015, Aura for PHP
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/aura/accept/README.md
+++ b/vendor/aura/accept/README.md
@@ -1,0 +1,224 @@
+# Aura.Accept
+
+Provides content-negotiation tools using `Accept*` headers.
+
+## Foreword
+
+### Installation
+
+This library requires PHP 5.3 or later; we recommend using the latest available version of PHP as a matter of principle. It has no userland dependencies.
+
+It is installable and autoloadable via Composer as [aura/accept](https://packagist.org/packages/aura/accept).
+
+Alternatively, [download a release](https://github.com/auraphp/Aura.Accept/releases) or clone this repository, then require or include its _autoload.php_ file.
+
+### Quality
+
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/auraphp/Aura.Accept/badges/quality-score.png?b=develop-2)](https://scrutinizer-ci.com/g/auraphp/Aura.Accept/)
+[![Code Coverage](https://scrutinizer-ci.com/g/auraphp/Aura.Accept/badges/coverage.png?b=develop-2)](https://scrutinizer-ci.com/g/auraphp/Aura.Accept/)
+[![Build Status](https://travis-ci.org/auraphp/Aura.Accept.png?branch=develop-2)](https://travis-ci.org/auraphp/Aura.Accept)
+
+To run the unit tests at the command line, issue `composer install` and then `phpunit` at the package root. This requires [Composer](http://getcomposer.org/) to be available as `composer`, and [PHPUnit](http://phpunit.de/manual/) to be available as `phpunit`.
+
+This library attempts to comply with [PSR-1][], [PSR-2][], and [PSR-4][]. If
+you notice compliance oversights, please send a patch via pull request.
+
+[PSR-1]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
+[PSR-2]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
+[PSR-4]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md
+
+### Community
+
+To ask questions, provide feedback, or otherwise communicate with the Aura community, please join our [Google Group](http://groups.google.com/group/auraphp), follow [@auraphp on Twitter](http://twitter.com/auraphp), or chat with us on #auraphp on Freenode.
+
+
+## Getting Started
+
+### Instantiation
+
+First, instantiate a _AcceptFactory_ object, then use it to create an _Accept_
+object.
+
+```php
+<?php
+use Aura\Accept\AcceptFactory;
+
+$accept_factory = new AcceptFactory($_SERVER);
+$accept = $accept_factory->newInstance();
+?>
+```
+
+The _Accept_ object provides convenienence methods to negotiate between
+acceptable (to the client) and available (from the application) charset,
+encoding, language, and media-type values. The methods are:
+
+- `negotiateCharset()`
+- `negotiateEncoding()`
+- `negotiateLanguage()`
+- `negotiateMedia()`
+
+Your application code, knowing what values it has available, should pass an
+array of the available values to the `negotiate*()` method. (The values that are
+acceptable to the client are already indicated by `$_SERVER`).
+
+The result returned from the method will be a `*Value` object describing the
+highest-quality match that was negotiated between the available and acceptable
+values. If there is no negotiable match, the result will be `false`.
+
+> N.b. Accept headers can be kind of complicated. See the
+> [HTTP Header Field Definitions](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html)
+> for more detailed information regarding quality factors, matching rules,
+> and parameters extensions.
+
+
+### Negotiating Media Types
+
+To negotiate a media type (aka a content type), call the `negotiateMedia()`
+method with a list of available media types. The available types should be in
+the order you prefer for delivery, from "most preferred" to "least preferred".
+
+```php
+<?php
+// assume the request indicates these Accept values (XML is best, then CSV,
+// then anything else)
+$_SERVER['HTTP_ACCEPT'] = 'application/xml;q=1.0,text/csv;q=0.5,*;q=0.1';
+
+// create the accept factory
+$accept_factory = new AcceptFactory($_SERVER);
+
+// create the accept object
+$accept = $accept_factory->newInstance();
+
+// assume our application has `application/json` and `text/csv` available
+// as media types, in order of highest-to-lowest preference for delivery
+$available = array(
+    'application/json',
+    'text/csv',
+);
+
+// get the best match between what the request finds acceptable and what we
+// have available; the result in this case is 'text/csv'
+$media = $accept->negotiateMedia($available);
+echo $media->getValue(); // text/csv
+?>
+```
+
+If the requested URL ends in a recognized file extension for a media type,
+the _MediaNegotiator_ object used by _Accept_ will use that file extension
+instead of the explicit `Accept` header value to determine the acceptable media
+type:
+
+```php
+<?php
+// assume the request indicates these Accept values (XML is best, then CSV,
+// then anything else)
+$_SERVER['HTTP_ACCEPT'] = 'application/xml;q=1.0,text/csv;q=0.5,*;q=0.1';
+
+// assume also that the request URI explicitly notes a .json file extension
+$_SERVER['REQUEST_URI'] = '/path/to/entity.json';
+
+// create the accept factory
+$accept_factory = new AcceptFactory($_SERVER);
+
+// factory the accept object
+$accept = $accept_factory->newInstance();
+
+// assume our application has `application/json` and `text/csv` available
+// as media types, in order of highest-to-lowest preference for delivery
+$available = array(
+    'application/json',
+    'text/csv',
+);
+
+// get the best match between what the request finds acceptable and what we
+// have available; the result in this case is 'application/json' because of
+// the file extenstion overriding the Accept header values
+$media = $accept->negotiateMedia($available);
+echo $media->getValue(); // application/json
+?>
+```
+
+(See the _MediaNegotiator_ class file for the list of what file extensions map
+to what media types.)
+
+To create your own mappings, set them into the _AcceptFactory_ object at
+construction time:
+
+```php
+<?php
+$accept_factory = new AcceptFactory($_SERVER, array(
+    '.foo' => 'application/x-foo-content-type',
+));
+
+$accept = $accept_factory->newInstance();
+?>
+```
+
+If the acceptable values indicate additional parameters, you can match on those
+as well:
+
+```php
+<?php
+// assume the request indicates these Accept values (XML is best, then CSV,
+// then anything else)
+$_SERVER['HTTP_ACCEPT'] = 'text/html;level=1;q=0.5,text/html;level=3';
+
+// create the accept factory
+$accept_factory = new AcceptFactory($_SERVER);
+
+// factory the accept object
+$accept = $accept_factory->newInstance();
+
+// assume our application has these available as media types,
+// in order of highest-to-lowest preference for delivery
+$available = array(
+    'text/html;level=1',
+    'text/html;level=2',
+);
+
+// get the best match between what the request finds acceptable and what we
+// have available; the result in this case is 'text/html;level=1'
+$media = $accept->negotiateMedia($available);
+echo $media->getValue(); // text/html
+var_dump($media->getParameters()); // array('level' => '1')
+?>
+```
+
+> N.b. Parameters in the acceptable values that are not present in the
+> available values will not be used for matching.
+
+
+### Negotiating Other Values
+
+The other negotiation methods work much the same way, although they are less
+complex than media-type negotiation.
+
+```php
+<?php
+// assume the request indicates these Accept-* values
+$_SERVER['HTTP_ACCEPT_CHARSET'] = 'iso-8859-5, unicode-1-1;q=0.8';
+$_SERVER['HTTP_ACCEPT_ENCODING'] = 'compress;q=0.5, gzip;q=1.0';
+$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US, en-GB, en, *';
+
+// create the accept factory
+$accept_factory = new AcceptFactory($_SERVER);
+
+// factory the accept object
+$accept = $accept_factory->newInstance();
+
+// charset negotiation
+$available_charsets = array('iso-1234', 'unicode-1-1');
+$charset = $accept->negotiateCharset($available_charsets);
+echo $charset->getValue('unicode-1-1');
+
+// encoding negotiation
+$available_encodings = array();
+$encoding = $accept->negotiateEncoding($available_encodings);
+var_dump($encoding); // false
+
+// language negotiation
+$available_languages = array('pt-BR', 'fr-FR');
+$language = $accept->negotiateLanguage($available_languages);
+echo $language->getValue(); // pt-BR
+?>
+```

--- a/vendor/aura/accept/autoload.php
+++ b/vendor/aura/accept/autoload.php
@@ -1,0 +1,45 @@
+<?php
+spl_autoload_register(function ($class) {
+
+    // the package namespace
+    $ns = 'Aura\Accept';
+
+    // what prefixes should be recognized?
+    $prefixes = array(
+        "{$ns}\_Config\\" => array(
+            __DIR__ . '/config',
+            __DIR__ . '/tests/container/src',
+        ),
+        "{$ns}\\" => array(
+            __DIR__ . '/src',
+            __DIR__ . '/tests/unit/src',
+        ),
+    );
+
+    // go through the prefixes
+    foreach ($prefixes as $prefix => $dirs) {
+
+        // does the requested class match the namespace prefix?
+        $prefix_len = strlen($prefix);
+        if (substr($class, 0, $prefix_len) !== $prefix) {
+            continue;
+        }
+
+        // strip the prefix off the class
+        $class = substr($class, $prefix_len);
+
+        // a partial filename
+        $part = str_replace('\\', DIRECTORY_SEPARATOR, $class) . '.php';
+
+        // go through the directories to find classes
+        foreach ($dirs as $dir) {
+            $dir = str_replace('/', DIRECTORY_SEPARATOR, $dir);
+            $file = $dir . DIRECTORY_SEPARATOR . $part;
+            if (is_readable($file)) {
+                require $file;
+                return;
+            }
+        }
+    }
+
+});

--- a/vendor/aura/accept/composer.json
+++ b/vendor/aura/accept/composer.json
@@ -1,0 +1,51 @@
+{
+    "name": "aura/accept",
+    "type": "library",
+    "description": "Provides content-negotiation tools using Accept* headers.",
+    "keywords": [
+        "accept",
+        "content negotiation",
+        "content type",
+        "media type",
+        "accept-charset",
+        "accept-encoding",
+        "accept-language"
+    ],
+    "homepage": "https://github.com/auraphp/Aura.Accept",
+    "license": "BSD-2-Clause",
+    "authors": [
+        {
+            "name": "Aura.Accept Contributors",
+            "homepage": "https://github.com/auraphp/Aura.Accept/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Aura\\Accept\\": "src/",
+            "Aura\\Accept\\_Config\\": "config/"
+        }
+    },
+    "extra": {
+        "aura": {
+            "type": "library",
+            "config": {
+                "common": "Aura\\Accept\\_Config\\Common"
+            }
+        },
+        "branch-alias": {
+            "dev-develop-2": "2.0.x-dev"
+        }
+    },
+    "require-dev": {
+        "aura/di": "~2.0"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Aura\\Accept\\": "tests/",
+            "Aura\\Di\\": "vendor/aura/di/tests/"
+        }
+    }
+}

--- a/vendor/aura/accept/config/Common.php
+++ b/vendor/aura/accept/config/Common.php
@@ -1,0 +1,29 @@
+<?php
+namespace Aura\Accept\_Config;
+
+use Aura\Di\Config;
+use Aura\Di\Container;
+
+class Common extends Config
+{
+    public function define(Container $di)
+    {
+        /**
+         * Aura\Accept\Accept
+         */
+        $di->params['Aura\Accept\Accept'] = array(
+            'charset'  => $di->lazyNew('Aura\Accept\Charset\CharsetNegotiator'),
+            'encoding' => $di->lazyNew('Aura\Accept\Encoding\EncodingNegotiator'),
+            'language' => $di->lazyNew('Aura\Accept\Language\LanguageNegotiator'),
+            'media'    => $di->lazyNew('Aura\Accept\Media\MediaNegotiator'),
+        );
+
+        /**
+         * Aura\Accept\AbstractNegotiator
+         */
+        $di->params['Aura\Accept\AbstractNegotiator'] = array(
+            'value_factory' => $di->lazyNew('Aura\Accept\ValueFactory'),
+            'server' => $_SERVER,
+        );
+    }
+}

--- a/vendor/aura/accept/phpunit.php
+++ b/vendor/aura/accept/phpunit.php
@@ -1,0 +1,9 @@
+<?php
+error_reporting(E_ALL);
+$autoloader = __DIR__ . '/vendor/autoload.php';
+if (! file_exists($autoloader)) {
+    echo "Composer autoloader not found: $autoloader" . PHP_EOL;
+    echo "Please issue 'composer install' and try again." . PHP_EOL;
+    exit(1);
+}
+require $autoloader;

--- a/vendor/aura/accept/phpunit.xml.dist
+++ b/vendor/aura/accept/phpunit.xml.dist
@@ -1,0 +1,7 @@
+<phpunit bootstrap="./phpunit.php">
+    <testsuites>
+        <testsuite>
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/vendor/aura/accept/src/AbstractNegotiator.php
+++ b/vendor/aura/accept/src/AbstractNegotiator.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Accept;
+
+use ArrayIterator;
+use IteratorAggregate;
+
+/**
+ *
+ * Represents a collection of `Accept*` header values, sorted in quality order.
+ *
+ * @package Aura.Accept
+ *
+ */
+abstract class AbstractNegotiator implements IteratorAggregate
+{
+    /**
+     *
+     * An array of objects representing acceptable values from the header.
+     *
+     * @var array
+     *
+     */
+    protected $acceptable = array();
+
+    /**
+     *
+     * The $_SERVER key to use when populating acceptable values.
+     *
+     * @var string
+     *
+     */
+    protected $server_key;
+
+    /**
+     *
+     * A factory to create value objects.
+     *
+     * @var ValueFactory
+     *
+     */
+    protected $value_factory;
+
+    /**
+     *
+     * The type of value object to create using the ValueFactory.
+     *
+     * @var string
+     *
+     */
+    protected $value_type;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param ValueFactory $value_factory A factory for value objects.
+     *
+     * @param array $server A copy of $_SERVER for finding acceptable values.
+     *
+     */
+    public function __construct(
+        ValueFactory $value_factory,
+        array $server = array()
+    ) {
+        $this->value_factory = $value_factory;
+        if (isset($server[$this->server_key])) {
+            $this->set($server[$this->server_key]);
+        }
+    }
+
+    /**
+     *
+     * Returns a value object by its sorted quality position.
+     *
+     * @param int $key The sorted position.
+     *
+     * @return Value\AbstractValue
+     *
+     */
+    public function get($key = null)
+    {
+        if ($key === null) {
+            return $this->acceptable;
+        }
+        return $this->acceptable[$key];
+    }
+
+    /**
+     *
+     * Sets the collection to one or more acceptable values, overwriting all
+     * previous values.
+     *
+     * @param string|array $acceptable An `Accept*` string value; e.g.,
+     * `text/plain;q=0.5,text/html,text/*;q=0.1`.
+     *
+     * @return null
+     *
+     */
+    public function set($acceptable = null)
+    {
+        $this->acceptable = array();
+        $this->add($acceptable);
+    }
+
+    /**
+     *
+     * Adds one or more acceptable values to this collection.
+     *
+     * @param string|array $acceptable One or more `Accept*` string values;
+     * e.g., the string `'text/plain;q=0.5,text/html,text/*;q=0.1'` and
+     * `array('text/plain;q=0.5','text/html','text/*;q=0.1')` are
+     * equivalent.
+     *
+     * @return null
+     *
+     * @todo Allow this to take an array so we can parse-and-sort in one pass.
+     *
+     */
+    public function add($acceptable = null)
+    {
+        foreach ((array) $acceptable as $string) {
+            $this->parse($string);
+        }
+
+        $this->sort();
+    }
+
+    /**
+     *
+     * Parses an acceptable string value into the `$acceptable` property.
+     *
+     * @param string $string An `Accept*` string value; e.g.,
+     * `text/plain;q=0.5,text/html,text/*;q=0.1`.
+     *
+     * @return array
+     *
+     */
+    protected function parse($string)
+    {
+        $acceptable = explode(',', $string);
+
+        foreach ($acceptable as $value) {
+            $pairs = explode(';', $value);
+            $value = $pairs[0];
+            unset($pairs[0]);
+
+            $parameters = array();
+            foreach ($pairs as $pair) {
+                $param = array();
+                preg_match(
+                    '/^(?P<name>.+?)=(?P<quoted>"|\')?(?P<value>.*?)(?:\k<quoted>)?$/',
+                    $pair,
+                    $param
+                );
+                $parameters[$param['name']] = $param['value'];
+            }
+
+            $quality = 1.0;
+            if (isset($parameters['q'])) {
+                $quality = $parameters['q'];
+                unset($parameters['q']);
+            }
+
+            $this->acceptable[] = $this->value_factory->newInstance(
+                $this->value_type,
+                trim($value),
+                (float) $quality,
+                $parameters
+            );
+        }
+    }
+
+    /**
+     *
+     * Sorts the `$acceptable` values according to quality levels.
+     *
+     * This is an unusual sort. Normally we'd think a reverse-sort would
+     * order the array by q values from 1 to 0, but the problem is that
+     * an implicit 1.0 on more than one value means that those values will
+     * be reverse from what the header specifies, which seems unexpected
+     * when negotiating later.
+     *
+     */
+    protected function sort()
+    {
+        // q-value buckets
+        $bucket = array();
+
+        // sort into q-value buckets
+        foreach ($this->acceptable as $value) {
+            $bucket[$value->getQuality()][] = $value;
+        }
+
+        // reverse-sort the buckets so that q=1 is first and q=0 is last,
+        // but the values in the buckets stay in the original order.
+        krsort($bucket);
+
+        // flatten the buckets back into the acceptable array
+        $this->acceptable = array();
+        foreach ($bucket as $q => $acceptable) {
+            foreach ($acceptable as $value) {
+                $this->acceptable[] = $value;
+            }
+        }
+    }
+
+    /**
+     *
+     * IteratorInterface: returns the iterator for this object.
+     *
+     * @return ArrayIterator
+     *
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->acceptable);
+    }
+
+    /**
+     *
+     * Negotiates between acceptable and available values.  On success, the
+     * return value is a plain old PHP object with the matching negotiated
+     * `$acceptable` and `$available` value objects; these are to be inspected
+     * by the calling code.
+     *
+     * @param array $available Available values in preference order, if any.
+     *
+     * @return mixed A plain-old PHP object with negotiated `$acceptable` and
+     * `$available` value objects on success, or false on failure.
+     *
+     */
+    public function negotiate(array $available = null)
+    {
+        // if none available, no possible match
+        if (! $available) {
+            return false;
+        }
+
+        // convert to object
+        $clone = clone $this;
+        $clone->set($available);
+        $available = $clone;
+
+        // if nothing acceptable specified, use first available
+        if (! $this->acceptable) {
+            return (object) array(
+                'acceptable' => false,
+                'available' => $available->get(0),
+            );
+        }
+
+        // loop through acceptable values
+        foreach ($this->acceptable as $accept) {
+
+            // if the acceptable quality is zero, skip it
+            if ($accept->getQuality() == 0) {
+                continue;
+            }
+
+            // if acceptable value is "anything" return the first available
+            if ($accept->isWildcard()) {
+                return (object) array(
+                    'acceptable' => $accept,
+                    'available' => $available->get(0),
+                );
+            }
+
+            // if acceptable value is available, use it
+            foreach ($available as $avail) {
+                if ($accept->match($avail)) {
+                    return (object) array(
+                        'acceptable' => $accept,
+                        'available' => $avail,
+                    );
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/vendor/aura/accept/src/AbstractValue.php
+++ b/vendor/aura/accept/src/AbstractValue.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Accept;
+
+/**
+ *
+ * Represents an acceptable value.
+ *
+ * @package Aura.Accept
+ *
+ */
+abstract class AbstractValue
+{
+    /**
+     *
+     * The acceptable value, not including any parameters.
+     *
+     * @var string
+     *
+     */
+    protected $value;
+
+    /**
+     *
+     * The quality parameter.
+     *
+     * @var float
+     *
+     */
+    protected $quality = 1.0;
+
+    /**
+     *
+     * Parameters additional to the acceptable value.
+     *
+     * @var array
+     *
+     */
+    protected $parameters = array();
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param string $value The acceptable value, not including any parameters.
+     *
+     * @param float $quality The quality parameter.
+     *
+     * @param array $parameters Other parameters additional to the value.
+     *
+     */
+    public function __construct(
+        $value,
+        $quality,
+        array $parameters
+    ) {
+        $this->value = $value;
+        $this->quality = $quality;
+        $this->parameters = $parameters;
+        $this->init();
+    }
+
+    /**
+     *
+     * Finishes construction of the value object.
+     *
+     * @return null
+     *
+     */
+    protected function init()
+    {
+    }
+
+    /**
+     *
+     * Match against the parameters of an available value.
+     *
+     * @param AbstractValue $avail The available value.
+     *
+     * @return bool True on a match, false if not.
+     *
+     */
+    protected function matchParameters(AbstractValue $avail)
+    {
+        foreach ($avail->getParameters() as $label => $value) {
+            if ($this->parameters[$label] != $value) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     *
+     * Is the acceptable value a wildcard?
+     *
+     * @return bool
+     *
+     */
+    public function isWildcard()
+    {
+        return $this->value == '*';
+    }
+
+    /**
+     *
+     * Returns the acceptable value.
+     *
+     * @return string
+     *
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     *
+     * Returns the quality level.
+     *
+     * @return float
+     *
+     */
+    public function getQuality()
+    {
+        return (float) $this->quality;
+    }
+
+    /**
+     *
+     * Returns the additional parameters.
+     *
+     * @return array
+     *
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+}

--- a/vendor/aura/accept/src/Accept.php
+++ b/vendor/aura/accept/src/Accept.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Accept;
+
+use Aura\Accept\Charset\CharsetNegotiator;
+use Aura\Accept\Encoding\EncodingNegotiator;
+use Aura\Accept\Language\LanguageNegotiator;
+use Aura\Accept\Media\MediaNegotiator;
+
+/**
+ *
+ * A collection of negotiator objects.
+ *
+ * @package Aura.Accept
+ *
+ */
+class Accept
+{
+    /**
+     *
+     * The media-type negotiator.
+     *
+     * @var MediaNegotiator
+     *
+     */
+    protected $media;
+
+    /**
+     *
+     * The charset negotiator.
+     *
+     * @var CharsetNegotiator
+     *
+     */
+    protected $charset;
+
+    /**
+     *
+     * The encoding negotiator.
+     *
+     * @var EncodingNegotiator
+     *
+     */
+    protected $encoding;
+
+    /**
+     *
+     * The language negotiator.
+     *
+     * @var LanguageNegotiator
+     *
+     */
+    protected $language;
+
+	/**
+	 *
+	 * Constructor.
+	 *
+	 * @param CharsetNegotiator $charset A charset negotiator.
+	 *
+	 * @param EncodingNegotiator $encoding An encoding negotiator.
+	 *
+	 * @param LanguageNegotiator $language A language negotiator.
+	 *
+	 * @param MediaNegotiator $media A media-type negotiator.
+	 *
+	 */
+    public function __construct(
+        CharsetNegotiator $charset,
+        EncodingNegotiator $encoding,
+        LanguageNegotiator $language,
+        MediaNegotiator $media
+    ) {
+        $this->charset  = $charset;
+        $this->encoding = $encoding;
+        $this->language = $language;
+        $this->media    = $media;
+    }
+
+    /**
+     *
+     * Negotiate between acceptable and available charsets.
+     *
+     * @param array $available The list of available charsets, ordered by most
+     * preferred to least preferred.
+     *
+     * @return Charset\CharsetValue
+     *
+     */
+    public function negotiateCharset(array $available)
+    {
+        return $this->parseResult($this->charset->negotiate($available));
+    }
+
+    /**
+     *
+     * Negotiate between acceptable and available encodings.
+     *
+     * @param array $available The list of available encodings, ordered by most
+     * preferred to least preferred.
+     *
+     * @return Encoding\EncodingValue|false
+     *
+     */
+    public function negotiateEncoding(array $available)
+    {
+        return $this->parseResult($this->encoding->negotiate($available));
+    }
+
+    /**
+     *
+     * Negotiate between acceptable and available languages.
+     *
+     * @param array $available The list of available languages, ordered by most
+     * preferred to least preferred.
+     *
+     * @return Language\LanguageValue|false
+     *
+     */
+    public function negotiateLanguage(array $available)
+    {
+        return $this->parseResult($this->language->negotiate($available));
+    }
+
+    /**
+     *
+     * Negotiate between acceptable and available media types.
+     *
+     * @param array $available The list of available media types, ordered by
+     * most preferred to least preferred.
+     *
+     * @return Media\MediaValue|false
+     *
+     */
+    public function negotiateMedia(array $available)
+    {
+        return $this->parseResult($this->media->negotiate($available));
+    }
+
+    /**
+     *
+     * Given a negotiation result, return either the acceptable value or the
+     * available value (or false if negotiation failed).
+     *
+     * Sometimes the acceptable value is a wildcard, or none was specified, so
+     * we have to go with the available value.
+     *
+     * @param mixed $result A negotiation result.
+     *
+     * @return AbstractValue|false
+     *
+     */
+    protected function parseResult($result)
+    {
+        if (! $result) {
+            return false;
+        }
+
+        if ($result->acceptable && ! $result->acceptable->isWildcard()) {
+            return $result->acceptable;
+        }
+
+        return $result->available;
+    }
+}

--- a/vendor/aura/accept/src/AcceptFactory.php
+++ b/vendor/aura/accept/src/AcceptFactory.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Accept;
+
+/**
+ *
+ * A factory to create an Accept objects.
+ *
+ * @package Aura.Accept
+ *
+ */
+class AcceptFactory
+{
+    /**
+     *
+     * A copy of $_SERVER.
+     *
+     * @var array
+     *
+     */
+    protected $server = array();
+
+    /**
+     *
+     * A map of file .extensions to media types.
+     *
+     * @var array
+     *
+     */
+    protected $types = array();
+
+    /**
+     *
+     * Contains the ValueFactory.
+     *
+     * @var ValueFactory
+     *
+     */
+    protected $value_factory;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param array $server A copy of $_SERVER.
+     *
+     * @param array $types A map of file .extensions to media types.
+     *
+     */
+    public function __construct(array $server = array(), array $types = array())
+    {
+        $this->server = $server;
+        $this->types = $types;
+        $this->value_factory = new ValueFactory;
+    }
+
+    /**
+     *
+     * Returns an Accept object with all negotiators.
+     *
+     * @return Accept
+     *
+     */
+    public function newInstance()
+    {
+        return new Accept(
+            $this->newCharsetNegotiator(),
+            $this->newEncodingNegotiator(),
+            $this->newLanguageNegotiator(),
+            $this->newMediaNegotiator()
+        );
+    }
+
+    /**
+     *
+     * Returns a charset negotiator.
+     *
+     * @return Charset\CharsetNegotiator
+     *
+     */
+    public function newCharsetNegotiator()
+    {
+        return new Charset\CharsetNegotiator($this->value_factory, $this->server);
+    }
+
+    /**
+     *
+     * Returns an encoding negotiator.
+     *
+     * @return Encoding\EncodingNegotiator
+     *
+     */
+    public function newEncodingNegotiator()
+    {
+        return new Encoding\EncodingNegotiator($this->value_factory, $this->server);
+    }
+
+    /**
+     *
+     * Returns a language negotiator.
+     *
+     * @return Language\LanguageNegotiator
+     *
+     */
+    public function newLanguageNegotiator()
+    {
+        return new Language\LanguageNegotiator($this->value_factory, $this->server);
+    }
+
+    /**
+     *
+     * Returns a media type negotiator.
+     *
+     * @return Media\MediaNegotiator
+     *
+     */
+    public function newMediaNegotiator()
+    {
+        return new Media\MediaNegotiator($this->value_factory, $this->server, $this->types);
+    }
+}

--- a/vendor/aura/accept/src/Charset/CharsetNegotiator.php
+++ b/vendor/aura/accept/src/Charset/CharsetNegotiator.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Accept\Charset;
+
+use Aura\Accept\AbstractNegotiator;
+use Aura\Accept\ValueFactory;
+
+/**
+ *
+ * Represents a collection of `Accept-Charset` header values, sorted in
+ * quality order.
+ *
+ * @package Aura.Accept
+ *
+ */
+class CharsetNegotiator extends AbstractNegotiator
+{
+    /**
+     *
+     * The $_SERVER key to use when populating acceptable values.
+     *
+     * @var string
+     *
+     */
+    protected $server_key = 'HTTP_ACCEPT_CHARSET';
+
+    /**
+     *
+     * The type of value object to create using the ValueFactory.
+     *
+     * @var string
+     *
+     */
+    protected $value_type = 'charset';
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param ValueFactory $value_factory A factory for value objects.
+     *
+     * @param array $server A copy of $_SERVER for finding acceptable values.
+     *
+     */
+    public function __construct(
+        ValueFactory $value_factory,
+        array $server = array()
+    ) {
+        // parent construction
+        parent::__construct($value_factory, $server);
+
+        // are charset values specified?
+        if (! $this->acceptable) {
+            // no, so don't modify anything
+            return;
+        }
+
+        // look for ISO-8859-1, case insensitive
+        foreach ($this->acceptable as $charset) {
+            if (strtolower($charset->getValue()) == 'iso-8859-1') {
+                // found it, no no need to modify
+                return;
+            }
+        }
+
+        // charset ISO-8859-1 is acceptable if not explicitly mentioned
+        $this->add('ISO-8859-1');
+    }
+}

--- a/vendor/aura/accept/src/Charset/CharsetValue.php
+++ b/vendor/aura/accept/src/Charset/CharsetValue.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Accept\Charset;
+
+use Aura\Accept\AbstractValue;
+
+/**
+ *
+ * Represents an acceptable charset value.
+ *
+ * @package Aura.Accept
+ *
+ */
+class CharsetValue extends AbstractValue
+{
+    /**
+     *
+     * Checks if an available charset value matches this acceptable value.
+     *
+     * @param Charset $avail An available charset value.
+     *
+     * @return True on a match, false if not.
+     *
+     */
+    public function match(CharsetValue $avail)
+    {
+        if ($avail->getValue() == '*') {
+            return true;
+        }
+
+        return strtolower($this->value) == strtolower($avail->getValue())
+            && $this->matchParameters($avail);
+    }
+}

--- a/vendor/aura/accept/src/Encoding/EncodingNegotiator.php
+++ b/vendor/aura/accept/src/Encoding/EncodingNegotiator.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Accept\Encoding;
+
+use Aura\Accept\AbstractNegotiator;
+
+/**
+ *
+ * Represents a collection of `Accept-Encoding` header values, sorted in
+ * quality order.
+ *
+ * @package Aura.Accept
+ *
+ */
+class EncodingNegotiator extends AbstractNegotiator
+{
+    /**
+     *
+     * The $_SERVER key to use when populating acceptable values.
+     *
+     * @var string
+     *
+     */
+    protected $server_key = 'HTTP_ACCEPT_ENCODING';
+
+    /**
+     *
+     * The type of value object to create using the ValueFactory.
+     *
+     * @var string
+     *
+     */
+    protected $value_type = 'encoding';
+}

--- a/vendor/aura/accept/src/Encoding/EncodingValue.php
+++ b/vendor/aura/accept/src/Encoding/EncodingValue.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Accept\Encoding;
+
+use Aura\Accept\AbstractValue;
+
+/**
+ *
+ * Represents an encoding value.
+ *
+ * @package Aura.Accept
+ *
+ */
+class EncodingValue extends AbstractValue
+{
+    /**
+     *
+     * Checks if an available encoding value matches this acceptable value.
+     *
+     * @param Encoding $avail An available encoding value.
+     *
+     * @return True on a match, false if not.
+     *
+     */
+    public function match(EncodingValue $avail)
+    {
+        if ($avail->getValue() == '*') {
+            return true;
+        }
+
+        return strtolower($this->value) == strtolower($avail->getValue())
+            && $this->matchParameters($avail);
+    }
+}

--- a/vendor/aura/accept/src/Language/LanguageNegotiator.php
+++ b/vendor/aura/accept/src/Language/LanguageNegotiator.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Accept\Language;
+
+use Aura\Accept\AbstractNegotiator;
+
+/**
+ *
+ * Represents a collection of `Accept-Language` header values, sorted in
+ * quality order.
+ *
+ * @package Aura.Accept
+ *
+ */
+class LanguageNegotiator extends AbstractNegotiator
+{
+    /**
+     *
+     * The $_SERVER key to use when populating acceptable values.
+     *
+     * @var string
+     *
+     */
+    protected $server_key = 'HTTP_ACCEPT_LANGUAGE';
+
+    /**
+     *
+     * The type of value object to create using the ValueFactory.
+     *
+     * @var string
+     *
+     */
+    protected $value_type = 'language';
+}

--- a/vendor/aura/accept/src/Language/LanguageValue.php
+++ b/vendor/aura/accept/src/Language/LanguageValue.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Accept\Language;
+
+use Aura\Accept\AbstractValue;
+
+/**
+ *
+ * Represents an acceptable language value.
+ *
+ * @package Aura.Accept
+ *
+ */
+class LanguageValue extends AbstractValue
+{
+    /**
+     *
+     * The language type.
+     *
+     * @var string
+     *
+     */
+    protected $type = '*';
+
+    /**
+     *
+     * The language subtype, if any.
+     *
+     * @var string
+     *
+     */
+    protected $subtype;
+
+    /**
+     *
+     * Finishes construction of the value object.
+     *
+     * @return null
+     *
+     */
+    protected function init()
+    {
+        list($this->type, $this->subtype) = array_pad(explode('-', $this->value), 2, false);
+    }
+
+    /**
+     *
+     * Returns the language type.
+     *
+     * @return string
+     *
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     *
+     * Returns the language subtype.
+     *
+     * @return string
+     *
+     */
+    public function getSubtype()
+    {
+        return $this->subtype;
+    }
+
+    /**
+     *
+     * Checks if an available language value matches this acceptable value.
+     *
+     * @param Language $avail An available language value.
+     *
+     * @return True on a match, false if not.
+     *
+     */
+    public function match(LanguageValue $avail)
+    {
+        if ($avail->getValue() == '*') {
+            return true;
+        }
+
+        // is it a full match?
+        if (strtolower($this->value) == strtolower($avail->getValue())) {
+            return $this->matchParameters($avail);
+        }
+
+        // is it a type-without-subtype match?
+        return ! $this->subtype
+            && strtolower($this->type) == strtolower($avail->getType())
+            && $this->matchParameters($avail);
+    }
+}

--- a/vendor/aura/accept/src/Media/MediaNegotiator.php
+++ b/vendor/aura/accept/src/Media/MediaNegotiator.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Accept\Media;
+
+use Aura\Accept\AbstractNegotiator;
+use Aura\Accept\ValueFactory;
+
+/**
+ *
+ * Represents a collection of `Accept` header values, sorted in quality
+ * order.
+ *
+ * @package Aura.Accept
+ *
+ */
+class MediaNegotiator extends AbstractNegotiator
+{
+    /**
+     *
+     * The $_SERVER key to use when populating acceptable values.
+     *
+     * @var string
+     *
+     */
+    protected $server_key = 'HTTP_ACCEPT';
+
+    /**
+     *
+     * The type of value object to create using the ValueFactory.
+     *
+     * @var string
+     *
+     */
+    protected $value_type = 'media';
+
+    /**
+     *
+     * A map of file .extensions to media types.
+     *
+     * @var array
+     *
+     */
+    protected $types = array(
+        '.aif'      => 'audio/x-aiff',
+        '.aifc'     => 'audio/x-aiff',
+        '.aiff'     => 'audio/x-aiff',
+        '.asf'      => 'video/x-ms-asf',
+        '.asr'      => 'video/x-ms-asf',
+        '.asx'      => 'video/x-ms-asf',
+        '.atom'     => 'application/atom+xml',
+        '.au'       => 'audio/basic',
+        '.avi'      => 'video/x-msvideo',
+        '.bas'      => 'text/plain',
+        '.bmp'      => 'image/bmp',
+        '.c'        => 'text/plain',
+        '.css'      => 'text/css',
+        '.csv'      => 'text/csv',
+        '.dtd'      => 'application/xml-dtd',
+        '.etx'      => 'text/x-setext',
+        '.flr'      => 'x-world/x-vrml',
+        '.gif'      => 'image/gif',
+        '.gz'       => 'application/x-gzip',
+        '.h'        => 'text/plain',
+        '.htm'      => 'text/html',
+        '.html'     => 'text/html',
+        '.ico'      => 'image/x-icon',
+        '.jfif'     => 'image/pipeg',
+        '.jpe'      => 'image/jpeg',
+        '.jpeg'     => 'image/jpeg',
+        '.jpg'      => 'image/jpeg',
+        '.js'       => 'text/javascript',
+        '.json'     => 'application/json',
+        '.lsf'      => 'video/x-la-asf',
+        '.lsx'      => 'video/x-la-asf',
+        '.m3u'      => 'audio/x-mpegurl',
+        '.mid'      => 'audio/mid',
+        '.mov'      => 'video/quicktime',
+        '.movie'    => 'video/x-sgi-movie',
+        '.mp2'      => 'video/mpeg',
+        '.mp3'      => 'audio/mpeg',
+        '.mpa'      => 'video/mpeg',
+        '.mpe'      => 'video/mpeg',
+        '.mpeg'     => 'video/mpeg',
+        '.mpg'      => 'video/mpeg',
+        '.mpv2'     => 'video/mpeg',
+        '.ogg'      => 'application/ogg',
+        '.pbm'      => 'image/x-portable-bitmap',
+        '.pdf'      => 'application/pdf',
+        '.pgm'      => 'image/x-portable-graymap',
+        '.png'      => 'image/png',
+        '.pnm'      => 'image/x-portable-anymap',
+        '.ppm'      => 'image/x-portable-pixmap',
+        '.ps'       => 'application/postscript',
+        '.qt'       => 'video/quicktime',
+        '.ra'       => 'audio/x-pn-realaudio',
+        '.ram'      => 'audio/x-pn-realaudio',
+        '.ras'      => 'image/x-cmu-raster',
+        '.rdf'      => 'application/rdf+xml',
+        '.rgb'      => 'image/x-rgb',
+        '.rmi'      => 'audio/mid',
+        '.rss'      => 'application/rss+xml',
+        '.rss2'     => 'application/rss+xml',
+        '.rtf'      => 'application/rtf',
+        '.snd'      => 'audio/basic',
+        '.svg'      => 'image/svg+xml',
+        '.text'     => 'text/plain',
+        '.tif'      => 'image/tiff',
+        '.tiff'     => 'image/tiff',
+        '.tsv'      => 'text/plain',
+        '.txt'      => 'text/plain',
+        '.vcf'      => 'text/x-vcard',
+        '.vrml'     => 'x-world/x-vrml',
+        '.wav'      => 'audio/x-wav',
+        '.wrl'      => 'x-world/x-vrml',
+        '.wrz'      => 'x-world/x-vrml',
+        '.xaf'      => 'x-world/x-vrml',
+        '.xbm'      => 'image/x-xbitmap',
+        '.xht'      => 'application/xhtml+xml',
+        '.xhtml'    => 'application/xhtml+xml',
+        '.xml'      => 'application/xml',
+        '.xof'      => 'x-world/x-vrml',
+        '.xpm'      => 'image/x-xpixmap',
+        '.xwd'      => 'image/x-xwindowdump',
+        '.zip'      => 'application/zip',
+    );
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param ValueFactory $value_factory A factory for value objects.
+     *
+     * @param array $server A copy of $_SERVER for finding acceptable values.
+     *
+     * @param array $types Additional extensions to media type mappings.
+     *
+     */
+    public function __construct(
+        ValueFactory $value_factory,
+        array $server = array(),
+        array $types = array()
+    ) {
+        // parent construction
+        parent::__construct($value_factory, $server);
+
+        // merge the media type mappings
+        $this->types = array_merge($this->types, $types);
+
+        // override the media type if a file extension exists in the path
+        $request_uri = isset($server['REQUEST_URI'])
+                     ? $server['REQUEST_URI']
+                     : null;
+        $path = parse_url('http://example.com/' . $request_uri, PHP_URL_PATH);
+        $name = basename((string) $path);
+        $ext  = strrchr($name, '.');
+        if ($ext && isset($this->types[$ext])) {
+            $this->set($this->types[$ext]);
+        }
+    }
+}

--- a/vendor/aura/accept/src/Media/MediaValue.php
+++ b/vendor/aura/accept/src/Media/MediaValue.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Accept\Media;
+
+use Aura\Accept\AbstractValue;
+
+/**
+ *
+ * Represents an acceptable media type value.
+ *
+ * @package Aura.Accept
+ *
+ */
+class MediaValue extends AbstractValue
+{
+    /**
+     *
+     * The media type.
+     *
+     * @var string
+     *
+     */
+    protected $type = '*';
+
+    /**
+     *
+     * The media subtype.
+     *
+     * @var string
+     *
+     */
+    protected $subtype = '*';
+
+    /**
+     *
+     * Finishes construction of the value object.
+     *
+     * @return null
+     *
+     */
+    protected function init()
+    {
+        list($this->type, $this->subtype) = explode('/', $this->value);
+    }
+
+    /**
+     *
+     * Returns the media type.
+     *
+     * @return string
+     *
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     *
+     * Returns the media subtype.
+     *
+     * @return string
+     *
+     */
+    public function getSubtype()
+    {
+        return $this->subtype;
+    }
+
+    /**
+     *
+     * Is the acceptable value a wildcard?
+     *
+     * @return bool
+     *
+     */
+    public function isWildcard()
+    {
+        return $this->value == '*/*';
+    }
+
+    /**
+     *
+     * Checks if an available media type value matches this acceptable value.
+     *
+     * @param Media $avail An available media type value.
+     *
+     * @return True on a match, false if not.
+     *
+     */
+    public function match(MediaValue $avail)
+    {
+        if ($avail->getValue() == '*/*') {
+            return true;
+        }
+
+        // is it a full match?
+        if (strtolower($this->value) == strtolower($avail->getValue())) {
+            return $this->matchParameters($avail);
+        }
+
+        // is it a type match?
+        return $this->subtype == '*'
+            && strtolower($this->type) == strtolower($avail->getType())
+            && $this->matchParameters($avail);
+    }
+}

--- a/vendor/aura/accept/src/ValueFactory.php
+++ b/vendor/aura/accept/src/ValueFactory.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Accept;
+
+/**
+ *
+ * A factory to create value objects.
+ *
+ * @package Aura.Accept
+ *
+ */
+class ValueFactory
+{
+    /**
+     *
+     * A map of value types to value classes.
+     *
+     * @var array
+     *
+     */
+    protected $map = array(
+        'charset' => 'Aura\Accept\Charset\CharsetValue',
+        'encoding' => 'Aura\Accept\Encoding\EncodingValue',
+        'language' => 'Aura\Accept\Language\LanguageValue',
+        'media' => 'Aura\Accept\Media\MediaValue',
+    );
+
+    /**
+     *
+     * Returns a new value object instance.
+     *
+     * @param string $type The value type.
+     *
+     * @param string $value The acceptable value.
+     *
+     * @param float $quality The quality parameter.
+     *
+     * @param array $parameters Additional parameters.
+     *
+     * @return AbstractValue
+     *
+     */
+    public function newInstance($type, $value, $quality, array $parameters)
+    {
+        $class = $this->map[$type];
+        return new $class($value, $quality, $parameters);
+    }
+}

--- a/vendor/aura/accept/tests/AcceptTest.php
+++ b/vendor/aura/accept/tests/AcceptTest.php
@@ -1,0 +1,46 @@
+<?php
+namespace Aura\Accept;
+
+class AcceptTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $factory = new AcceptFactory(array(
+            'HTTP_ACCEPT' => 'application/json, application/xml, text/*, */*',
+            'HTTP_ACCEPT_CHARSET' => 'iso-8859-5, unicode-1-1;q=0.8',
+            'HTTP_ACCEPT_ENCODING' => 'compress;q=0.5, gzip;q=1.0',
+            'HTTP_ACCEPT_LANGUAGE' => 'en-US, en-GB, en, *',
+        ));
+        $this->accept = $factory->newInstance();
+    }
+
+    public function testNegotiateCharset()
+    {
+        $actual = $this->accept->negotiateCharset(array('unicode-1-1'));
+        $expect = 'unicode-1-1';
+        $this->assertSame($expect, $actual->getValue());
+    }
+
+    public function testNegotiateEncoding()
+    {
+        $actual = $this->accept->negotiateEncoding(array());
+        $this->assertFalse($actual);
+    }
+
+    public function testNegotiateLanguage()
+    {
+        $actual = $this->accept->negotiateLanguage(array('pt-BR', 'fr-FR'));
+        $expect = 'pt-BR';
+        $this->assertSame($expect, $actual->getValue());
+    }
+
+    public function testNegotiateMedia()
+    {
+        $actual = $this->accept->negotiateMedia(array(
+            'application/xml',
+            'application/json',
+        ));
+        $expect = 'application/json';
+        $this->assertSame($expect, $actual->getValue());
+    }
+}

--- a/vendor/aura/accept/tests/AcceptTestCase.php
+++ b/vendor/aura/accept/tests/AcceptTestCase.php
@@ -1,0 +1,19 @@
+<?php
+namespace Aura\Accept;
+
+class AcceptTestCase extends \PHPUnit_Framework_TestCase
+{
+    protected function assertAcceptValues($actual, $expect, $negotiator_class, $value_class)
+    {
+        $this->assertInstanceOf($negotiator_class, $actual);
+        $this->assertSameSize($actual->get(), $expect);
+
+        foreach ($actual as $key => $item) {
+            $this->assertInstanceOf($value_class, $item);
+            foreach ($expect[$key] as $func => $value) {
+                $func = 'get' . $func;
+                $this->assertEquals($value, $item->$func());
+            }
+        }
+    }
+}

--- a/vendor/aura/accept/tests/CharsetTest.php
+++ b/vendor/aura/accept/tests/CharsetTest.php
@@ -1,0 +1,107 @@
+<?php
+namespace Aura\Accept;
+
+class CharsetTest extends AcceptTestCase
+{
+    protected $charset;
+
+    protected function newCharset($server = array())
+    {
+        return new Charset\CharsetNegotiator(new ValueFactory, $server);
+    }
+
+    /**
+     * @dataProvider charsetProvider
+     * @param $accept
+     * @param $expect
+     * @param $negotiator_class
+     * @param $value_class
+     */
+    public function testGetCharset($server, $expect, $negotiator_class, $value_class)
+    {
+        $charset = $this->newCharset($server);
+        $this->assertAcceptValues($charset, $expect, $negotiator_class, $value_class);
+    }
+
+    /**
+     * @dataProvider charsetNegotiateProvider
+     * @param $accept
+     * @param $available
+     * @param $expected
+     */
+    public function testGetCharset_negotiate($server, $available, $expected)
+    {
+        $charset = $this->newCharset($server);
+        $actual = $charset->negotiate($available);
+
+        if ($expected === false) {
+            $this->assertFalse($expected, $actual);
+        } else {
+            $this->assertInstanceOf('Aura\Accept\Charset\CharsetValue', $actual->available);
+            $this->assertSame($expected, $actual->available->getValue());
+        }
+    }
+
+    public function charsetProvider()
+    {
+        return array(
+            array(
+                'server' => array(
+                    'HTTP_ACCEPT_CHARSET' => 'iso-8859-5, unicode-1-1;q=0.8',
+                ),
+                'expected' => array(
+                    array(
+                        'value' => 'iso-8859-5',
+                        'quality' => 1.0,
+                    ),
+                    array(
+                        'value' => 'ISO-8859-1',
+                        'quality' => 1.0,
+                    ),
+                    array(
+                        'value' => 'unicode-1-1',
+                        'quality' => 0.8,
+                    ),
+                ),
+                'negotiator_class' => 'Aura\Accept\Charset\CharsetNegotiator',
+                'value_class' => 'Aura\Accept\Charset\CharsetValue',
+            )
+        );
+    }
+
+    public function charsetNegotiateProvider()
+    {
+        return array(
+            array(
+                'server' => array('HTTP_ACCEPT_CHARSET' => 'iso-8859-5, unicode-1-1, *'),
+                'available' => array(),
+                'expected' => false,
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_CHARSET' => 'iso-8859-5, unicode-1-1, *'),
+                'available' => array('foo', 'bar'),
+                'expected' => 'foo'
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_CHARSET' => 'iso-8859-5, unicode-1-1, *'),
+                'available' => array('foo', 'UniCode-1-1'),
+                'expected' => 'UniCode-1-1'
+            ),
+            array(
+                'server' => array(),
+                'available' => array('ISO-8859-5', 'foo'),
+                'expected' => 'ISO-8859-5'
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_CHARSET' => 'ISO-8859-1, baz;q=0'),
+                'available' => array('baz'),
+                'expected' => false
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_CHARSET' => 'iso-8859-5, unicode-1-1'),
+                'available' => array('*'),
+                'expected' => '*'
+            ),
+        );
+    }
+}

--- a/vendor/aura/accept/tests/ContainerTest.php
+++ b/vendor/aura/accept/tests/ContainerTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace Aura\Accept\_Config;
+
+use Aura\Di\ContainerAssertionsTrait;
+
+use Aura\Di\_Config\AbstractContainerTest;
+
+class ContainerTest extends AbstractContainerTest
+{
+    protected function getConfigClasses()
+    {
+        return array(
+            'Aura\Accept\_Config\Common'
+        );
+    }
+
+    protected function getAutoResolve()
+    {
+        return false;
+    }
+
+    public function provideNewInstance()
+    {
+        return array(
+            array('Aura\Accept\Accept'),
+            array('Aura\Accept\Charset\CharsetNegotiator'),
+            array('Aura\Accept\Encoding\EncodingNegotiator'),
+            array('Aura\Accept\Language\LanguageNegotiator'),
+            array('Aura\Accept\Media\MediaNegotiator'),
+        );
+    }
+}

--- a/vendor/aura/accept/tests/EncodingTest.php
+++ b/vendor/aura/accept/tests/EncodingTest.php
@@ -1,0 +1,93 @@
+<?php
+namespace Aura\Accept;
+
+class EncodingTest extends AcceptTestCase
+{
+    protected function newEncoding($server = array())
+    {
+        return new Encoding\EncodingNegotiator(new ValueFactory, $server);
+    }
+
+    /**
+     * @dataProvider encodingProvider
+     * @param $accept
+     * @param $expect
+     * @param $negotiator_class
+     * @param $value_class
+     */
+    public function testGetEncoding($server, $expect, $negotiator_class, $value_class)
+    {
+        $encoding = $this->newEncoding($server);
+        $this->assertAcceptValues($encoding, $expect, $negotiator_class, $value_class);
+    }
+
+    /**
+     * @dataProvider encodingNegotiateProvider
+     * @param $accept
+     * @param $available
+     * @param $expected
+     */
+    public function testGetEncoding_negotiate($server, $available, $expected)
+    {
+        $encoding = $this->newEncoding($server);
+        $actual = $encoding->negotiate($available);
+
+        if ($expected === false) {
+            $this->assertFalse($actual);
+        } else {
+            $this->assertInstanceOf('Aura\Accept\Encoding\EncodingValue', $actual->available);
+            $this->assertSame($expected, $actual->available->getValue());
+        }
+    }
+
+    public function encodingProvider()
+    {
+        return array(
+            array(
+                'server' => array('HTTP_ACCEPT_ENCODING' => 'compress;q=0.5, gzip;q=1.0'),
+                'expect' => array(
+                    array('value' => 'gzip', 'quality' => 1.0),
+                    array('value' => 'compress', 'quality' => 0.5)
+                ),
+                'negotiator_class' => 'Aura\Accept\Encoding\EncodingNegotiator',
+                'value_class' => 'Aura\Accept\Encoding\EncodingValue',
+            )
+        );
+    }
+
+    public function encodingNegotiateProvider()
+    {
+        return array(
+            array(
+                'server' => array('HTTP_ACCEPT_ENCODING' => 'gzip, compress, *',),
+                'available' => array(),
+                'expected' => false,
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_ENCODING' => 'gzip, compress, *'),
+                'available' => array('foo', 'bar'),
+                'expected' => 'foo',
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_ENCODING' => 'gzip, compress, *',),
+                'available' => array('foo', 'GZIP'),
+                'expected' => 'GZIP',
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_ENCODING' => 'gzip, compress, *',),
+                'available' => array('gzip', 'compress'),
+                'expected' => 'gzip',
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_ENCODING' => 'gzip, compress, foo;q=0'),
+                'available' => array('foo'),
+                'expected' => false,
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_ENCODING' => 'gzip, compress, foo;q=0'),
+                'available' => array('*'),
+                'expected' => '*',
+            ),
+        );
+    }
+}

--- a/vendor/aura/accept/tests/LanguageTest.php
+++ b/vendor/aura/accept/tests/LanguageTest.php
@@ -1,0 +1,118 @@
+<?php
+namespace Aura\Accept;
+
+class LanguageTest extends AcceptTestCase
+{
+    protected function newLanguage($server = array())
+    {
+        return new Language\LanguageNegotiator(new ValueFactory, $server);
+    }
+
+    /**
+     * @dataProvider languageProvider
+     * @param $accept
+     * @param $expect
+     * @param $negotiator_class
+     * @param $value_class
+     */
+    public function testGetLanguage($server, $expect, $negotiator_class, $value_class)
+    {
+        $language = $this->newLanguage($server);
+        $this->assertAcceptValues($language, $expect, $negotiator_class, $value_class);
+    }
+
+    /**
+     * @dataProvider languageNegotiateProvider
+     * @param $accept
+     * @param $available
+     * @param $expected
+     */
+    public function testGetLanguage_negotiate($server, $available, $expected)
+    {
+        $language = $this->newLanguage($server);
+        $actual = $language->negotiate($available);
+
+        if ($expected === false) {
+            $this->assertFalse($actual);
+        } else {
+            $this->assertInstanceOf('Aura\Accept\Language\LanguageValue', $actual->available);
+            $this->assertSame($expected, $actual->available->getValue());
+        }
+    }
+
+    public function languageProvider()
+    {
+        return array(
+            array(
+                'server' => array(),
+                'expect' => array(),
+                'negotiator_class' => 'Aura\Accept\Language\LanguageNegotiator',
+                'value_class' => 'Aura\Accept\Language\LanguageValue',
+            ),
+            array(
+                'server' => array(
+                    'HTTP_ACCEPT_LANGUAGE' => '*',
+                ),
+                'expect' => array(
+                    array('type' => '*', 'subtype' => false, 'value' => '*',  'quality' => 1.0, 'parameters' => array())
+                ),
+                'negotiator_class' => 'Aura\Accept\Language\LanguageNegotiator',
+                'value_class' => 'Aura\Accept\Language\LanguageValue',
+            ),
+            array(
+                'server' => array(
+                    'HTTP_ACCEPT_LANGUAGE' => 'en-US, en-GB, en, *',
+                ),
+                'expect' => array(
+                    array('type' => 'en', 'subtype' => 'US', 'value' => 'en-US', 'quality' => 1.0, 'parameters' => array()),
+                    array('type' => 'en', 'subtype' => 'GB', 'value' => 'en-GB', 'quality' => 1.0, 'parameters' => array()),
+                    array('type' => 'en', 'subtype' => false, 'value' => 'en', 'quality' => 1.0, 'parameters' => array()),
+                    array('type' => '*', 'subtype' => false, 'value' => '*',  'quality' => 1.0, 'parameters' => array())
+                ),
+                'negotiator_class' => 'Aura\Accept\Language\LanguageNegotiator',
+                'value_class' => 'Aura\Accept\Language\LanguageValue',
+            ),
+        );
+    }
+
+    public function languageNegotiateProvider()
+    {
+        return array(
+            array(
+                'server' => array('HTTP_ACCEPT_LANGUAGE' => 'en-US, en-GB, en, *'),
+                'available' => array(),
+                'expected' => false,
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_LANGUAGE' => 'en-US, en-GB, en, *'),
+                'available' => array('foo-bar' , 'baz-dib'),
+                'expected' => 'foo-bar',
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_LANGUAGE' => 'en-US, en-GB, en, *'),
+                'available' => array('en-gb', 'fr-FR'),
+                'expected' => 'en-gb',
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_LANGUAGE' => 'en-US, en-GB, en, *'),
+                'available' => array('foo-bar', 'en-zo', 'baz-qux'),
+                'expected' => 'en-zo',
+            ),
+            array(
+                'server' => array(),
+                'available' => array('en-us', 'en-gb'),
+                'expected' => 'en-us',
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_LANGUAGE' => 'en-us, en-gb, en, foo-bar;q=0'),
+                'available' => array('foo-bar'),
+                'expected' => false
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT_LANGUAGE' => 'en-us, en-gb, en, foo-bar;q=0'),
+                'available' => array('*'),
+                'expected' => '*'
+            )
+        );
+    }
+}

--- a/vendor/aura/accept/tests/MediaTest.php
+++ b/vendor/aura/accept/tests/MediaTest.php
@@ -1,0 +1,230 @@
+<?php
+namespace Aura\Accept;
+
+class MediaTest extends AcceptTestCase
+{
+    protected function newMedia($server = array())
+    {
+        return new Media\MediaNegotiator(new ValueFactory,$server);
+    }
+
+    /**
+     * @dataProvider mediaProvider
+     * @param $accept
+     * @param $expect
+     * @param $negotiator_class
+     * @param $value_class
+     */
+    public function testGetMedia($server, $expected, $negotiator_class, $value_class)
+    {
+        $media = $this->newMedia($server);
+        $this->assertAcceptValues($media, $expected, $negotiator_class, $value_class);
+    }
+
+    /**
+     * @dataProvider mediaNegotiateProvider
+     * @param $accept
+     * @param $available
+     * @param $expected_value
+     * @param $expected_params
+     */
+    public function testGetMedia_negotiate($server, $available, $expected_value, $expected_params)
+    {
+        $media = $this->newMedia($server);
+        $actual = $media->negotiate($available);
+
+        if ($expected_value === false) {
+            $this->assertFalse($actual);
+        } else {
+            $this->assertInstanceOf('Aura\Accept\Media\MediaValue', $actual->available);
+            $this->assertSame($expected_value, $actual->available->getValue());
+            $this->assertSame($expected_params, $actual->available->getParameters());
+        }
+    }
+
+    public function mediaNegotiateProvider()
+    {
+        return array(
+            array(
+                // nothing available
+                'server' => array('HTTP_ACCEPT' => 'application/json, application/xml, text/*, */*'),
+                'available' => array(),
+                'expected_value' => false,
+                'expected_params' => array(),
+            ),
+            array(
+                // explicitly accepts */*, and no matching media are available
+                'server' => array('HTTP_ACCEPT' => 'application/json, application/xml, text/*, */*'),
+                'available' => array('foo/bar', 'baz/dib'),
+                'expected_value' => 'foo/bar',
+                'expected_params' => array(),
+            ),
+            array(
+                // explictly accepts application/xml, which is explictly available.
+                // note that it returns the *available* value, which is determined
+                // by the developer, not the acceptable value, which is determined
+                // by the user/client/headers.
+                'server' => array('HTTP_ACCEPT' => 'application/json, application/xml, text/*, */*'),
+                'available' => array('application/XML', 'text/csv'),
+                'expected_value' => 'application/XML',
+                'expected_params' => array(),
+            ),
+            array(
+                // a subtype is available
+                'server' => array('HTTP_ACCEPT' => 'application/json, application/xml, text/*, */*'),
+                'available' => array('foo/bar', 'text/csv', 'baz/qux'),
+                'expected_value' => 'text/csv',
+                'expected_params' => array(),
+            ),
+            array(
+                // no acceptable media specified, use first available
+                'server' => array(),
+                'available' => array('application/json', 'application/xml'),
+                'expected_value' => 'application/json',
+                'expected_params' => array(),
+            ),
+            array(
+                // media is available but quality level is not acceptable
+                'server' => array('HTTP_ACCEPT' => 'application/json, application/xml, text/*, foo/bar;q=0'),
+                'available' => array('foo/bar'),
+                'expected_value' => false,
+                'expected_params' => array(),
+            ),
+            array(
+                // override with file extension
+                'server' => array(
+                    'HTTP_ACCEPT' => 'text/html, text/xhtml, text/plain',
+                    'REQUEST_URI' => '/path/to/resource.json',
+                ),
+                'available' => array('text/html', 'application/json'),
+                'expected_value' => 'application/json',
+                'expected_params' => array(),
+            ),
+            array(
+                // check against parameters when they are available
+                'server' => array('HTTP_ACCEPT' => 'text/html;level=2, text/html;level=1;q=0.5'),
+                'available' => array('text/html;level=1'),
+                'expected_value' => 'text/html',
+                'expected_params' => array('level' => '1'),
+            ),
+            array(
+                // check against parameters when they are not available
+                'server' => array('HTTP_ACCEPT' => 'text/html;level=2, text/html;level=1;q=0.5'),
+                'available' => array('text/html;level=3'),
+                'expected_value' => false,
+                'expected_params' => array(),
+            ),
+            array(
+                // */* is available
+                'server' => array('HTTP_ACCEPT' => 'application/json, application/xml, text/csv'),
+                'available' => array('*/*'),
+                'expected_value' => '*/*',
+                'expected_params' => array(),
+            ),
+        );
+    }
+
+    public function mediaProvider()
+    {
+        return array(
+            array(
+                'server' => array('HTTP_ACCEPT' => 'text/*;q=0.9, text/html, text/xhtml;q=0.8'),
+                'expect' => array(
+                    array(
+                        'type' => 'text',
+                        'subtype' => 'html',
+                        'value' => 'text/html',
+                        'quality' => 1.0,
+                        'parameters' => array(),
+                    ),
+                    array(
+                        'type' => 'text',
+                        'subtype' => '*',
+                        'value' => 'text/*',
+                        'quality' => 0.9,
+                        'parameters' => array(),
+                    ),
+                    array(
+                        'type' => 'text',
+                        'subtype' => 'xhtml',
+                        'value' => 'text/xhtml',
+                        'quality' => 0.8,
+                        'parameters' => array(),
+                    ),
+                ),
+                'negotiator_class' => 'Aura\Accept\Media\MediaNegotiator',
+                'value_class' => 'Aura\Accept\Media\MediaValue',
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT' => 'text/json;version=1,text/html;q=1;version=2,application/xml+xhtml;q=0'),
+                'expect' => array(
+                    array(
+                        'type' => 'text',
+                        'subtype' => 'json',
+                        'value' => 'text/json',
+                        'quality' => 1.0,
+                        'parameters' => array('version' => 1),
+                    ),
+                    array(
+                        'type' => 'text',
+                        'subtype' => 'html',
+                        'value' => 'text/html',
+                        'quality' => 1.0,
+                        'parameters' => array('version' => 2),
+                    ),
+                    array(
+                        'type' => 'application',
+                        'subtype' => 'xml+xhtml',
+                        'value' => 'application/xml+xhtml',
+                        'quality' => 0,
+                        'parameters' => array(),
+                    ),
+                ),
+                'negotiator_class' => 'Aura\Accept\Media\MediaNegotiator',
+                'value_class' => 'Aura\Accept\Media\MediaValue',
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT' => 'text/json;version=1;foo=bar,text/html;version=2,application/xml+xhtml'),
+                'expect' => array(
+                    array(
+                        'type' => 'text',
+                        'subtype' => 'json',
+                        'value' => 'text/json',
+                        'quality' => 1.0,
+                        'parameters' => array('version' => 1, 'foo' => 'bar'),
+                    ),
+                    array(
+                        'type' => 'text',
+                        'subtype' => 'html',
+                        'value' => 'text/html',
+                        'quality' => 1.0,
+                        'parameters' => array('version' => 2),
+                    ),
+                    array(
+                        'type' => 'application',
+                        'subtype' => 'xml+xhtml',
+                        'value' => 'application/xml+xhtml',
+                        'quality' => 1.0,
+                        'parameters' => array(),
+                    ),
+                ),
+                'negotiator_class' => 'Aura\Accept\Media\MediaNegotiator',
+                'value_class' => 'Aura\Accept\Media\MediaValue',
+            ),
+            array(
+                'server' => array('HTTP_ACCEPT' => 'text/json;q=0.9;version=1;foo="bar"'),
+                'expect' => array(
+                    array(
+                        'type' => 'text',
+                        'subtype' => 'json',
+                        'value' => 'text/json',
+                        'quality' => 0.9,
+                        'parameters' => array('version' => 1, 'foo' => 'bar'),
+                    ),
+                ),
+                'negotiator_class' => 'Aura\Accept\Media\MediaNegotiator',
+                'value_class' => 'Aura\Accept\Media\MediaValue',
+            ),
+        );
+    }
+}

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -152,4 +152,5 @@ return array(
     'migration_253' => $baseDir . '/install/migrations/2.5.3.php',
     'migration_260' => $baseDir . '/install/migrations/2.6.0.php',
     'migration_261' => $baseDir . '/install/migrations/2.6.1.php',
+    'migration_270' => $baseDir . '/install/migrations/2.7.0.php',
 );

--- a/vendor/composer/autoload_psr4.php
+++ b/vendor/composer/autoload_psr4.php
@@ -6,4 +6,6 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname($vendorDir);
 
 return array(
+    'Aura\\Accept\\_Config\\' => array($vendorDir . '/aura/accept/config'),
+    'Aura\\Accept\\' => array($vendorDir . '/aura/accept/src'),
 );

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -1,0 +1,65 @@
+[
+    {
+        "name": "aura/accept",
+        "version": "2.2.2",
+        "version_normalized": "2.2.2.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/auraphp/Aura.Accept.git",
+            "reference": "1c40bc38333a7899b95823a4d85ab758f7c618b2"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/auraphp/Aura.Accept/zipball/1c40bc38333a7899b95823a4d85ab758f7c618b2",
+            "reference": "1c40bc38333a7899b95823a4d85ab758f7c618b2",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.0"
+        },
+        "require-dev": {
+            "aura/di": "~2.0"
+        },
+        "time": "2015-03-27 17:05:44",
+        "type": "library",
+        "extra": {
+            "aura": {
+                "type": "library",
+                "config": {
+                    "common": "Aura\\Accept\\_Config\\Common"
+                }
+            },
+            "branch-alias": {
+                "dev-develop-2": "2.0.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Aura\\Accept\\": "src/",
+                "Aura\\Accept\\_Config\\": "config/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "BSD-2-Clause"
+        ],
+        "authors": [
+            {
+                "name": "Aura.Accept Contributors",
+                "homepage": "https://github.com/auraphp/Aura.Accept/contributors"
+            }
+        ],
+        "description": "Provides content-negotiation tools using Accept* headers.",
+        "homepage": "https://github.com/auraphp/Aura.Accept",
+        "keywords": [
+            "accept",
+            "accept-charset",
+            "accept-encoding",
+            "accept-language",
+            "content negotiation",
+            "content type",
+            "media type"
+        ]
+    }
+]


### PR DESCRIPTION
- Removed hardcoded content types from Symphony's system page types.
- Content types are now configurable in the `config.php`.
- Existing core content types are pre-configured.
- Added `text/plain` and `application/xhtml+xml` as well.
- Fallback is `text/html` if a content type is missing from page types or `config.php`.
- Added new system page type `attachment` that triggers download of page/resource.
- Makes [Content Type Mappings][1] obsolete from a functional point of view.
- Doesn't provide a UI on the preferences page like Content Type Mappings does, so the extension could be updated to provide its UI on top of the core functionality for people who need it.

See discussion #2414 for reference.

Makes sense?

[1]: https://github.com/symphonists/content_type_mappings