### PR TITLE
More url input sanitizing

### DIFF
--- a/symphony/lib/boot/bundle.php
+++ b/symphony/lib/boot/bundle.php
@@ -31,8 +31,8 @@
         // Handle custom admin paths, #702
         $adminPath = Symphony::Configuration()->get('admin-path', 'symphony');
         $adminPath = (is_null($adminPath)) ? 'symphony' :  $adminPath;
-        if (isset($_GET['symphony-page']) && strpos($_GET['symphony-page'], $adminPath, 0) === 0) {
-            $_GET['symphony-page'] = preg_replace('%^' . preg_quote($adminPath) . '\/%', '', $_GET['symphony-page'], 1);
+        if (strpos(getCurrentPage(), $adminPath, 0) === 0) {
+            $_GET['symphony-page'] = preg_replace('%^' . preg_quote($adminPath) . '\/%', '', getCurrentPage(), 1);
 
             if ($_GET['symphony-page'] == '') {
                 unset($_GET['symphony-page']);

--- a/symphony/lib/boot/func.utilities.php
+++ b/symphony/lib/boot/func.utilities.php
@@ -75,7 +75,7 @@ function define_safe($name, $value)
  */
 function getCurrentPage()
 {
-    if (!isset($_GET['symphony-page'])) {
+    if (!isset($_GET['symphony-page']) || !is_string($_GET['symphony-page'])) {
         return null;
     }
 
@@ -222,7 +222,7 @@ function symphony($mode)
  */
 function symphony_launcher($mode)
 {
-    if (strtolower($mode) == 'administration') {
+    if (is_string($mode) && strtolower($mode) == 'administration') {
         $renderer = Administration::instance();
     } else {
         $renderer = Frontend::instance();


### PR DESCRIPTION
This commits prevents full path disclosure (and fatal errors) if the
mode or symphony-path $_GET values are not strings. Since symphony's
parses query[]= as strings, this check is required before any str*
calls.