### PR TITLE
Allow extensions access to the composer autoloader

### DIFF
--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
     ));
 
     // Include autoloader:
-    require_once DOCROOT . '/vendor/autoload.php';
+    $autoloader = require_once DOCROOT . '/vendor/autoload.php';
 
     // Include the boot script:
     require_once DOCROOT . '/symphony/lib/boot/bundle.php';

--- a/symphony/lib/boot/bundle.php
+++ b/symphony/lib/boot/bundle.php
@@ -31,6 +31,20 @@
         Symphony::initialiseDatabase();
         Symphony::initialiseExtensionManager();
 
+        /**
+         * When the composer autoloader has been loaded.
+         * @delegate ComposerReady
+         * @param string $context
+         * '/all/'
+         * @param Composer\Autoload\ClassLoader $autoloader
+         *  The Composer autoloader.
+         */
+        Symphony::ExtensionManager()->notifyMembers(
+            'ComposerReady', '/all/', array(
+                'autoloader' => $autoloader
+            )
+        );
+
         // Handle custom admin paths, #702
         $adminPath = Symphony::Configuration()->get('admin-path', 'symphony');
         $adminPath = (is_null($adminPath)) ? 'symphony' :  $adminPath;


### PR DESCRIPTION
Allow extensions access to the composer autoloader at the earliest possible moment.

In an `extension.driver.php` file:
```php
public function getSubscribedDelegates()
{
    return [
        [
            'page' =>       '*',
            'delegate' =>   'ComposerReady',
            'callback' =>   'onComposerReady'
        ]
    ];
}

public function onComposerReady($context)
{
    $context['autoloader']->setPsr4('SymphonyCMS\\Extensions\\Relationships\\', __DIR__ . '/libs');
}
```