### PR TITLE
Move date conversion to the PHP level (away from MySQL)

### DIFF
--- a/symphony/lib/toolkit/class.entrymanager.php
+++ b/symphony/lib/toolkit/class.entrymanager.php
@@ -420,8 +420,8 @@ class EntryManager
 
         $sql = sprintf("
             SELECT %s`e`.id, `e`.section_id, e.`author_id`,
-                UNIX_TIMESTAMP(e.`creation_date`) AS `creation_date`,
-                UNIX_TIMESTAMP(e.`modification_date`) AS `modification_date`
+                e.`creation_date` AS `creation_date`,
+                e.`modification_date` AS `modification_date`
             FROM `tbl_entries` AS `e`
             %s
             WHERE 1
@@ -441,6 +441,13 @@ class EntryManager
         );
 
         $rows = Symphony::Database()->fetch($sql);
+
+        // Create UNIX timestamps, as it has always been (Re: #2501)
+        foreach ($rows as &$entry) {
+            $entry['creation_date'] = DateTimeObj::get('U', $entry['creation_date']);
+            $entry['modification_date'] = DateTimeObj::get('U', $entry['modification_date']);
+        }
+        unset($entry);
 
         return ($buildentries && (is_array($rows) && !empty($rows)) ? self::__buildEntries($rows, $section_id, $element_names) : $rows);
     }

--- a/symphony/lib/toolkit/class.entrymanager.php
+++ b/symphony/lib/toolkit/class.entrymanager.php
@@ -419,9 +419,9 @@ class EntryManager
         }
 
         $sql = sprintf("
-            SELECT %s`e`.id, `e`.section_id, e.`author_id`,
-                e.`creation_date` AS `creation_date`,
-                e.`modification_date` AS `modification_date`
+            SELECT %s`e`.`id`, `e`.section_id, `e`.`author_id`,
+                `e`.`creation_date` AS `creation_date`,
+                `e`.`modification_date` AS `modification_date`
             FROM `tbl_entries` AS `e`
             %s
             WHERE 1


### PR DESCRIPTION
This fix moves date conversion to the PHP level (not MySQL).

Creating timestamps (from datetime strings) in MySQL would only work as intended if MySQL was aware of a named timezone including daylight saving time (DST) logic. Unfortunately, Symphony can only set a fixed time offset - and not a named timezone - for database connections, because it must be friendly to shared hosting environments. So date conversion in MySQL can produce wrong results for system dates, because these have been saved without an explicit (DST/non-DST) offset. The solution is to perform date conversion in PHP exclusively, because Symphony’s `DateTimeObj` will assume the correct time offset.
