### PR TITLE
Escape all commas in filtering suggestions.

### DIFF
--- a/symphony/assets/js/src/symphony.suggestions.js
+++ b/symphony/assets/js/src/symphony.suggestions.js
@@ -325,7 +325,7 @@
 				insert(value, input);
 			}
 			else {
-				input.val(value.replace(',', '\\,'));
+				input.val(value.split(',').join('\\,'));
 				input.addClass('updated');
 				input.change();
 			}


### PR DESCRIPTION
The previous fix replaced the first comma only.

Fixes #2349.