### PR TITLE
Dates not formatted correctly in Select Box Link

### DIFF
--- a/symphony/lib/toolkit/fields/field.date.php
+++ b/symphony/lib/toolkit/fields/field.date.php
@@ -648,8 +648,9 @@ class FieldDate extends Field implements ExportableField, ImportableField
     public function getExportModes()
     {
         return array(
-            'getObject' =>      ExportableField::OBJECT,
-            'getPostdata' =>    ExportableField::POSTDATA
+            'getValue'    => ExportableField::VALUE,
+            'getObject'   => ExportableField::OBJECT,
+            'getPostdata' => ExportableField::POSTDATA
         );
     }
 
@@ -665,6 +666,14 @@ class FieldDate extends Field implements ExportableField, ImportableField
     public function prepareExportValue($data, $mode, $entry_id = null)
     {
         $modes = (object)$this->getExportModes();
+
+        if ($mode === $modes->getValue) {
+
+            return $this->formatDate(
+
+                isset($data['value']) ? $data['value'] : null
+            );
+        }
 
         if ($mode === $modes->getObject) {
             $timezone = Symphony::Configuration()->get('timezone', 'region');


### PR DESCRIPTION
Depending on the field's setting, dates are formatted with or without time on publish page, publish index and association drawer. For Select Box Link values, this setting has been ignored and dates were always formatted with time.

By the way, dates are also formatted even more differently when used as dynamic values for a normal Select Box field (not covered by this change).