### PR TITLE
Removed dead __SYM_DB_INSERT_FAILED__ const

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -1122,7 +1122,6 @@ class contentPublish extends AdministrationPage
 
                 // Check to see if the dancing was premature
                 if (!$entry->commit()) {
-                    define_safe('__SYM_DB_INSERT_FAILED__', true);
                     $this->pageAlert(null, Alert::ERROR);
                 } else {
                     /**
@@ -1402,7 +1401,6 @@ class contentPublish extends AdministrationPage
 
                 // Check to see if the dancing was premature
                 if (!$entry->commit()) {
-                    define_safe('__SYM_DB_INSERT_FAILED__', true);
                     $this->pageAlert(null, Alert::ERROR);
                 } else {
                     /**


### PR DESCRIPTION
I've made a git blame to try to find the origin of this but I could not
find anything since it was part of the original commit (7f90fa0) !

Nothing in the current base code checks its value.