### PR TITLE
Add delegate for composer to allow use of autoloaded extensions

### DIFF
--- a/index.php
+++ b/index.php
@@ -9,10 +9,24 @@
     ));
 
     // Include autoloader:
-    require_once DOCROOT . '/vendor/autoload.php';
+    $autoloader = require_once DOCROOT . '/vendor/autoload.php';
 
     // Include the boot script:
     require_once DOCROOT . '/symphony/lib/boot/bundle.php';
+
+    /**
+     * When the composer autoloader has been loaded.
+     *
+     * @delegate ComposerReady
+     * @param string $context
+     *  '/all/'
+     * @param Composer\Autoload\ClassLoader $autoloader
+     *  The Composer autoloader.
+     * @since 3.0.0
+     */
+    Symphony::ExtensionManager()->notifyMembers('ComposerReady', '/all/', [
+        'autoloader' => $autoloader
+    ]);
 
     // Begin Symphony proper:
     symphony(APP_MODE);


### PR DESCRIPTION
Using composer means that classes can be added to the autoloader. This delegate allows extensions to use autoloaded classes in their code.

The extension driver need only listen to the delegate and run something like the following

```php
$context['autoloader']->setPsr4('SymphonyCMS\\Extensions\\MyExtensionClass\\', EXTENSIONS . '/extension_name/libs');
```

Based on work by @psychoticmeow 