### PR TITLE
set seed to that at start of ds processing

### DIFF
--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -753,7 +753,7 @@ class FrontendPage extends XSLTPage
             uasort($pool, array($this, '__findEventOrder'));
 
             foreach ($pool as $handle => $event) {
-                Symphony::Profiler()->seed();
+                $startTime = precision_timer();
                 $queries = Symphony::Database()->queryCount();
 
                 if ($xml = $event->load()) {
@@ -767,6 +767,7 @@ class FrontendPage extends XSLTPage
                 }
 
                 $queries = Symphony::Database()->queryCount() - $queries;
+                Symphony::Profiler()->seed($startTime);
                 Symphony::Profiler()->sample($handle, PROFILE_LAP, 'Event', $queries);
             }
         }

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -855,7 +855,7 @@ class FrontendPage extends XSLTPage
         $dsOrder = $this->__findDatasourceOrder($dependencies);
 
         foreach ($dsOrder as $handle) {
-            Symphony::Profiler()->seed();
+            $startTime = precision_timer();
             $queries = Symphony::Database()->queryCount();
 
             // default to no XML
@@ -930,6 +930,7 @@ class FrontendPage extends XSLTPage
             }
 
             $queries = Symphony::Database()->queryCount() - $queries;
+            Symphony::Profiler()->seed($startTime);
             Symphony::Profiler()->sample($handle, PROFILE_LAP, 'Datasource', $queries);
             unset($ds);
         }


### PR DESCRIPTION
The seed value gets overwritten by any DatasourcePreExecute and DatasourcePostExecute delegates, thus the timings would be incorrect. This change ensures that the correct profile start time is used when generating profile timing for datasources.