### PR TITLE
Fix author email already exists

### DIFF
--- a/symphony/lib/toolkit/class.author.php
+++ b/symphony/lib/toolkit/class.author.php
@@ -207,7 +207,7 @@ class Author
                     FROM `tbl_authors`
                     WHERE `email` = '%s'",
                     General::sanitize($this->get('email'))
-                )) !== 0
+                )) != 0
             ) {
                 $errors['email'] = __('E-mail address is already taken');
             }


### PR DESCRIPTION
This is similar to an issue which was fixed with the Username. As fetchVar returns a string it always returns false, stating that the email is duplicate.