### PR TITLE
Added root-dir parameter

### DIFF
--- a/symphony/lib/boot/defines.php
+++ b/symphony/lib/boot/defines.php
@@ -241,11 +241,16 @@ define_safe('__SECURE__',
 );
 
 /**
+ * The root url directory.
+ * @var string
+ */
+define_safe('DIRROOT', rtrim(dirname($_SERVER['PHP_SELF']), '\/'));
+
+/**
  * The current domain name.
  * @var string
  */
-define_safe('DOMAIN', HTTP_HOST . rtrim(dirname($_SERVER['PHP_SELF']), '\/'));
-
+define_safe('DOMAIN', HTTP_HOST . DIRROOT);
 
 /**
  * The base URL of this Symphony install, minus the symphony path.

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -368,6 +368,7 @@ class FrontendPage extends XSLTPage
             'website-name' => Symphony::Configuration()->get('sitename', 'general'),
             'page-title' => $page['title'],
             'root' => URL,
+            'root-dir' => '/' . DIRROOT,
             'workspace' => URL . '/workspace',
             'http-host' => HTTP_HOST,
             'root-page' => ($root_page ? $root_page : $page['handle']),


### PR DESCRIPTION
Now that Symphony can be installed in subfolder, I need to be able to get that subfolder without the domain attached to it.

So I've splitted up the DOMAIN constant to create the DIRROOT constant that contains only the basename of PHP_SELF.

DOMAIN does not change values, so this is not a breaking change.