### PR TITLE
Fix ds profile

### DIFF
--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -753,7 +753,7 @@ class FrontendPage extends XSLTPage
             uasort($pool, array($this, '__findEventOrder'));
 
             foreach ($pool as $handle => $event) {
-                Symphony::Profiler()->seed();
+                $startTime = precision_timer();
                 $queries = Symphony::Database()->queryCount();
 
                 if ($xml = $event->load()) {
@@ -767,6 +767,7 @@ class FrontendPage extends XSLTPage
                 }
 
                 $queries = Symphony::Database()->queryCount() - $queries;
+                Symphony::Profiler()->seed($startTime);
                 Symphony::Profiler()->sample($handle, PROFILE_LAP, 'Event', $queries);
             }
         }

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -855,7 +855,7 @@ class FrontendPage extends XSLTPage
         $dsOrder = $this->__findDatasourceOrder($dependencies);
 
         foreach ($dsOrder as $handle) {
-            Symphony::Profiler()->seed();
+            $startTime = precision_timer();
             $queries = Symphony::Database()->queryCount();
 
             // default to no XML
@@ -930,6 +930,7 @@ class FrontendPage extends XSLTPage
             }
 
             $queries = Symphony::Database()->queryCount() - $queries;
+            Symphony::Profiler()->seed($startTime);
             Symphony::Profiler()->sample($handle, PROFILE_LAP, 'Datasource', $queries);
             unset($ds);
         }


### PR DESCRIPTION
I don't think that I had issues a PR with this before been pending a while. This corrects the amount of time each datasource takes to process, as it would be otherwise restarted by delegates running their own timing functions within a datasource; eg Association Output.