### PR TITLE
Upload Field: Change self:: to static:: to allow overrides

### DIFF
--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -441,7 +441,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
                 }
 
                 if (empty($result['meta'])) {
-                    $result['meta'] = serialize(self::getMetaInfo($file, $result['mimetype']));
+                    $result['meta'] = serialize(static::getMetaInfo($file, $result['mimetype']));
                 }
 
                 // The file was not found, or is unreadable:
@@ -549,7 +549,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
             'file' =>       basename($file),
             'size' =>       $data['size'],
             'mimetype' =>   $data['type'],
-            'meta' =>       serialize(self::getMetaInfo($file, $data['type']))
+            'meta' =>       serialize(static::getMetaInfo($file, $data['type']))
         );
     }
 


### PR DESCRIPTION
This changes will allow field that inherits from fieldUpload to provide a custom version of getMetaInfo()

This is RE: #2432 

Since we do not want to make great chances that might break, this is a really small one with impact only on classes that extends this one. 

I my case (for image_upload_field), I need this functionality.