### PR TITLE
Better error handling and disabled display of exception data by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to Symphony
+
+This is a TL;DR version of the [complete contribution guide](https://github.com/symphonycms/symphony-2/wiki/Contributing-to-Symphony).
+
+The two most important things are [comments](https://github.com/symphonycms/symphony-2/wiki/Contributing-to-Symphony#commenting) and [https://github.com/symphonycms/symphony-2/wiki/Contributing-to-Symphony#code-style](code style).
+
+Please insure that any new method is properly documented and that the code style is respected.
+
+Thanks!
+
+- The Symphony Team
+
+### Legal
+
+This submitting your code to the community, you agree to release all copyrights on the code you submit.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+Affected Symphony version(s) :
+PHP version(s) :
+OS(es) :

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Fix for #
+
+or
+
+Describe new feature here

--- a/README.markdown
+++ b/README.markdown
@@ -8,6 +8,7 @@
 - Date: 08th February 2016
 - [Release notes](http://getsymphony.com/download/releases/version/2.6.7/)
 - [Github repository](https://github.com/symphonycms/symphony-2/tree/2.6.7)
+- [MIT Licence](https://github.com/symphonycms/symphony-2/blob/master/LICENCE)
 
 ## Contents
 

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
       "issues": "https://github.com/symphonycms/symphony-2/issues",
       "wiki": "https://github.com/symphonycms/symphony-2/wiki"
     },
+    "require-dev": {
+        "squizlabs/php_codesniffer": "2.*"
+    },
     "minimum-stability": "stable",
     "autoload": {
       "classmap": ["symphony/content", "symphony/lib", "symphony/template", "install"],

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -127,6 +127,23 @@ module.exports = function (grunt) {
             scripts: {
                 files: 'symphony/assets/js/src/*.js',
                 tasks: ['js']
+            },
+            php: {
+                files: ['symphony/**/*.php', 'install/**/*.php'],
+                tasks: ['php']
+            }
+        },
+
+        phpcs: {
+            application: {
+                src: ['symphony/**/*.php', 'install/**/*.php', 'index.php']
+            },
+            options: {
+                bin: 'vendor/bin/phpcs',
+                standard: 'PSR1',
+                showSniffCodes: true,
+                tabWidth: 4,
+                errorSeverity: 10
             }
         }
 
@@ -138,8 +155,10 @@ module.exports = function (grunt) {
     //grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-phpcs');
 
     grunt.registerTask('default', ['concat', 'autoprefixer', 'csso', 'uglify']);
     grunt.registerTask('css', ['concat', 'autoprefixer', 'csso']);
+    grunt.registerTask('php', ['phpcs']);
     grunt.registerTask('js', ['uglify']);
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -101,6 +101,7 @@ module.exports = function (grunt) {
                         'symphony/assets/js/src/symphony.js',
                         'symphony/assets/js/src/symphony.affix.js',
                         'symphony/assets/js/src/symphony.collapsible.js',
+                        'symphony/assets/js/src/symphony.defaultvalue.js',
                         'symphony/assets/js/src/symphony.orderable.js',
                         'symphony/assets/js/src/symphony.selectable.js',
                         'symphony/assets/js/src/symphony.duplicator.js',

--- a/index.php
+++ b/index.php
@@ -3,6 +3,9 @@
     // Find out where we are:
     define('DOCROOT', __DIR__);
 
+    // Propagate this change to all executables:
+    chdir(DOCROOT);
+
     // Include autoloader:
     require_once DOCROOT . '/vendor/autoload.php';
 

--- a/install/includes/htaccess.txt
+++ b/install/includes/htaccess.txt
@@ -12,7 +12,7 @@ Options +SymLinksIfOwnerMatch -Indexes
     </IfModule>
 
     RewriteEngine on
-    RewriteBase /<!-- REWRITE_BASE -->
+    RewriteBase "/<!-- REWRITE_BASE -->"
 
     ### SECURITY - Protect crucial files
     RewriteRule ^manifest/(.*)$ - [F]

--- a/install/includes/install.sql
+++ b/install/includes/install.sql
@@ -7,7 +7,7 @@ CREATE TABLE `tbl_authors` (
   `first_name` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
   `last_name` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
   `email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `last_seen` datetime DEFAULT '0000-00-00 00:00:00',
+  `last_seen` datetime DEFAULT '1000-01-01 00:00:00',
   `user_type` enum('author','manager','developer') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'author',
   `primary` enum('yes','no') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'no',
   `default_area` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,

--- a/install/lib/class.installer.php
+++ b/install/lib/class.installer.php
@@ -456,7 +456,7 @@
                     'last_seen'             => null,
                     'user_type'             => 'developer',
                     'primary'               => 'yes',
-                    'default_area'          => null,
+                    'default_area'          => '/blueprints/sections/',
                     'auth_token_active'     => 'no'
                 ), 'tbl_authors');
             } catch (DatabaseException $e) {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "license": "MIT",
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-autoprefixer": "~3.0.3",
-    "grunt-csso": "~0.8.0",
-    "grunt-contrib-jshint": "~0.11.3",
-    "grunt-contrib-uglify": "~0.11.0",
+    "grunt-autoprefixer": "~3.0.4",
+    "grunt-csso": "~0.8.1",
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-contrib-uglify": "~0.11.1",
     "grunt-contrib-concat": "~0.5.1",
     "grunt-contrib-watch": "~0.6.1"
   }

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-autoprefixer": "~3.0.4",
-    "grunt-csso": "~0.8.1",
+    "grunt-contrib-concat": "~0.5.1",
     "grunt-contrib-jshint": "~1.0.0",
     "grunt-contrib-uglify": "~0.11.1",
-    "grunt-contrib-concat": "~0.5.1",
-    "grunt-contrib-watch": "~0.6.1"
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-csso": "~0.8.1",
+    "grunt-phpcs": "^0.4.0"
   }
 }

--- a/symphony/assets/js/src/backend.views.js
+++ b/symphony/assets/js/src/backend.views.js
@@ -606,6 +606,10 @@ Symphony.View.add('/blueprints/datasources/:action:/:id:/:status:/:*:', function
 				});
 			}
 		}, 500, nameChangeCount, current, value);
+	})
+	// Enable the default value for Data Source name
+	.symphonyDefaultValue({
+		sourceElement: context
 	});
 
 	// Update output parameters
@@ -735,6 +739,10 @@ Symphony.View.add('/blueprints/events/:action:/:name:/:status:/:*:', function() 
 				Symphony.Elements.contents.trigger('update.admin');
 			}
 		}, 500, nameChangeCount, current);
+	})
+	// Enable the default value for Event name
+	.symphonyDefaultValue({
+		sourceElement: context
 	});
 
 	// Change context

--- a/symphony/assets/js/src/symphony.defaultvalue.js
+++ b/symphony/assets/js/src/symphony.defaultvalue.js
@@ -1,0 +1,95 @@
+/**
+ * @package assets
+ */
+
+(function($, Symphony) {
+
+	/**
+	 * Fills the target input/textarea with a value from the source element.
+	 * The plugin cease to change the value when the target is edited by the user and has a value.
+	 *
+	 * @name $.symphonyDefaultValue
+	 * @class
+	 *
+	 * @param {Object} options An object specifying containing the attributes specified below
+	 * @param {String} [options.sourceElement='.js-defaultvalue-source'] Selector to find the default value
+	 * @param {String} [options.sourceEvent='select'] The event that triggers setting the value in the target element
+	 * @param {String} [options.targetEvent='keyup blur'] The event(s) to watch for user interaction
+	 *
+	 * @example
+
+			$('.js-defaultvalue-target').symphonyDefaultValue();
+	 */
+	$.fn.symphonyDefaultValue = function(options) {
+		var objects = this,
+			isOn = false,
+			settings = {
+				sourceElement: '.js-defaultvalue-source',
+				sourceEvent: 'change',
+				targetEvent: 'keyup blur'
+			};
+
+		$.extend(settings, options);
+
+		// append our namespace on the sourceEvent
+		settings.sourceEvent += '.symphony-defaultvalue';
+
+		var source = $(settings.sourceElement);
+
+		var getTargetValue = function () {
+			return objects.val();
+		};
+
+		var setTargetValue = function (val) {
+			objects.val(val);
+		};
+
+		var getSourceValue = function () {
+			return source.find('option:selected').text();
+		};
+
+		var sourceChanged = function (e) {
+			if (isOn) {
+				setTargetValue(getSourceValue());
+			}
+		};
+
+		var on = function () {
+			if (isOn) {
+				return;
+			}
+			source.on(settings.sourceEvent, sourceChanged);
+			isOn = true;
+		};
+
+		var off = function () {
+			if (!isOn) {
+				return;
+			}
+			$(settings.sourceElement).off(settings.sourceEvent);
+			isOn = false;
+		};
+
+	/*-------------------------------------------------------------------------
+		Initialisation
+	-------------------------------------------------------------------------*/
+
+		objects.on(settings.targetEvent, function (e) {
+			if (!getTargetValue()) {
+				on();
+			}
+			else {
+				off();
+			}
+		});
+
+		if (!getTargetValue()) {
+			on();
+		}
+
+	/*-----------------------------------------------------------------------*/
+
+		return objects;
+	};
+
+})(window.jQuery, window.Symphony);

--- a/symphony/assets/js/src/symphony.filtering.js
+++ b/symphony/assets/js/src/symphony.filtering.js
@@ -88,12 +88,13 @@
 			var item = $(this),
 				comparison;
 
-			// Show help contextually
+			// Case: Adding a new filter instance
 			if(item.is('.instance')) {
-				comparison = item.find('.comparison').val();
+				comparison = item.find('.comparison option:selected').attr('data-comparison');
 			}
+			// Case: selecting a new comparison mode of an existing filter instance
 			else {
-				comparison = item.val();
+				comparison = item.find('option:selected').attr('data-comparison');
 				item = item.parents('.instance');
 			}
 
@@ -127,15 +128,15 @@
 
 			filtering.find('.instance:not(.template):visible').each(function() {
 				var item = $(this),
-					comparison = $.trim(item.find('.comparison').val()),
+					filterPrefix = item.find('.comparison').val(),
 					query = item.find('.filter'),
 					value;
 
-				if (!!comparison) {
-					comparison = comparison + ' ';
+				if (filterPrefix.length === 0 || !filterPrefix.trim()) {
+					filterPrefix = '';
 				}
 
-				value = 'filter[' + query.attr('name') + ']=' + comparison + $.trim(query.val());
+				value = 'filter[' + query.attr('name') + ']=' + filterPrefix + $.trim(query.val());
 				filters.push(value);
 			});
 

--- a/symphony/assets/js/symphony.min.js
+++ b/symphony/assets/js/symphony.min.js
@@ -11,7 +11,353 @@
  *
  * Date: 2015-04-28T16:01Z
  */
-!function(a,b){"object"==typeof module&&"object"==typeof module.exports?module.exports=a.document?b(a,!0):function(a){if(!a.document)throw new Error("jQuery requires a window with a document");return b(a)}:b(a)}("undefined"!=typeof window?window:this,function(a,b){function c(a){var b="length"in a&&a.length,c=_.type(a);return"function"===c||_.isWindow(a)?!1:1===a.nodeType&&b?!0:"array"===c||0===b||"number"==typeof b&&b>0&&b-1 in a}function d(a,b,c){if(_.isFunction(b))return _.grep(a,function(a,d){return!!b.call(a,d,a)!==c});if(b.nodeType)return _.grep(a,function(a){return a===b!==c});if("string"==typeof b){if(ha.test(b))return _.filter(b,a,c);b=_.filter(b,a)}return _.grep(a,function(a){return U.call(b,a)>=0!==c})}function e(a,b){for(;(a=a[b])&&1!==a.nodeType;);return a}function f(a){var b=oa[a]={};return _.each(a.match(na)||[],function(a,c){b[c]=!0}),b}function g(){Z.removeEventListener("DOMContentLoaded",g,!1),a.removeEventListener("load",g,!1),_.ready()}function h(){Object.defineProperty(this.cache={},0,{get:function(){return{}}}),this.expando=_.expando+h.uid++}function i(a,b,c){var d;if(void 0===c&&1===a.nodeType)if(d="data-"+b.replace(ua,"-$1").toLowerCase(),c=a.getAttribute(d),"string"==typeof c){try{c="true"===c?!0:"false"===c?!1:"null"===c?null:+c+""===c?+c:ta.test(c)?_.parseJSON(c):c}catch(e){}sa.set(a,b,c)}else c=void 0;return c}function j(){return!0}function k(){return!1}function l(){try{return Z.activeElement}catch(a){}}function m(a,b){return _.nodeName(a,"table")&&_.nodeName(11!==b.nodeType?b:b.firstChild,"tr")?a.getElementsByTagName("tbody")[0]||a.appendChild(a.ownerDocument.createElement("tbody")):a}function n(a){return a.type=(null!==a.getAttribute("type"))+"/"+a.type,a}function o(a){var b=Ka.exec(a.type);return b?a.type=b[1]:a.removeAttribute("type"),a}function p(a,b){for(var c=0,d=a.length;d>c;c++)ra.set(a[c],"globalEval",!b||ra.get(b[c],"globalEval"))}function q(a,b){var c,d,e,f,g,h,i,j;if(1===b.nodeType){if(ra.hasData(a)&&(f=ra.access(a),g=ra.set(b,f),j=f.events)){delete g.handle,g.events={};for(e in j)for(c=0,d=j[e].length;d>c;c++)_.event.add(b,e,j[e][c])}sa.hasData(a)&&(h=sa.access(a),i=_.extend({},h),sa.set(b,i))}}function r(a,b){var c=a.getElementsByTagName?a.getElementsByTagName(b||"*"):a.querySelectorAll?a.querySelectorAll(b||"*"):[];return void 0===b||b&&_.nodeName(a,b)?_.merge([a],c):c}function s(a,b){var c=b.nodeName.toLowerCase();"input"===c&&ya.test(a.type)?b.checked=a.checked:("input"===c||"textarea"===c)&&(b.defaultValue=a.defaultValue)}function t(b,c){var d,e=_(c.createElement(b)).appendTo(c.body),f=a.getDefaultComputedStyle&&(d=a.getDefaultComputedStyle(e[0]))?d.display:_.css(e[0],"display");return e.detach(),f}function u(a){var b=Z,c=Oa[a];return c||(c=t(a,b),"none"!==c&&c||(Na=(Na||_("<iframe frameborder='0' width='0' height='0'/>")).appendTo(b.documentElement),b=Na[0].contentDocument,b.write(),b.close(),c=t(a,b),Na.detach()),Oa[a]=c),c}function v(a,b,c){var d,e,f,g,h=a.style;return c=c||Ra(a),c&&(g=c.getPropertyValue(b)||c[b]),c&&(""!==g||_.contains(a.ownerDocument,a)||(g=_.style(a,b)),Qa.test(g)&&Pa.test(b)&&(d=h.width,e=h.minWidth,f=h.maxWidth,h.minWidth=h.maxWidth=h.width=g,g=c.width,h.width=d,h.minWidth=e,h.maxWidth=f)),void 0!==g?g+"":g}function w(a,b){return{get:function(){return a()?void delete this.get:(this.get=b).apply(this,arguments)}}}function x(a,b){if(b in a)return b;for(var c=b[0].toUpperCase()+b.slice(1),d=b,e=Xa.length;e--;)if(b=Xa[e]+c,b in a)return b;return d}function y(a,b,c){var d=Ta.exec(b);return d?Math.max(0,d[1]-(c||0))+(d[2]||"px"):b}function z(a,b,c,d,e){for(var f=c===(d?"border":"content")?4:"width"===b?1:0,g=0;4>f;f+=2)"margin"===c&&(g+=_.css(a,c+wa[f],!0,e)),d?("content"===c&&(g-=_.css(a,"padding"+wa[f],!0,e)),"margin"!==c&&(g-=_.css(a,"border"+wa[f]+"Width",!0,e))):(g+=_.css(a,"padding"+wa[f],!0,e),"padding"!==c&&(g+=_.css(a,"border"+wa[f]+"Width",!0,e)));return g}function A(a,b,c){var d=!0,e="width"===b?a.offsetWidth:a.offsetHeight,f=Ra(a),g="border-box"===_.css(a,"boxSizing",!1,f);if(0>=e||null==e){if(e=v(a,b,f),(0>e||null==e)&&(e=a.style[b]),Qa.test(e))return e;d=g&&(Y.boxSizingReliable()||e===a.style[b]),e=parseFloat(e)||0}return e+z(a,b,c||(g?"border":"content"),d,f)+"px"}function B(a,b){for(var c,d,e,f=[],g=0,h=a.length;h>g;g++)d=a[g],d.style&&(f[g]=ra.get(d,"olddisplay"),c=d.style.display,b?(f[g]||"none"!==c||(d.style.display=""),""===d.style.display&&xa(d)&&(f[g]=ra.access(d,"olddisplay",u(d.nodeName)))):(e=xa(d),"none"===c&&e||ra.set(d,"olddisplay",e?c:_.css(d,"display"))));for(g=0;h>g;g++)d=a[g],d.style&&(b&&"none"!==d.style.display&&""!==d.style.display||(d.style.display=b?f[g]||"":"none"));return a}function C(a,b,c,d,e){return new C.prototype.init(a,b,c,d,e)}function D(){return setTimeout(function(){Ya=void 0}),Ya=_.now()}function E(a,b){var c,d=0,e={height:a};for(b=b?1:0;4>d;d+=2-b)c=wa[d],e["margin"+c]=e["padding"+c]=a;return b&&(e.opacity=e.width=a),e}function F(a,b,c){for(var d,e=(cb[b]||[]).concat(cb["*"]),f=0,g=e.length;g>f;f++)if(d=e[f].call(c,b,a))return d}function G(a,b,c){var d,e,f,g,h,i,j,k,l=this,m={},n=a.style,o=a.nodeType&&xa(a),p=ra.get(a,"fxshow");c.queue||(h=_._queueHooks(a,"fx"),null==h.unqueued&&(h.unqueued=0,i=h.empty.fire,h.empty.fire=function(){h.unqueued||i()}),h.unqueued++,l.always(function(){l.always(function(){h.unqueued--,_.queue(a,"fx").length||h.empty.fire()})})),1===a.nodeType&&("height"in b||"width"in b)&&(c.overflow=[n.overflow,n.overflowX,n.overflowY],j=_.css(a,"display"),k="none"===j?ra.get(a,"olddisplay")||u(a.nodeName):j,"inline"===k&&"none"===_.css(a,"float")&&(n.display="inline-block")),c.overflow&&(n.overflow="hidden",l.always(function(){n.overflow=c.overflow[0],n.overflowX=c.overflow[1],n.overflowY=c.overflow[2]}));for(d in b)if(e=b[d],$a.exec(e)){if(delete b[d],f=f||"toggle"===e,e===(o?"hide":"show")){if("show"!==e||!p||void 0===p[d])continue;o=!0}m[d]=p&&p[d]||_.style(a,d)}else j=void 0;if(_.isEmptyObject(m))"inline"===("none"===j?u(a.nodeName):j)&&(n.display=j);else{p?"hidden"in p&&(o=p.hidden):p=ra.access(a,"fxshow",{}),f&&(p.hidden=!o),o?_(a).show():l.done(function(){_(a).hide()}),l.done(function(){var b;ra.remove(a,"fxshow");for(b in m)_.style(a,b,m[b])});for(d in m)g=F(o?p[d]:0,d,l),d in p||(p[d]=g.start,o&&(g.end=g.start,g.start="width"===d||"height"===d?1:0))}}function H(a,b){var c,d,e,f,g;for(c in a)if(d=_.camelCase(c),e=b[d],f=a[c],_.isArray(f)&&(e=f[1],f=a[c]=f[0]),c!==d&&(a[d]=f,delete a[c]),g=_.cssHooks[d],g&&"expand"in g){f=g.expand(f),delete a[d];for(c in f)c in a||(a[c]=f[c],b[c]=e)}else b[d]=e}function I(a,b,c){var d,e,f=0,g=bb.length,h=_.Deferred().always(function(){delete i.elem}),i=function(){if(e)return!1;for(var b=Ya||D(),c=Math.max(0,j.startTime+j.duration-b),d=c/j.duration||0,f=1-d,g=0,i=j.tweens.length;i>g;g++)j.tweens[g].run(f);return h.notifyWith(a,[j,f,c]),1>f&&i?c:(h.resolveWith(a,[j]),!1)},j=h.promise({elem:a,props:_.extend({},b),opts:_.extend(!0,{specialEasing:{}},c),originalProperties:b,originalOptions:c,startTime:Ya||D(),duration:c.duration,tweens:[],createTween:function(b,c){var d=_.Tween(a,j.opts,b,c,j.opts.specialEasing[b]||j.opts.easing);return j.tweens.push(d),d},stop:function(b){var c=0,d=b?j.tweens.length:0;if(e)return this;for(e=!0;d>c;c++)j.tweens[c].run(1);return b?h.resolveWith(a,[j,b]):h.rejectWith(a,[j,b]),this}}),k=j.props;for(H(k,j.opts.specialEasing);g>f;f++)if(d=bb[f].call(j,a,k,j.opts))return d;return _.map(k,F,j),_.isFunction(j.opts.start)&&j.opts.start.call(a,j),_.fx.timer(_.extend(i,{elem:a,anim:j,queue:j.opts.queue})),j.progress(j.opts.progress).done(j.opts.done,j.opts.complete).fail(j.opts.fail).always(j.opts.always)}function J(a){return function(b,c){"string"!=typeof b&&(c=b,b="*");var d,e=0,f=b.toLowerCase().match(na)||[];if(_.isFunction(c))for(;d=f[e++];)"+"===d[0]?(d=d.slice(1)||"*",(a[d]=a[d]||[]).unshift(c)):(a[d]=a[d]||[]).push(c)}}function K(a,b,c,d){function e(h){var i;return f[h]=!0,_.each(a[h]||[],function(a,h){var j=h(b,c,d);return"string"!=typeof j||g||f[j]?g?!(i=j):void 0:(b.dataTypes.unshift(j),e(j),!1)}),i}var f={},g=a===tb;return e(b.dataTypes[0])||!f["*"]&&e("*")}function L(a,b){var c,d,e=_.ajaxSettings.flatOptions||{};for(c in b)void 0!==b[c]&&((e[c]?a:d||(d={}))[c]=b[c]);return d&&_.extend(!0,a,d),a}function M(a,b,c){for(var d,e,f,g,h=a.contents,i=a.dataTypes;"*"===i[0];)i.shift(),void 0===d&&(d=a.mimeType||b.getResponseHeader("Content-Type"));if(d)for(e in h)if(h[e]&&h[e].test(d)){i.unshift(e);break}if(i[0]in c)f=i[0];else{for(e in c){if(!i[0]||a.converters[e+" "+i[0]]){f=e;break}g||(g=e)}f=f||g}return f?(f!==i[0]&&i.unshift(f),c[f]):void 0}function N(a,b,c,d){var e,f,g,h,i,j={},k=a.dataTypes.slice();if(k[1])for(g in a.converters)j[g.toLowerCase()]=a.converters[g];for(f=k.shift();f;)if(a.responseFields[f]&&(c[a.responseFields[f]]=b),!i&&d&&a.dataFilter&&(b=a.dataFilter(b,a.dataType)),i=f,f=k.shift())if("*"===f)f=i;else if("*"!==i&&i!==f){if(g=j[i+" "+f]||j["* "+f],!g)for(e in j)if(h=e.split(" "),h[1]===f&&(g=j[i+" "+h[0]]||j["* "+h[0]])){g===!0?g=j[e]:j[e]!==!0&&(f=h[0],k.unshift(h[1]));break}if(g!==!0)if(g&&a["throws"])b=g(b);else try{b=g(b)}catch(l){return{state:"parsererror",error:g?l:"No conversion from "+i+" to "+f}}}return{state:"success",data:b}}function O(a,b,c,d){var e;if(_.isArray(b))_.each(b,function(b,e){c||yb.test(a)?d(a,e):O(a+"["+("object"==typeof e?b:"")+"]",e,c,d)});else if(c||"object"!==_.type(b))d(a,b);else for(e in b)O(a+"["+e+"]",b[e],c,d)}function P(a){return _.isWindow(a)?a:9===a.nodeType&&a.defaultView}var Q=[],R=Q.slice,S=Q.concat,T=Q.push,U=Q.indexOf,V={},W=V.toString,X=V.hasOwnProperty,Y={},Z=a.document,$="2.1.4",_=function(a,b){return new _.fn.init(a,b)},aa=/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g,ba=/^-ms-/,ca=/-([\da-z])/gi,da=function(a,b){return b.toUpperCase()};_.fn=_.prototype={jquery:$,constructor:_,selector:"",length:0,toArray:function(){return R.call(this)},get:function(a){return null!=a?0>a?this[a+this.length]:this[a]:R.call(this)},pushStack:function(a){var b=_.merge(this.constructor(),a);return b.prevObject=this,b.context=this.context,b},each:function(a,b){return _.each(this,a,b)},map:function(a){return this.pushStack(_.map(this,function(b,c){return a.call(b,c,b)}))},slice:function(){return this.pushStack(R.apply(this,arguments))},first:function(){return this.eq(0)},last:function(){return this.eq(-1)},eq:function(a){var b=this.length,c=+a+(0>a?b:0);return this.pushStack(c>=0&&b>c?[this[c]]:[])},end:function(){return this.prevObject||this.constructor(null)},push:T,sort:Q.sort,splice:Q.splice},_.extend=_.fn.extend=function(){var a,b,c,d,e,f,g=arguments[0]||{},h=1,i=arguments.length,j=!1;for("boolean"==typeof g&&(j=g,g=arguments[h]||{},h++),"object"==typeof g||_.isFunction(g)||(g={}),h===i&&(g=this,h--);i>h;h++)if(null!=(a=arguments[h]))for(b in a)c=g[b],d=a[b],g!==d&&(j&&d&&(_.isPlainObject(d)||(e=_.isArray(d)))?(e?(e=!1,f=c&&_.isArray(c)?c:[]):f=c&&_.isPlainObject(c)?c:{},g[b]=_.extend(j,f,d)):void 0!==d&&(g[b]=d));return g},_.extend({expando:"jQuery"+($+Math.random()).replace(/\D/g,""),isReady:!0,error:function(a){throw new Error(a)},noop:function(){},isFunction:function(a){return"function"===_.type(a)},isArray:Array.isArray,isWindow:function(a){return null!=a&&a===a.window},isNumeric:function(a){return!_.isArray(a)&&a-parseFloat(a)+1>=0},isPlainObject:function(a){return"object"!==_.type(a)||a.nodeType||_.isWindow(a)?!1:a.constructor&&!X.call(a.constructor.prototype,"isPrototypeOf")?!1:!0},isEmptyObject:function(a){var b;for(b in a)return!1;return!0},type:function(a){return null==a?a+"":"object"==typeof a||"function"==typeof a?V[W.call(a)]||"object":typeof a},globalEval:function(a){var b,c=eval;a=_.trim(a),a&&(1===a.indexOf("use strict")?(b=Z.createElement("script"),b.text=a,Z.head.appendChild(b).parentNode.removeChild(b)):c(a))},camelCase:function(a){return a.replace(ba,"ms-").replace(ca,da)},nodeName:function(a,b){return a.nodeName&&a.nodeName.toLowerCase()===b.toLowerCase()},each:function(a,b,d){var e,f=0,g=a.length,h=c(a);if(d){if(h)for(;g>f&&(e=b.apply(a[f],d),e!==!1);f++);else for(f in a)if(e=b.apply(a[f],d),e===!1)break}else if(h)for(;g>f&&(e=b.call(a[f],f,a[f]),e!==!1);f++);else for(f in a)if(e=b.call(a[f],f,a[f]),e===!1)break;return a},trim:function(a){return null==a?"":(a+"").replace(aa,"")},makeArray:function(a,b){var d=b||[];return null!=a&&(c(Object(a))?_.merge(d,"string"==typeof a?[a]:a):T.call(d,a)),d},inArray:function(a,b,c){return null==b?-1:U.call(b,a,c)},merge:function(a,b){for(var c=+b.length,d=0,e=a.length;c>d;d++)a[e++]=b[d];return a.length=e,a},grep:function(a,b,c){for(var d,e=[],f=0,g=a.length,h=!c;g>f;f++)d=!b(a[f],f),d!==h&&e.push(a[f]);return e},map:function(a,b,d){var e,f=0,g=a.length,h=c(a),i=[];if(h)for(;g>f;f++)e=b(a[f],f,d),null!=e&&i.push(e);else for(f in a)e=b(a[f],f,d),null!=e&&i.push(e);return S.apply([],i)},guid:1,proxy:function(a,b){var c,d,e;return"string"==typeof b&&(c=a[b],b=a,a=c),_.isFunction(a)?(d=R.call(arguments,2),e=function(){return a.apply(b||this,d.concat(R.call(arguments)))},e.guid=a.guid=a.guid||_.guid++,e):void 0},now:Date.now,support:Y}),_.each("Boolean Number String Function Array Date RegExp Object Error".split(" "),function(a,b){V["[object "+b+"]"]=b.toLowerCase()});var ea=/*!
+!function(a,b){"object"==typeof module&&"object"==typeof module.exports?
+// For CommonJS and CommonJS-like environments where a proper `window`
+// is present, execute the factory and get jQuery.
+// For environments that do not have a `window` with a `document`
+// (such as Node.js), expose a factory as module.exports.
+// This accentuates the need for the creation of a real `window`.
+// e.g. var jQuery = require("jquery")(window);
+// See ticket #14549 for more info.
+module.exports=a.document?b(a,!0):function(a){if(!a.document)throw new Error("jQuery requires a window with a document");return b(a)}:b(a)}("undefined"!=typeof window?window:this,function(a,b){function c(a){
+// Support: iOS 8.2 (not reproducible in simulator)
+// `in` check used to prevent JIT error (gh-2145)
+// hasOwn isn't used here due to false negatives
+// regarding Nodelist length in IE
+var b="length"in a&&a.length,c=_.type(a);return"function"===c||_.isWindow(a)?!1:1===a.nodeType&&b?!0:"array"===c||0===b||"number"==typeof b&&b>0&&b-1 in a}
+// Implement the identical functionality for filter and not
+function d(a,b,c){if(_.isFunction(b))return _.grep(a,function(a,d){/* jshint -W018 */
+return!!b.call(a,d,a)!==c});if(b.nodeType)return _.grep(a,function(a){return a===b!==c});if("string"==typeof b){if(ha.test(b))return _.filter(b,a,c);b=_.filter(b,a)}return _.grep(a,function(a){return U.call(b,a)>=0!==c})}function e(a,b){for(;(a=a[b])&&1!==a.nodeType;);return a}
+// Convert String-formatted options into Object-formatted ones and store in cache
+function f(a){var b=oa[a]={};return _.each(a.match(na)||[],function(a,c){b[c]=!0}),b}/**
+ * The ready event handler and self cleanup method
+ */
+function g(){Z.removeEventListener("DOMContentLoaded",g,!1),a.removeEventListener("load",g,!1),_.ready()}function h(){
+// Support: Android<4,
+// Old WebKit does not have Object.preventExtensions/freeze method,
+// return new empty object instead with no [[set]] accessor
+Object.defineProperty(this.cache={},0,{get:function(){return{}}}),this.expando=_.expando+h.uid++}function i(a,b,c){var d;
+// If nothing was found internally, try to fetch any
+// data from the HTML5 data-* attribute
+if(void 0===c&&1===a.nodeType)if(d="data-"+b.replace(ua,"-$1").toLowerCase(),c=a.getAttribute(d),"string"==typeof c){try{c="true"===c?!0:"false"===c?!1:"null"===c?null:+c+""===c?+c:ta.test(c)?_.parseJSON(c):c}catch(e){}
+// Make sure we set the data so it isn't changed later
+sa.set(a,b,c)}else c=void 0;return c}function j(){return!0}function k(){return!1}function l(){try{return Z.activeElement}catch(a){}}
+// Support: 1.x compatibility
+// Manipulating tables requires a tbody
+function m(a,b){return _.nodeName(a,"table")&&_.nodeName(11!==b.nodeType?b:b.firstChild,"tr")?a.getElementsByTagName("tbody")[0]||a.appendChild(a.ownerDocument.createElement("tbody")):a}
+// Replace/restore the type attribute of script elements for safe DOM manipulation
+function n(a){return a.type=(null!==a.getAttribute("type"))+"/"+a.type,a}function o(a){var b=Ka.exec(a.type);return b?a.type=b[1]:a.removeAttribute("type"),a}
+// Mark scripts as having already been evaluated
+function p(a,b){for(var c=0,d=a.length;d>c;c++)ra.set(a[c],"globalEval",!b||ra.get(b[c],"globalEval"))}function q(a,b){var c,d,e,f,g,h,i,j;if(1===b.nodeType){
+// 1. Copy private data: events, handlers, etc.
+if(ra.hasData(a)&&(f=ra.access(a),g=ra.set(b,f),j=f.events)){delete g.handle,g.events={};for(e in j)for(c=0,d=j[e].length;d>c;c++)_.event.add(b,e,j[e][c])}
+// 2. Copy user data
+sa.hasData(a)&&(h=sa.access(a),i=_.extend({},h),sa.set(b,i))}}function r(a,b){var c=a.getElementsByTagName?a.getElementsByTagName(b||"*"):a.querySelectorAll?a.querySelectorAll(b||"*"):[];return void 0===b||b&&_.nodeName(a,b)?_.merge([a],c):c}
+// Fix IE bugs, see support tests
+function s(a,b){var c=b.nodeName.toLowerCase();
+// Fails to persist the checked state of a cloned checkbox or radio button.
+"input"===c&&ya.test(a.type)?b.checked=a.checked:("input"===c||"textarea"===c)&&(b.defaultValue=a.defaultValue)}/**
+ * Retrieve the actual display of a element
+ * @param {String} name nodeName of the element
+ * @param {Object} doc Document object
+ */
+// Called only from within defaultDisplay
+function t(b,c){var d,e=_(c.createElement(b)).appendTo(c.body),
+// getDefaultComputedStyle might be reliably used only on attached element
+f=a.getDefaultComputedStyle&&(d=a.getDefaultComputedStyle(e[0]))?
+// Use of this method is a temporary fix (more like optimization) until something better comes along,
+// since it was removed from specification and supported only in FF
+d.display:_.css(e[0],"display");
+// We don't have any data stored on the element,
+// so use "detach" method as fast way to get rid of the element
+return e.detach(),f}/**
+ * Try to determine the default display value of an element
+ * @param {String} nodeName
+ */
+function u(a){var b=Z,c=Oa[a];
+// If the simple way fails, read from inside an iframe
+// Use the already-created iframe if possible
+// Always write a new HTML skeleton so Webkit and Firefox don't choke on reuse
+// Support: IE
+// Store the correct default display
+return c||(c=t(a,b),"none"!==c&&c||(Na=(Na||_("<iframe frameborder='0' width='0' height='0'/>")).appendTo(b.documentElement),b=Na[0].contentDocument,b.write(),b.close(),c=t(a,b),Na.detach()),Oa[a]=c),c}function v(a,b,c){var d,e,f,g,h=a.style;
+// Support: IE9
+// getPropertyValue is only needed for .css('filter') (#12537)
+// Support: iOS < 6
+// A tribute to the "awesome hack by Dean Edwards"
+// iOS < 6 (at least) returns percentage for a larger set of values, but width seems to be reliably pixels
+// this is against the CSSOM draft spec: http://dev.w3.org/csswg/cssom/#resolved-values
+// Remember the original values
+// Put in the new values to get a computed value out
+// Revert the changed values
+// Support: IE
+// IE returns zIndex value as an integer.
+return c=c||Ra(a),c&&(g=c.getPropertyValue(b)||c[b]),c&&(""!==g||_.contains(a.ownerDocument,a)||(g=_.style(a,b)),Qa.test(g)&&Pa.test(b)&&(d=h.width,e=h.minWidth,f=h.maxWidth,h.minWidth=h.maxWidth=h.width=g,g=c.width,h.width=d,h.minWidth=e,h.maxWidth=f)),void 0!==g?g+"":g}function w(a,b){
+// Define the hook, we'll check on the first run if it's really needed.
+return{get:function(){
+// Hook not needed (or it's not possible to use it due
+// to missing dependency), remove it.
+return a()?void delete this.get:(this.get=b).apply(this,arguments)}}}
+// Return a css property mapped to a potentially vendor prefixed property
+function x(a,b){
+// Shortcut for names that are not vendor prefixed
+if(b in a)return b;for(
+// Check for vendor prefixed names
+var c=b[0].toUpperCase()+b.slice(1),d=b,e=Xa.length;e--;)if(b=Xa[e]+c,b in a)return b;return d}function y(a,b,c){var d=Ta.exec(b);
+// Guard against undefined "subtract", e.g., when used as in cssHooks
+return d?Math.max(0,d[1]-(c||0))+(d[2]||"px"):b}function z(a,b,c,d,e){for(var f=c===(d?"border":"content")?
+// If we already have the right measurement, avoid augmentation
+4:"width"===b?1:0,g=0;4>f;f+=2)
+// Both box models exclude margin, so add it if we want it
+"margin"===c&&(g+=_.css(a,c+wa[f],!0,e)),d?(
+// border-box includes padding, so remove it if we want content
+"content"===c&&(g-=_.css(a,"padding"+wa[f],!0,e)),
+// At this point, extra isn't border nor margin, so remove border
+"margin"!==c&&(g-=_.css(a,"border"+wa[f]+"Width",!0,e))):(g+=_.css(a,"padding"+wa[f],!0,e),"padding"!==c&&(g+=_.css(a,"border"+wa[f]+"Width",!0,e)));return g}function A(a,b,c){
+// Start with offset property, which is equivalent to the border-box value
+var d=!0,e="width"===b?a.offsetWidth:a.offsetHeight,f=Ra(a),g="border-box"===_.css(a,"boxSizing",!1,f);
+// Some non-html elements return undefined for offsetWidth, so check for null/undefined
+// svg - https://bugzilla.mozilla.org/show_bug.cgi?id=649285
+// MathML - https://bugzilla.mozilla.org/show_bug.cgi?id=491668
+if(0>=e||null==e){
+// Computed unit is not pixels. Stop here and return.
+if(e=v(a,b,f),(0>e||null==e)&&(e=a.style[b]),Qa.test(e))return e;
+// Check for style in case a browser which returns unreliable values
+// for getComputedStyle silently falls back to the reliable elem.style
+d=g&&(Y.boxSizingReliable()||e===a.style[b]),
+// Normalize "", auto, and prepare for extra
+e=parseFloat(e)||0}
+// Use the active box-sizing model to add/subtract irrelevant styles
+return e+z(a,b,c||(g?"border":"content"),d,f)+"px"}function B(a,b){for(var c,d,e,f=[],g=0,h=a.length;h>g;g++)d=a[g],d.style&&(f[g]=ra.get(d,"olddisplay"),c=d.style.display,b?(f[g]||"none"!==c||(d.style.display=""),""===d.style.display&&xa(d)&&(f[g]=ra.access(d,"olddisplay",u(d.nodeName)))):(e=xa(d),"none"===c&&e||ra.set(d,"olddisplay",e?c:_.css(d,"display"))));
+// Set the display of most of the elements in a second loop
+// to avoid the constant reflow
+for(g=0;h>g;g++)d=a[g],d.style&&(b&&"none"!==d.style.display&&""!==d.style.display||(d.style.display=b?f[g]||"":"none"));return a}function C(a,b,c,d,e){return new C.prototype.init(a,b,c,d,e)}
+// Animations created synchronously will run synchronously
+function D(){return setTimeout(function(){Ya=void 0}),Ya=_.now()}
+// Generate parameters to create a standard animation
+function E(a,b){var c,d=0,e={height:a};for(
+// If we include width, step value is 1 to do all cssExpand values,
+// otherwise step value is 2 to skip over Left and Right
+b=b?1:0;4>d;d+=2-b)c=wa[d],e["margin"+c]=e["padding"+c]=a;return b&&(e.opacity=e.width=a),e}function F(a,b,c){for(var d,e=(cb[b]||[]).concat(cb["*"]),f=0,g=e.length;g>f;f++)if(d=e[f].call(c,b,a))
+// We're done with this property
+return d}function G(a,b,c){/* jshint validthis: true */
+var d,e,f,g,h,i,j,k,l=this,m={},n=a.style,o=a.nodeType&&xa(a),p=ra.get(a,"fxshow");
+// Handle queue: false promises
+c.queue||(h=_._queueHooks(a,"fx"),null==h.unqueued&&(h.unqueued=0,i=h.empty.fire,h.empty.fire=function(){h.unqueued||i()}),h.unqueued++,l.always(function(){l.always(function(){h.unqueued--,_.queue(a,"fx").length||h.empty.fire()})})),
+// Height/width overflow pass
+1===a.nodeType&&("height"in b||"width"in b)&&(
+// Make sure that nothing sneaks out
+// Record all 3 overflow attributes because IE9-10 do not
+// change the overflow attribute when overflowX and
+// overflowY are set to the same value
+c.overflow=[n.overflow,n.overflowX,n.overflowY],j=_.css(a,"display"),k="none"===j?ra.get(a,"olddisplay")||u(a.nodeName):j,"inline"===k&&"none"===_.css(a,"float")&&(n.display="inline-block")),c.overflow&&(n.overflow="hidden",l.always(function(){n.overflow=c.overflow[0],n.overflowX=c.overflow[1],n.overflowY=c.overflow[2]}));
+// show/hide pass
+for(d in b)if(e=b[d],$a.exec(e)){if(delete b[d],f=f||"toggle"===e,e===(o?"hide":"show")){
+// If there is dataShow left over from a stopped hide or show and we are going to proceed with show, we should pretend to be hidden
+if("show"!==e||!p||void 0===p[d])continue;o=!0}m[d]=p&&p[d]||_.style(a,d)}else j=void 0;if(_.isEmptyObject(m))"inline"===("none"===j?u(a.nodeName):j)&&(n.display=j);else{p?"hidden"in p&&(o=p.hidden):p=ra.access(a,"fxshow",{}),
+// Store state if its toggle - enables .stop().toggle() to "reverse"
+f&&(p.hidden=!o),o?_(a).show():l.done(function(){_(a).hide()}),l.done(function(){var b;ra.remove(a,"fxshow");for(b in m)_.style(a,b,m[b])});for(d in m)g=F(o?p[d]:0,d,l),d in p||(p[d]=g.start,o&&(g.end=g.start,g.start="width"===d||"height"===d?1:0))}}function H(a,b){var c,d,e,f,g;
+// camelCase, specialEasing and expand cssHook pass
+for(c in a)if(d=_.camelCase(c),e=b[d],f=a[c],_.isArray(f)&&(e=f[1],f=a[c]=f[0]),c!==d&&(a[d]=f,delete a[c]),g=_.cssHooks[d],g&&"expand"in g){f=g.expand(f),delete a[d];
+// Not quite $.extend, this won't overwrite existing keys.
+// Reusing 'index' because we have the correct "name"
+for(c in f)c in a||(a[c]=f[c],b[c]=e)}else b[d]=e}function I(a,b,c){var d,e,f=0,g=bb.length,h=_.Deferred().always(function(){
+// Don't match elem in the :animated selector
+delete i.elem}),i=function(){if(e)return!1;for(var b=Ya||D(),c=Math.max(0,j.startTime+j.duration-b),
+// Support: Android 2.3
+// Archaic crash bug won't allow us to use `1 - ( 0.5 || 0 )` (#12497)
+d=c/j.duration||0,f=1-d,g=0,i=j.tweens.length;i>g;g++)j.tweens[g].run(f);return h.notifyWith(a,[j,f,c]),1>f&&i?c:(h.resolveWith(a,[j]),!1)},j=h.promise({elem:a,props:_.extend({},b),opts:_.extend(!0,{specialEasing:{}},c),originalProperties:b,originalOptions:c,startTime:Ya||D(),duration:c.duration,tweens:[],createTween:function(b,c){var d=_.Tween(a,j.opts,b,c,j.opts.specialEasing[b]||j.opts.easing);return j.tweens.push(d),d},stop:function(b){var c=0,
+// If we are going to the end, we want to run all the tweens
+// otherwise we skip this part
+d=b?j.tweens.length:0;if(e)return this;for(e=!0;d>c;c++)j.tweens[c].run(1);
+// Resolve when we played the last frame; otherwise, reject
+return b?h.resolveWith(a,[j,b]):h.rejectWith(a,[j,b]),this}}),k=j.props;for(H(k,j.opts.specialEasing);g>f;f++)if(d=bb[f].call(j,a,k,j.opts))return d;
+// attach callbacks from options
+return _.map(k,F,j),_.isFunction(j.opts.start)&&j.opts.start.call(a,j),_.fx.timer(_.extend(i,{elem:a,anim:j,queue:j.opts.queue})),j.progress(j.opts.progress).done(j.opts.done,j.opts.complete).fail(j.opts.fail).always(j.opts.always)}
+// Base "constructor" for jQuery.ajaxPrefilter and jQuery.ajaxTransport
+function J(a){
+// dataTypeExpression is optional and defaults to "*"
+return function(b,c){"string"!=typeof b&&(c=b,b="*");var d,e=0,f=b.toLowerCase().match(na)||[];if(_.isFunction(c))
+// For each dataType in the dataTypeExpression
+for(;d=f[e++];)
+// Prepend if requested
+"+"===d[0]?(d=d.slice(1)||"*",(a[d]=a[d]||[]).unshift(c)):(a[d]=a[d]||[]).push(c)}}
+// Base inspection function for prefilters and transports
+function K(a,b,c,d){function e(h){var i;return f[h]=!0,_.each(a[h]||[],function(a,h){var j=h(b,c,d);return"string"!=typeof j||g||f[j]?g?!(i=j):void 0:(b.dataTypes.unshift(j),e(j),!1)}),i}var f={},g=a===tb;return e(b.dataTypes[0])||!f["*"]&&e("*")}
+// A special extend for ajax options
+// that takes "flat" options (not to be deep extended)
+// Fixes #9887
+function L(a,b){var c,d,e=_.ajaxSettings.flatOptions||{};for(c in b)void 0!==b[c]&&((e[c]?a:d||(d={}))[c]=b[c]);return d&&_.extend(!0,a,d),a}/* Handles responses to an ajax request:
+ * - finds the right dataType (mediates between content-type and expected dataType)
+ * - returns the corresponding response
+ */
+function M(a,b,c){
+// Remove auto dataType and get content-type in the process
+for(var d,e,f,g,h=a.contents,i=a.dataTypes;"*"===i[0];)i.shift(),void 0===d&&(d=a.mimeType||b.getResponseHeader("Content-Type"));
+// Check if we're dealing with a known content-type
+if(d)for(e in h)if(h[e]&&h[e].test(d)){i.unshift(e);break}
+// Check to see if we have a response for the expected dataType
+if(i[0]in c)f=i[0];else{
+// Try convertible dataTypes
+for(e in c){if(!i[0]||a.converters[e+" "+i[0]]){f=e;break}g||(g=e)}
+// Or just use first one
+f=f||g}
+// If we found a dataType
+// We add the dataType to the list if needed
+// and return the corresponding response
+// If we found a dataType
+// We add the dataType to the list if needed
+// and return the corresponding response
+return f?(f!==i[0]&&i.unshift(f),c[f]):void 0}/* Chain conversions given the request and the original response
+ * Also sets the responseXXX fields on the jqXHR instance
+ */
+function N(a,b,c,d){var e,f,g,h,i,j={},
+// Work with a copy of dataTypes in case we need to modify it for conversion
+k=a.dataTypes.slice();
+// Create converters map with lowercased keys
+if(k[1])for(g in a.converters)j[g.toLowerCase()]=a.converters[g];
+// Convert to each sequential dataType
+for(f=k.shift();f;)if(a.responseFields[f]&&(c[a.responseFields[f]]=b),
+// Apply the dataFilter if provided
+!i&&d&&a.dataFilter&&(b=a.dataFilter(b,a.dataType)),i=f,f=k.shift())
+// There's only work to do if current dataType is non-auto
+if("*"===f)f=i;else if("*"!==i&&i!==f){
+// If none found, seek a pair
+if(g=j[i+" "+f]||j["* "+f],!g)for(e in j)if(h=e.split(" "),h[1]===f&&(g=j[i+" "+h[0]]||j["* "+h[0]])){
+// Condense equivalence converters
+g===!0?g=j[e]:j[e]!==!0&&(f=h[0],k.unshift(h[1]));break}
+// Apply converter (if not an equivalence)
+if(g!==!0)
+// Unless errors are allowed to bubble, catch and return them
+if(g&&a["throws"])b=g(b);else try{b=g(b)}catch(l){return{state:"parsererror",error:g?l:"No conversion from "+i+" to "+f}}}return{state:"success",data:b}}function O(a,b,c,d){var e;if(_.isArray(b))
+// Serialize array item.
+_.each(b,function(b,e){c||yb.test(a)?
+// Treat each array item as a scalar.
+d(a,e):
+// Item is non-scalar (array or object), encode its numeric index.
+O(a+"["+("object"==typeof e?b:"")+"]",e,c,d)});else if(c||"object"!==_.type(b))
+// Serialize scalar item.
+d(a,b);else
+// Serialize object item.
+for(e in b)O(a+"["+e+"]",b[e],c,d)}/**
+ * Gets a window from an element
+ */
+function P(a){return _.isWindow(a)?a:9===a.nodeType&&a.defaultView}
+// Support: Firefox 18+
+// Can't be in strict mode, several libs including ASP.NET trace
+// the stack via arguments.caller.callee and Firefox dies if
+// you try to trace through "use strict" call chains. (#13335)
+//
+var Q=[],R=Q.slice,S=Q.concat,T=Q.push,U=Q.indexOf,V={},W=V.toString,X=V.hasOwnProperty,Y={},
+// Use the correct document accordingly with window argument (sandbox)
+Z=a.document,$="2.1.4",
+// Define a local copy of jQuery
+_=function(a,b){
+// The jQuery object is actually just the init constructor 'enhanced'
+// Need init if jQuery is called (just allow error to be thrown if not included)
+return new _.fn.init(a,b)},
+// Support: Android<4.1
+// Make sure we trim BOM and NBSP
+aa=/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g,
+// Matches dashed string for camelizing
+ba=/^-ms-/,ca=/-([\da-z])/gi,
+// Used by jQuery.camelCase as callback to replace()
+da=function(a,b){return b.toUpperCase()};_.fn=_.prototype={
+// The current version of jQuery being used
+jquery:$,constructor:_,
+// Start with an empty selector
+selector:"",
+// The default length of a jQuery object is 0
+length:0,toArray:function(){return R.call(this)},
+// Get the Nth element in the matched element set OR
+// Get the whole matched element set as a clean array
+get:function(a){
+// Return just the one element from the set
+// Return all the elements in a clean array
+return null!=a?0>a?this[a+this.length]:this[a]:R.call(this)},
+// Take an array of elements and push it onto the stack
+// (returning the new matched element set)
+pushStack:function(a){
+// Build a new jQuery matched element set
+var b=_.merge(this.constructor(),a);
+// Return the newly-formed element set
+// Add the old object onto the stack (as a reference)
+return b.prevObject=this,b.context=this.context,b},
+// Execute a callback for every element in the matched set.
+// (You can seed the arguments with an array of args, but this is
+// only used internally.)
+each:function(a,b){return _.each(this,a,b)},map:function(a){return this.pushStack(_.map(this,function(b,c){return a.call(b,c,b)}))},slice:function(){return this.pushStack(R.apply(this,arguments))},first:function(){return this.eq(0)},last:function(){return this.eq(-1)},eq:function(a){var b=this.length,c=+a+(0>a?b:0);return this.pushStack(c>=0&&b>c?[this[c]]:[])},end:function(){return this.prevObject||this.constructor(null)},
+// For internal use only.
+// Behaves like an Array's method, not like a jQuery method.
+push:T,sort:Q.sort,splice:Q.splice},_.extend=_.fn.extend=function(){var a,b,c,d,e,f,g=arguments[0]||{},h=1,i=arguments.length,j=!1;for(
+// Handle a deep copy situation
+"boolean"==typeof g&&(j=g,g=arguments[h]||{},h++),
+// Handle case when target is a string or something (possible in deep copy)
+"object"==typeof g||_.isFunction(g)||(g={}),
+// Extend jQuery itself if only one argument is passed
+h===i&&(g=this,h--);i>h;h++)
+// Only deal with non-null/undefined values
+if(null!=(a=arguments[h]))
+// Extend the base object
+for(b in a)c=g[b],d=a[b],g!==d&&(j&&d&&(_.isPlainObject(d)||(e=_.isArray(d)))?(e?(e=!1,f=c&&_.isArray(c)?c:[]):f=c&&_.isPlainObject(c)?c:{},g[b]=_.extend(j,f,d)):void 0!==d&&(g[b]=d));
+// Return the modified object
+return g},_.extend({
+// Unique for each copy of jQuery on the page
+expando:"jQuery"+($+Math.random()).replace(/\D/g,""),
+// Assume jQuery is ready without the ready module
+isReady:!0,error:function(a){throw new Error(a)},noop:function(){},isFunction:function(a){return"function"===_.type(a)},isArray:Array.isArray,isWindow:function(a){return null!=a&&a===a.window},isNumeric:function(a){
+// parseFloat NaNs numeric-cast false positives (null|true|false|"")
+// ...but misinterprets leading-number strings, particularly hex literals ("0x...")
+// subtraction forces infinities to NaN
+// adding 1 corrects loss of precision from parseFloat (#15100)
+return!_.isArray(a)&&a-parseFloat(a)+1>=0},isPlainObject:function(a){
+// Not plain objects:
+// - Any object or value whose internal [[Class]] property is not "[object Object]"
+// - DOM nodes
+// - window
+// Not plain objects:
+// - Any object or value whose internal [[Class]] property is not "[object Object]"
+// - DOM nodes
+// - window
+return"object"!==_.type(a)||a.nodeType||_.isWindow(a)?!1:a.constructor&&!X.call(a.constructor.prototype,"isPrototypeOf")?!1:!0},isEmptyObject:function(a){var b;for(b in a)return!1;return!0},type:function(a){return null==a?a+"":"object"==typeof a||"function"==typeof a?V[W.call(a)]||"object":typeof a},
+// Evaluates a script in a global context
+globalEval:function(a){var b,c=eval;a=_.trim(a),a&&(1===a.indexOf("use strict")?(b=Z.createElement("script"),b.text=a,Z.head.appendChild(b).parentNode.removeChild(b)):c(a))},
+// Convert dashed to camelCase; used by the css and data modules
+// Support: IE9-11+
+// Microsoft forgot to hump their vendor prefix (#9572)
+camelCase:function(a){return a.replace(ba,"ms-").replace(ca,da)},nodeName:function(a,b){return a.nodeName&&a.nodeName.toLowerCase()===b.toLowerCase()},
+// args is for internal usage only
+each:function(a,b,d){var e,f=0,g=a.length,h=c(a);if(d){if(h)for(;g>f&&(e=b.apply(a[f],d),e!==!1);f++);else for(f in a)if(e=b.apply(a[f],d),e===!1)break}else if(h)for(;g>f&&(e=b.call(a[f],f,a[f]),e!==!1);f++);else for(f in a)if(e=b.call(a[f],f,a[f]),e===!1)break;return a},
+// Support: Android<4.1
+trim:function(a){return null==a?"":(a+"").replace(aa,"")},
+// results is for internal usage only
+makeArray:function(a,b){var d=b||[];return null!=a&&(c(Object(a))?_.merge(d,"string"==typeof a?[a]:a):T.call(d,a)),d},inArray:function(a,b,c){return null==b?-1:U.call(b,a,c)},merge:function(a,b){for(var c=+b.length,d=0,e=a.length;c>d;d++)a[e++]=b[d];return a.length=e,a},grep:function(a,b,c){
+// Go through the array, only saving the items
+// that pass the validator function
+for(var d,e=[],f=0,g=a.length,h=!c;g>f;f++)d=!b(a[f],f),d!==h&&e.push(a[f]);return e},
+// arg is for internal usage only
+map:function(a,b,d){var e,f=0,g=a.length,h=c(a),i=[];
+// Go through the array, translating each of the items to their new values
+if(h)for(;g>f;f++)e=b(a[f],f,d),null!=e&&i.push(e);else for(f in a)e=b(a[f],f,d),null!=e&&i.push(e);
+// Flatten any nested arrays
+return S.apply([],i)},
+// A global GUID counter for objects
+guid:1,
+// Bind a function to a context, optionally partially applying any
+// arguments.
+proxy:function(a,b){var c,d,e;
+// Quick check to determine if target is callable, in the spec
+// this throws a TypeError, but we will just return undefined.
+// Quick check to determine if target is callable, in the spec
+// this throws a TypeError, but we will just return undefined.
+// Simulated bind
+// Set the guid of unique handler to the same of original handler, so it can be removed
+return"string"==typeof b&&(c=a[b],b=a,a=c),_.isFunction(a)?(d=R.call(arguments,2),e=function(){return a.apply(b||this,d.concat(R.call(arguments)))},e.guid=a.guid=a.guid||_.guid++,e):void 0},now:Date.now,
+// jQuery.support is not used in Core but other projects attach their
+// properties to it so it needs to exist.
+support:Y}),
+// Populate the class2type map
+_.each("Boolean Number String Function Array Date RegExp Object Error".split(" "),function(a,b){V["[object "+b+"]"]=b.toLowerCase()});var ea=/*!
  * Sizzle CSS Selector Engine v2.2.0-pre
  * http://sizzlejs.com/
  *
@@ -21,21 +367,1501 @@
  *
  * Date: 2014-12-16
  */
-function(a){function b(a,b,c,d){var e,f,g,h,i,j,l,n,o,p;if((b?b.ownerDocument||b:O)!==G&&F(b),b=b||G,c=c||[],h=b.nodeType,"string"!=typeof a||!a||1!==h&&9!==h&&11!==h)return c;if(!d&&I){if(11!==h&&(e=sa.exec(a)))if(g=e[1]){if(9===h){if(f=b.getElementById(g),!f||!f.parentNode)return c;if(f.id===g)return c.push(f),c}else if(b.ownerDocument&&(f=b.ownerDocument.getElementById(g))&&M(b,f)&&f.id===g)return c.push(f),c}else{if(e[2])return $.apply(c,b.getElementsByTagName(a)),c;if((g=e[3])&&v.getElementsByClassName)return $.apply(c,b.getElementsByClassName(g)),c}if(v.qsa&&(!J||!J.test(a))){if(n=l=N,o=b,p=1!==h&&a,1===h&&"object"!==b.nodeName.toLowerCase()){for(j=z(a),(l=b.getAttribute("id"))?n=l.replace(ua,"\\$&"):b.setAttribute("id",n),n="[id='"+n+"'] ",i=j.length;i--;)j[i]=n+m(j[i]);o=ta.test(a)&&k(b.parentNode)||b,p=j.join(",")}if(p)try{return $.apply(c,o.querySelectorAll(p)),c}catch(q){}finally{l||b.removeAttribute("id")}}}return B(a.replace(ia,"$1"),b,c,d)}function c(){function a(c,d){return b.push(c+" ")>w.cacheLength&&delete a[b.shift()],a[c+" "]=d}var b=[];return a}function d(a){return a[N]=!0,a}function e(a){var b=G.createElement("div");try{return!!a(b)}catch(c){return!1}finally{b.parentNode&&b.parentNode.removeChild(b),b=null}}function f(a,b){for(var c=a.split("|"),d=a.length;d--;)w.attrHandle[c[d]]=b}function g(a,b){var c=b&&a,d=c&&1===a.nodeType&&1===b.nodeType&&(~b.sourceIndex||V)-(~a.sourceIndex||V);if(d)return d;if(c)for(;c=c.nextSibling;)if(c===b)return-1;return a?1:-1}function h(a){return function(b){var c=b.nodeName.toLowerCase();return"input"===c&&b.type===a}}function i(a){return function(b){var c=b.nodeName.toLowerCase();return("input"===c||"button"===c)&&b.type===a}}function j(a){return d(function(b){return b=+b,d(function(c,d){for(var e,f=a([],c.length,b),g=f.length;g--;)c[e=f[g]]&&(c[e]=!(d[e]=c[e]))})})}function k(a){return a&&"undefined"!=typeof a.getElementsByTagName&&a}function l(){}function m(a){for(var b=0,c=a.length,d="";c>b;b++)d+=a[b].value;return d}function n(a,b,c){var d=b.dir,e=c&&"parentNode"===d,f=Q++;return b.first?function(b,c,f){for(;b=b[d];)if(1===b.nodeType||e)return a(b,c,f)}:function(b,c,g){var h,i,j=[P,f];if(g){for(;b=b[d];)if((1===b.nodeType||e)&&a(b,c,g))return!0}else for(;b=b[d];)if(1===b.nodeType||e){if(i=b[N]||(b[N]={}),(h=i[d])&&h[0]===P&&h[1]===f)return j[2]=h[2];if(i[d]=j,j[2]=a(b,c,g))return!0}}}function o(a){return a.length>1?function(b,c,d){for(var e=a.length;e--;)if(!a[e](b,c,d))return!1;return!0}:a[0]}function p(a,c,d){for(var e=0,f=c.length;f>e;e++)b(a,c[e],d);return d}function q(a,b,c,d,e){for(var f,g=[],h=0,i=a.length,j=null!=b;i>h;h++)(f=a[h])&&(!c||c(f,d,e))&&(g.push(f),j&&b.push(h));return g}function r(a,b,c,e,f,g){return e&&!e[N]&&(e=r(e)),f&&!f[N]&&(f=r(f,g)),d(function(d,g,h,i){var j,k,l,m=[],n=[],o=g.length,r=d||p(b||"*",h.nodeType?[h]:h,[]),s=!a||!d&&b?r:q(r,m,a,h,i),t=c?f||(d?a:o||e)?[]:g:s;if(c&&c(s,t,h,i),e)for(j=q(t,n),e(j,[],h,i),k=j.length;k--;)(l=j[k])&&(t[n[k]]=!(s[n[k]]=l));if(d){if(f||a){if(f){for(j=[],k=t.length;k--;)(l=t[k])&&j.push(s[k]=l);f(null,t=[],j,i)}for(k=t.length;k--;)(l=t[k])&&(j=f?aa(d,l):m[k])>-1&&(d[j]=!(g[j]=l))}}else t=q(t===g?t.splice(o,t.length):t),f?f(null,g,t,i):$.apply(g,t)})}function s(a){for(var b,c,d,e=a.length,f=w.relative[a[0].type],g=f||w.relative[" "],h=f?1:0,i=n(function(a){return a===b},g,!0),j=n(function(a){return aa(b,a)>-1},g,!0),k=[function(a,c,d){var e=!f&&(d||c!==C)||((b=c).nodeType?i(a,c,d):j(a,c,d));return b=null,e}];e>h;h++)if(c=w.relative[a[h].type])k=[n(o(k),c)];else{if(c=w.filter[a[h].type].apply(null,a[h].matches),c[N]){for(d=++h;e>d&&!w.relative[a[d].type];d++);return r(h>1&&o(k),h>1&&m(a.slice(0,h-1).concat({value:" "===a[h-2].type?"*":""})).replace(ia,"$1"),c,d>h&&s(a.slice(h,d)),e>d&&s(a=a.slice(d)),e>d&&m(a))}k.push(c)}return o(k)}function t(a,c){var e=c.length>0,f=a.length>0,g=function(d,g,h,i,j){var k,l,m,n=0,o="0",p=d&&[],r=[],s=C,t=d||f&&w.find.TAG("*",j),u=P+=null==s?1:Math.random()||.1,v=t.length;for(j&&(C=g!==G&&g);o!==v&&null!=(k=t[o]);o++){if(f&&k){for(l=0;m=a[l++];)if(m(k,g,h)){i.push(k);break}j&&(P=u)}e&&((k=!m&&k)&&n--,d&&p.push(k))}if(n+=o,e&&o!==n){for(l=0;m=c[l++];)m(p,r,g,h);if(d){if(n>0)for(;o--;)p[o]||r[o]||(r[o]=Y.call(i));r=q(r)}$.apply(i,r),j&&!d&&r.length>0&&n+c.length>1&&b.uniqueSort(i)}return j&&(P=u,C=s),p};return e?d(g):g}var u,v,w,x,y,z,A,B,C,D,E,F,G,H,I,J,K,L,M,N="sizzle"+1*new Date,O=a.document,P=0,Q=0,R=c(),S=c(),T=c(),U=function(a,b){return a===b&&(E=!0),0},V=1<<31,W={}.hasOwnProperty,X=[],Y=X.pop,Z=X.push,$=X.push,_=X.slice,aa=function(a,b){for(var c=0,d=a.length;d>c;c++)if(a[c]===b)return c;return-1},ba="checked|selected|async|autofocus|autoplay|controls|defer|disabled|hidden|ismap|loop|multiple|open|readonly|required|scoped",ca="[\\x20\\t\\r\\n\\f]",da="(?:\\\\.|[\\w-]|[^\\x00-\\xa0])+",ea=da.replace("w","w#"),fa="\\["+ca+"*("+da+")(?:"+ca+"*([*^$|!~]?=)"+ca+"*(?:'((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\"|("+ea+"))|)"+ca+"*\\]",ga=":("+da+")(?:\\((('((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\")|((?:\\\\.|[^\\\\()[\\]]|"+fa+")*)|.*)\\)|)",ha=new RegExp(ca+"+","g"),ia=new RegExp("^"+ca+"+|((?:^|[^\\\\])(?:\\\\.)*)"+ca+"+$","g"),ja=new RegExp("^"+ca+"*,"+ca+"*"),ka=new RegExp("^"+ca+"*([>+~]|"+ca+")"+ca+"*"),la=new RegExp("="+ca+"*([^\\]'\"]*?)"+ca+"*\\]","g"),ma=new RegExp(ga),na=new RegExp("^"+ea+"$"),oa={ID:new RegExp("^#("+da+")"),CLASS:new RegExp("^\\.("+da+")"),TAG:new RegExp("^("+da.replace("w","w*")+")"),ATTR:new RegExp("^"+fa),PSEUDO:new RegExp("^"+ga),CHILD:new RegExp("^:(only|first|last|nth|nth-last)-(child|of-type)(?:\\("+ca+"*(even|odd|(([+-]|)(\\d*)n|)"+ca+"*(?:([+-]|)"+ca+"*(\\d+)|))"+ca+"*\\)|)","i"),bool:new RegExp("^(?:"+ba+")$","i"),needsContext:new RegExp("^"+ca+"*[>+~]|:(even|odd|eq|gt|lt|nth|first|last)(?:\\("+ca+"*((?:-\\d)?\\d*)"+ca+"*\\)|)(?=[^-]|$)","i")},pa=/^(?:input|select|textarea|button)$/i,qa=/^h\d$/i,ra=/^[^{]+\{\s*\[native \w/,sa=/^(?:#([\w-]+)|(\w+)|\.([\w-]+))$/,ta=/[+~]/,ua=/'|\\/g,va=new RegExp("\\\\([\\da-f]{1,6}"+ca+"?|("+ca+")|.)","ig"),wa=function(a,b,c){var d="0x"+b-65536;return d!==d||c?b:0>d?String.fromCharCode(d+65536):String.fromCharCode(d>>10|55296,1023&d|56320)},xa=function(){F()};try{$.apply(X=_.call(O.childNodes),O.childNodes),X[O.childNodes.length].nodeType}catch(ya){$={apply:X.length?function(a,b){Z.apply(a,_.call(b))}:function(a,b){for(var c=a.length,d=0;a[c++]=b[d++];);a.length=c-1}}}v=b.support={},y=b.isXML=function(a){var b=a&&(a.ownerDocument||a).documentElement;return b?"HTML"!==b.nodeName:!1},F=b.setDocument=function(a){var b,c,d=a?a.ownerDocument||a:O;return d!==G&&9===d.nodeType&&d.documentElement?(G=d,H=d.documentElement,c=d.defaultView,c&&c!==c.top&&(c.addEventListener?c.addEventListener("unload",xa,!1):c.attachEvent&&c.attachEvent("onunload",xa)),I=!y(d),v.attributes=e(function(a){return a.className="i",!a.getAttribute("className")}),v.getElementsByTagName=e(function(a){return a.appendChild(d.createComment("")),!a.getElementsByTagName("*").length}),v.getElementsByClassName=ra.test(d.getElementsByClassName),v.getById=e(function(a){return H.appendChild(a).id=N,!d.getElementsByName||!d.getElementsByName(N).length}),v.getById?(w.find.ID=function(a,b){if("undefined"!=typeof b.getElementById&&I){var c=b.getElementById(a);return c&&c.parentNode?[c]:[]}},w.filter.ID=function(a){var b=a.replace(va,wa);return function(a){return a.getAttribute("id")===b}}):(delete w.find.ID,w.filter.ID=function(a){var b=a.replace(va,wa);return function(a){var c="undefined"!=typeof a.getAttributeNode&&a.getAttributeNode("id");return c&&c.value===b}}),w.find.TAG=v.getElementsByTagName?function(a,b){return"undefined"!=typeof b.getElementsByTagName?b.getElementsByTagName(a):v.qsa?b.querySelectorAll(a):void 0}:function(a,b){var c,d=[],e=0,f=b.getElementsByTagName(a);if("*"===a){for(;c=f[e++];)1===c.nodeType&&d.push(c);return d}return f},w.find.CLASS=v.getElementsByClassName&&function(a,b){return I?b.getElementsByClassName(a):void 0},K=[],J=[],(v.qsa=ra.test(d.querySelectorAll))&&(e(function(a){H.appendChild(a).innerHTML="<a id='"+N+"'></a><select id='"+N+"-\f]' msallowcapture=''><option selected=''></option></select>",a.querySelectorAll("[msallowcapture^='']").length&&J.push("[*^$]="+ca+"*(?:''|\"\")"),a.querySelectorAll("[selected]").length||J.push("\\["+ca+"*(?:value|"+ba+")"),a.querySelectorAll("[id~="+N+"-]").length||J.push("~="),a.querySelectorAll(":checked").length||J.push(":checked"),a.querySelectorAll("a#"+N+"+*").length||J.push(".#.+[+~]")}),e(function(a){var b=d.createElement("input");b.setAttribute("type","hidden"),a.appendChild(b).setAttribute("name","D"),a.querySelectorAll("[name=d]").length&&J.push("name"+ca+"*[*^$|!~]?="),a.querySelectorAll(":enabled").length||J.push(":enabled",":disabled"),a.querySelectorAll("*,:x"),J.push(",.*:")})),(v.matchesSelector=ra.test(L=H.matches||H.webkitMatchesSelector||H.mozMatchesSelector||H.oMatchesSelector||H.msMatchesSelector))&&e(function(a){v.disconnectedMatch=L.call(a,"div"),L.call(a,"[s!='']:x"),K.push("!=",ga)}),J=J.length&&new RegExp(J.join("|")),K=K.length&&new RegExp(K.join("|")),b=ra.test(H.compareDocumentPosition),M=b||ra.test(H.contains)?function(a,b){var c=9===a.nodeType?a.documentElement:a,d=b&&b.parentNode;return a===d||!(!d||1!==d.nodeType||!(c.contains?c.contains(d):a.compareDocumentPosition&&16&a.compareDocumentPosition(d)))}:function(a,b){if(b)for(;b=b.parentNode;)if(b===a)return!0;return!1},U=b?function(a,b){if(a===b)return E=!0,0;var c=!a.compareDocumentPosition-!b.compareDocumentPosition;return c?c:(c=(a.ownerDocument||a)===(b.ownerDocument||b)?a.compareDocumentPosition(b):1,1&c||!v.sortDetached&&b.compareDocumentPosition(a)===c?a===d||a.ownerDocument===O&&M(O,a)?-1:b===d||b.ownerDocument===O&&M(O,b)?1:D?aa(D,a)-aa(D,b):0:4&c?-1:1)}:function(a,b){if(a===b)return E=!0,0;var c,e=0,f=a.parentNode,h=b.parentNode,i=[a],j=[b];if(!f||!h)return a===d?-1:b===d?1:f?-1:h?1:D?aa(D,a)-aa(D,b):0;if(f===h)return g(a,b);for(c=a;c=c.parentNode;)i.unshift(c);for(c=b;c=c.parentNode;)j.unshift(c);for(;i[e]===j[e];)e++;return e?g(i[e],j[e]):i[e]===O?-1:j[e]===O?1:0},d):G},b.matches=function(a,c){return b(a,null,null,c)},b.matchesSelector=function(a,c){if((a.ownerDocument||a)!==G&&F(a),c=c.replace(la,"='$1']"),!(!v.matchesSelector||!I||K&&K.test(c)||J&&J.test(c)))try{var d=L.call(a,c);if(d||v.disconnectedMatch||a.document&&11!==a.document.nodeType)return d}catch(e){}return b(c,G,null,[a]).length>0},b.contains=function(a,b){return(a.ownerDocument||a)!==G&&F(a),M(a,b)},b.attr=function(a,b){(a.ownerDocument||a)!==G&&F(a);var c=w.attrHandle[b.toLowerCase()],d=c&&W.call(w.attrHandle,b.toLowerCase())?c(a,b,!I):void 0;return void 0!==d?d:v.attributes||!I?a.getAttribute(b):(d=a.getAttributeNode(b))&&d.specified?d.value:null},b.error=function(a){throw new Error("Syntax error, unrecognized expression: "+a)},b.uniqueSort=function(a){var b,c=[],d=0,e=0;if(E=!v.detectDuplicates,D=!v.sortStable&&a.slice(0),a.sort(U),E){for(;b=a[e++];)b===a[e]&&(d=c.push(e));for(;d--;)a.splice(c[d],1)}return D=null,a},x=b.getText=function(a){var b,c="",d=0,e=a.nodeType;if(e){if(1===e||9===e||11===e){if("string"==typeof a.textContent)return a.textContent;for(a=a.firstChild;a;a=a.nextSibling)c+=x(a)}else if(3===e||4===e)return a.nodeValue}else for(;b=a[d++];)c+=x(b);return c},w=b.selectors={cacheLength:50,createPseudo:d,match:oa,attrHandle:{},find:{},relative:{">":{dir:"parentNode",first:!0}," ":{dir:"parentNode"},"+":{dir:"previousSibling",first:!0},"~":{dir:"previousSibling"}},preFilter:{ATTR:function(a){return a[1]=a[1].replace(va,wa),a[3]=(a[3]||a[4]||a[5]||"").replace(va,wa),"~="===a[2]&&(a[3]=" "+a[3]+" "),a.slice(0,4)},CHILD:function(a){return a[1]=a[1].toLowerCase(),"nth"===a[1].slice(0,3)?(a[3]||b.error(a[0]),a[4]=+(a[4]?a[5]+(a[6]||1):2*("even"===a[3]||"odd"===a[3])),a[5]=+(a[7]+a[8]||"odd"===a[3])):a[3]&&b.error(a[0]),a},PSEUDO:function(a){var b,c=!a[6]&&a[2];return oa.CHILD.test(a[0])?null:(a[3]?a[2]=a[4]||a[5]||"":c&&ma.test(c)&&(b=z(c,!0))&&(b=c.indexOf(")",c.length-b)-c.length)&&(a[0]=a[0].slice(0,b),a[2]=c.slice(0,b)),a.slice(0,3))}},filter:{TAG:function(a){var b=a.replace(va,wa).toLowerCase();return"*"===a?function(){return!0}:function(a){return a.nodeName&&a.nodeName.toLowerCase()===b}},CLASS:function(a){var b=R[a+" "];return b||(b=new RegExp("(^|"+ca+")"+a+"("+ca+"|$)"))&&R(a,function(a){return b.test("string"==typeof a.className&&a.className||"undefined"!=typeof a.getAttribute&&a.getAttribute("class")||"")})},ATTR:function(a,c,d){return function(e){var f=b.attr(e,a);return null==f?"!="===c:c?(f+="","="===c?f===d:"!="===c?f!==d:"^="===c?d&&0===f.indexOf(d):"*="===c?d&&f.indexOf(d)>-1:"$="===c?d&&f.slice(-d.length)===d:"~="===c?(" "+f.replace(ha," ")+" ").indexOf(d)>-1:"|="===c?f===d||f.slice(0,d.length+1)===d+"-":!1):!0}},CHILD:function(a,b,c,d,e){var f="nth"!==a.slice(0,3),g="last"!==a.slice(-4),h="of-type"===b;return 1===d&&0===e?function(a){return!!a.parentNode}:function(b,c,i){var j,k,l,m,n,o,p=f!==g?"nextSibling":"previousSibling",q=b.parentNode,r=h&&b.nodeName.toLowerCase(),s=!i&&!h;if(q){if(f){for(;p;){for(l=b;l=l[p];)if(h?l.nodeName.toLowerCase()===r:1===l.nodeType)return!1;o=p="only"===a&&!o&&"nextSibling"}return!0}if(o=[g?q.firstChild:q.lastChild],g&&s){for(k=q[N]||(q[N]={}),j=k[a]||[],n=j[0]===P&&j[1],m=j[0]===P&&j[2],l=n&&q.childNodes[n];l=++n&&l&&l[p]||(m=n=0)||o.pop();)if(1===l.nodeType&&++m&&l===b){k[a]=[P,n,m];break}}else if(s&&(j=(b[N]||(b[N]={}))[a])&&j[0]===P)m=j[1];else for(;(l=++n&&l&&l[p]||(m=n=0)||o.pop())&&((h?l.nodeName.toLowerCase()!==r:1!==l.nodeType)||!++m||(s&&((l[N]||(l[N]={}))[a]=[P,m]),l!==b)););return m-=e,m===d||m%d===0&&m/d>=0}}},PSEUDO:function(a,c){var e,f=w.pseudos[a]||w.setFilters[a.toLowerCase()]||b.error("unsupported pseudo: "+a);return f[N]?f(c):f.length>1?(e=[a,a,"",c],w.setFilters.hasOwnProperty(a.toLowerCase())?d(function(a,b){for(var d,e=f(a,c),g=e.length;g--;)d=aa(a,e[g]),a[d]=!(b[d]=e[g])}):function(a){return f(a,0,e)}):f}},pseudos:{not:d(function(a){var b=[],c=[],e=A(a.replace(ia,"$1"));return e[N]?d(function(a,b,c,d){for(var f,g=e(a,null,d,[]),h=a.length;h--;)(f=g[h])&&(a[h]=!(b[h]=f))}):function(a,d,f){return b[0]=a,e(b,null,f,c),b[0]=null,!c.pop()}}),has:d(function(a){return function(c){return b(a,c).length>0}}),contains:d(function(a){return a=a.replace(va,wa),function(b){return(b.textContent||b.innerText||x(b)).indexOf(a)>-1}}),lang:d(function(a){return na.test(a||"")||b.error("unsupported lang: "+a),a=a.replace(va,wa).toLowerCase(),function(b){var c;do if(c=I?b.lang:b.getAttribute("xml:lang")||b.getAttribute("lang"))return c=c.toLowerCase(),c===a||0===c.indexOf(a+"-");while((b=b.parentNode)&&1===b.nodeType);return!1}}),target:function(b){var c=a.location&&a.location.hash;return c&&c.slice(1)===b.id},root:function(a){return a===H},focus:function(a){return a===G.activeElement&&(!G.hasFocus||G.hasFocus())&&!!(a.type||a.href||~a.tabIndex)},enabled:function(a){return a.disabled===!1},disabled:function(a){return a.disabled===!0},checked:function(a){var b=a.nodeName.toLowerCase();return"input"===b&&!!a.checked||"option"===b&&!!a.selected},selected:function(a){return a.parentNode&&a.parentNode.selectedIndex,a.selected===!0},empty:function(a){for(a=a.firstChild;a;a=a.nextSibling)if(a.nodeType<6)return!1;return!0},parent:function(a){return!w.pseudos.empty(a)},header:function(a){return qa.test(a.nodeName)},input:function(a){return pa.test(a.nodeName)},button:function(a){var b=a.nodeName.toLowerCase();return"input"===b&&"button"===a.type||"button"===b},text:function(a){var b;return"input"===a.nodeName.toLowerCase()&&"text"===a.type&&(null==(b=a.getAttribute("type"))||"text"===b.toLowerCase())},first:j(function(){return[0]}),last:j(function(a,b){return[b-1]}),eq:j(function(a,b,c){return[0>c?c+b:c]}),even:j(function(a,b){for(var c=0;b>c;c+=2)a.push(c);return a}),odd:j(function(a,b){for(var c=1;b>c;c+=2)a.push(c);return a}),lt:j(function(a,b,c){for(var d=0>c?c+b:c;--d>=0;)a.push(d);return a}),gt:j(function(a,b,c){for(var d=0>c?c+b:c;++d<b;)a.push(d);return a})}},w.pseudos.nth=w.pseudos.eq;for(u in{radio:!0,checkbox:!0,file:!0,password:!0,image:!0})w.pseudos[u]=h(u);for(u in{submit:!0,reset:!0})w.pseudos[u]=i(u);return l.prototype=w.filters=w.pseudos,w.setFilters=new l,z=b.tokenize=function(a,c){var d,e,f,g,h,i,j,k=S[a+" "];if(k)return c?0:k.slice(0);for(h=a,i=[],j=w.preFilter;h;){(!d||(e=ja.exec(h)))&&(e&&(h=h.slice(e[0].length)||h),i.push(f=[])),d=!1,(e=ka.exec(h))&&(d=e.shift(),f.push({value:d,type:e[0].replace(ia," ")}),h=h.slice(d.length));for(g in w.filter)!(e=oa[g].exec(h))||j[g]&&!(e=j[g](e))||(d=e.shift(),f.push({value:d,type:g,matches:e}),h=h.slice(d.length));if(!d)break}return c?h.length:h?b.error(a):S(a,i).slice(0)},A=b.compile=function(a,b){var c,d=[],e=[],f=T[a+" "];if(!f){for(b||(b=z(a)),c=b.length;c--;)f=s(b[c]),f[N]?d.push(f):e.push(f);f=T(a,t(e,d)),f.selector=a}return f},B=b.select=function(a,b,c,d){var e,f,g,h,i,j="function"==typeof a&&a,l=!d&&z(a=j.selector||a);if(c=c||[],1===l.length){if(f=l[0]=l[0].slice(0),f.length>2&&"ID"===(g=f[0]).type&&v.getById&&9===b.nodeType&&I&&w.relative[f[1].type]){if(b=(w.find.ID(g.matches[0].replace(va,wa),b)||[])[0],!b)return c;j&&(b=b.parentNode),a=a.slice(f.shift().value.length)}for(e=oa.needsContext.test(a)?0:f.length;e--&&(g=f[e],!w.relative[h=g.type]);)if((i=w.find[h])&&(d=i(g.matches[0].replace(va,wa),ta.test(f[0].type)&&k(b.parentNode)||b))){if(f.splice(e,1),a=d.length&&m(f),!a)return $.apply(c,d),c;break}}return(j||A(a,l))(d,b,!I,c,ta.test(a)&&k(b.parentNode)||b),c},v.sortStable=N.split("").sort(U).join("")===N,v.detectDuplicates=!!E,F(),v.sortDetached=e(function(a){return 1&a.compareDocumentPosition(G.createElement("div"))}),e(function(a){return a.innerHTML="<a href='#'></a>","#"===a.firstChild.getAttribute("href")})||f("type|href|height|width",function(a,b,c){return c?void 0:a.getAttribute(b,"type"===b.toLowerCase()?1:2)}),v.attributes&&e(function(a){return a.innerHTML="<input/>",a.firstChild.setAttribute("value",""),""===a.firstChild.getAttribute("value")})||f("value",function(a,b,c){return c||"input"!==a.nodeName.toLowerCase()?void 0:a.defaultValue}),e(function(a){return null==a.getAttribute("disabled")})||f(ba,function(a,b,c){var d;return c?void 0:a[b]===!0?b.toLowerCase():(d=a.getAttributeNode(b))&&d.specified?d.value:null}),b}(a);_.find=ea,_.expr=ea.selectors,_.expr[":"]=_.expr.pseudos,_.unique=ea.uniqueSort,_.text=ea.getText,_.isXMLDoc=ea.isXML,_.contains=ea.contains;var fa=_.expr.match.needsContext,ga=/^<(\w+)\s*\/?>(?:<\/\1>|)$/,ha=/^.[^:#\[\.,]*$/;_.filter=function(a,b,c){var d=b[0];return c&&(a=":not("+a+")"),1===b.length&&1===d.nodeType?_.find.matchesSelector(d,a)?[d]:[]:_.find.matches(a,_.grep(b,function(a){return 1===a.nodeType}))},_.fn.extend({find:function(a){var b,c=this.length,d=[],e=this;if("string"!=typeof a)return this.pushStack(_(a).filter(function(){for(b=0;c>b;b++)if(_.contains(e[b],this))return!0}));for(b=0;c>b;b++)_.find(a,e[b],d);return d=this.pushStack(c>1?_.unique(d):d),d.selector=this.selector?this.selector+" "+a:a,d},filter:function(a){return this.pushStack(d(this,a||[],!1))},not:function(a){return this.pushStack(d(this,a||[],!0))},is:function(a){return!!d(this,"string"==typeof a&&fa.test(a)?_(a):a||[],!1).length}});var ia,ja=/^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/,ka=_.fn.init=function(a,b){var c,d;if(!a)return this;if("string"==typeof a){if(c="<"===a[0]&&">"===a[a.length-1]&&a.length>=3?[null,a,null]:ja.exec(a),!c||!c[1]&&b)return!b||b.jquery?(b||ia).find(a):this.constructor(b).find(a);if(c[1]){if(b=b instanceof _?b[0]:b,_.merge(this,_.parseHTML(c[1],b&&b.nodeType?b.ownerDocument||b:Z,!0)),ga.test(c[1])&&_.isPlainObject(b))for(c in b)_.isFunction(this[c])?this[c](b[c]):this.attr(c,b[c]);return this}return d=Z.getElementById(c[2]),d&&d.parentNode&&(this.length=1,this[0]=d),this.context=Z,this.selector=a,this}return a.nodeType?(this.context=this[0]=a,this.length=1,this):_.isFunction(a)?"undefined"!=typeof ia.ready?ia.ready(a):a(_):(void 0!==a.selector&&(this.selector=a.selector,this.context=a.context),_.makeArray(a,this))};ka.prototype=_.fn,ia=_(Z);var la=/^(?:parents|prev(?:Until|All))/,ma={children:!0,contents:!0,next:!0,prev:!0};_.extend({dir:function(a,b,c){for(var d=[],e=void 0!==c;(a=a[b])&&9!==a.nodeType;)if(1===a.nodeType){if(e&&_(a).is(c))break;d.push(a)}return d},sibling:function(a,b){for(var c=[];a;a=a.nextSibling)1===a.nodeType&&a!==b&&c.push(a);return c}}),_.fn.extend({has:function(a){var b=_(a,this),c=b.length;return this.filter(function(){for(var a=0;c>a;a++)if(_.contains(this,b[a]))return!0})},closest:function(a,b){for(var c,d=0,e=this.length,f=[],g=fa.test(a)||"string"!=typeof a?_(a,b||this.context):0;e>d;d++)for(c=this[d];c&&c!==b;c=c.parentNode)if(c.nodeType<11&&(g?g.index(c)>-1:1===c.nodeType&&_.find.matchesSelector(c,a))){f.push(c);break}return this.pushStack(f.length>1?_.unique(f):f)},index:function(a){return a?"string"==typeof a?U.call(_(a),this[0]):U.call(this,a.jquery?a[0]:a):this[0]&&this[0].parentNode?this.first().prevAll().length:-1},add:function(a,b){return this.pushStack(_.unique(_.merge(this.get(),_(a,b))))},addBack:function(a){return this.add(null==a?this.prevObject:this.prevObject.filter(a))}}),_.each({parent:function(a){var b=a.parentNode;return b&&11!==b.nodeType?b:null},parents:function(a){return _.dir(a,"parentNode")},parentsUntil:function(a,b,c){return _.dir(a,"parentNode",c)},next:function(a){return e(a,"nextSibling")},prev:function(a){return e(a,"previousSibling")},nextAll:function(a){return _.dir(a,"nextSibling")},prevAll:function(a){return _.dir(a,"previousSibling")},nextUntil:function(a,b,c){return _.dir(a,"nextSibling",c)},prevUntil:function(a,b,c){return _.dir(a,"previousSibling",c)},siblings:function(a){return _.sibling((a.parentNode||{}).firstChild,a)},children:function(a){return _.sibling(a.firstChild)},contents:function(a){return a.contentDocument||_.merge([],a.childNodes)}},function(a,b){_.fn[a]=function(c,d){var e=_.map(this,b,c);return"Until"!==a.slice(-5)&&(d=c),d&&"string"==typeof d&&(e=_.filter(d,e)),this.length>1&&(ma[a]||_.unique(e),la.test(a)&&e.reverse()),this.pushStack(e)}});var na=/\S+/g,oa={};_.Callbacks=function(a){a="string"==typeof a?oa[a]||f(a):_.extend({},a);var b,c,d,e,g,h,i=[],j=!a.once&&[],k=function(f){for(b=a.memory&&f,c=!0,h=e||0,e=0,g=i.length,d=!0;i&&g>h;h++)if(i[h].apply(f[0],f[1])===!1&&a.stopOnFalse){b=!1;break}d=!1,i&&(j?j.length&&k(j.shift()):b?i=[]:l.disable())},l={add:function(){if(i){var c=i.length;!function f(b){_.each(b,function(b,c){var d=_.type(c);"function"===d?a.unique&&l.has(c)||i.push(c):c&&c.length&&"string"!==d&&f(c)})}(arguments),d?g=i.length:b&&(e=c,k(b))}return this},remove:function(){return i&&_.each(arguments,function(a,b){for(var c;(c=_.inArray(b,i,c))>-1;)i.splice(c,1),d&&(g>=c&&g--,h>=c&&h--)}),this},has:function(a){return a?_.inArray(a,i)>-1:!(!i||!i.length)},empty:function(){return i=[],g=0,this},disable:function(){return i=j=b=void 0,this},disabled:function(){return!i},lock:function(){return j=void 0,b||l.disable(),this},locked:function(){return!j},fireWith:function(a,b){return!i||c&&!j||(b=b||[],b=[a,b.slice?b.slice():b],d?j.push(b):k(b)),this},fire:function(){return l.fireWith(this,arguments),this},fired:function(){return!!c}};return l},_.extend({Deferred:function(a){var b=[["resolve","done",_.Callbacks("once memory"),"resolved"],["reject","fail",_.Callbacks("once memory"),"rejected"],["notify","progress",_.Callbacks("memory")]],c="pending",d={state:function(){return c},always:function(){return e.done(arguments).fail(arguments),this},then:function(){var a=arguments;return _.Deferred(function(c){_.each(b,function(b,f){var g=_.isFunction(a[b])&&a[b];e[f[1]](function(){var a=g&&g.apply(this,arguments);a&&_.isFunction(a.promise)?a.promise().done(c.resolve).fail(c.reject).progress(c.notify):c[f[0]+"With"](this===d?c.promise():this,g?[a]:arguments)})}),a=null}).promise()},promise:function(a){return null!=a?_.extend(a,d):d}},e={};return d.pipe=d.then,_.each(b,function(a,f){var g=f[2],h=f[3];d[f[1]]=g.add,h&&g.add(function(){c=h},b[1^a][2].disable,b[2][2].lock),e[f[0]]=function(){return e[f[0]+"With"](this===e?d:this,arguments),this},e[f[0]+"With"]=g.fireWith}),d.promise(e),a&&a.call(e,e),e},when:function(a){var b,c,d,e=0,f=R.call(arguments),g=f.length,h=1!==g||a&&_.isFunction(a.promise)?g:0,i=1===h?a:_.Deferred(),j=function(a,c,d){return function(e){c[a]=this,d[a]=arguments.length>1?R.call(arguments):e,d===b?i.notifyWith(c,d):--h||i.resolveWith(c,d)}};if(g>1)for(b=new Array(g),c=new Array(g),d=new Array(g);g>e;e++)f[e]&&_.isFunction(f[e].promise)?f[e].promise().done(j(e,d,f)).fail(i.reject).progress(j(e,c,b)):--h;return h||i.resolveWith(d,f),i.promise()}});var pa;_.fn.ready=function(a){return _.ready.promise().done(a),this},_.extend({isReady:!1,readyWait:1,holdReady:function(a){a?_.readyWait++:_.ready(!0)},ready:function(a){(a===!0?--_.readyWait:_.isReady)||(_.isReady=!0,a!==!0&&--_.readyWait>0||(pa.resolveWith(Z,[_]),_.fn.triggerHandler&&(_(Z).triggerHandler("ready"),_(Z).off("ready"))))}}),_.ready.promise=function(b){return pa||(pa=_.Deferred(),"complete"===Z.readyState?setTimeout(_.ready):(Z.addEventListener("DOMContentLoaded",g,!1),a.addEventListener("load",g,!1))),pa.promise(b)},_.ready.promise();var qa=_.access=function(a,b,c,d,e,f,g){var h=0,i=a.length,j=null==c;if("object"===_.type(c)){e=!0;for(h in c)_.access(a,b,h,c[h],!0,f,g)}else if(void 0!==d&&(e=!0,_.isFunction(d)||(g=!0),j&&(g?(b.call(a,d),b=null):(j=b,b=function(a,b,c){return j.call(_(a),c)})),b))for(;i>h;h++)b(a[h],c,g?d:d.call(a[h],h,b(a[h],c)));return e?a:j?b.call(a):i?b(a[0],c):f};_.acceptData=function(a){return 1===a.nodeType||9===a.nodeType||!+a.nodeType},h.uid=1,h.accepts=_.acceptData,h.prototype={key:function(a){if(!h.accepts(a))return 0;var b={},c=a[this.expando];if(!c){c=h.uid++;try{b[this.expando]={value:c},Object.defineProperties(a,b)}catch(d){b[this.expando]=c,_.extend(a,b)}}return this.cache[c]||(this.cache[c]={}),c},set:function(a,b,c){var d,e=this.key(a),f=this.cache[e];if("string"==typeof b)f[b]=c;else if(_.isEmptyObject(f))_.extend(this.cache[e],b);else for(d in b)f[d]=b[d];return f},get:function(a,b){var c=this.cache[this.key(a)];return void 0===b?c:c[b]},access:function(a,b,c){var d;return void 0===b||b&&"string"==typeof b&&void 0===c?(d=this.get(a,b),void 0!==d?d:this.get(a,_.camelCase(b))):(this.set(a,b,c),void 0!==c?c:b)},remove:function(a,b){var c,d,e,f=this.key(a),g=this.cache[f];if(void 0===b)this.cache[f]={};else{_.isArray(b)?d=b.concat(b.map(_.camelCase)):(e=_.camelCase(b),b in g?d=[b,e]:(d=e,d=d in g?[d]:d.match(na)||[])),c=d.length;for(;c--;)delete g[d[c]]}},hasData:function(a){return!_.isEmptyObject(this.cache[a[this.expando]]||{})},discard:function(a){a[this.expando]&&delete this.cache[a[this.expando]]}};var ra=new h,sa=new h,ta=/^(?:\{[\w\W]*\}|\[[\w\W]*\])$/,ua=/([A-Z])/g;_.extend({hasData:function(a){return sa.hasData(a)||ra.hasData(a)},data:function(a,b,c){return sa.access(a,b,c)},removeData:function(a,b){sa.remove(a,b)},_data:function(a,b,c){return ra.access(a,b,c)},_removeData:function(a,b){ra.remove(a,b)}}),_.fn.extend({data:function(a,b){var c,d,e,f=this[0],g=f&&f.attributes;if(void 0===a){if(this.length&&(e=sa.get(f),1===f.nodeType&&!ra.get(f,"hasDataAttrs"))){for(c=g.length;c--;)g[c]&&(d=g[c].name,0===d.indexOf("data-")&&(d=_.camelCase(d.slice(5)),i(f,d,e[d])));ra.set(f,"hasDataAttrs",!0)}return e}return"object"==typeof a?this.each(function(){sa.set(this,a)}):qa(this,function(b){var c,d=_.camelCase(a);if(f&&void 0===b){if(c=sa.get(f,a),void 0!==c)return c;if(c=sa.get(f,d),void 0!==c)return c;if(c=i(f,d,void 0),void 0!==c)return c}else this.each(function(){var c=sa.get(this,d);sa.set(this,d,b),-1!==a.indexOf("-")&&void 0!==c&&sa.set(this,a,b)})},null,b,arguments.length>1,null,!0)},removeData:function(a){return this.each(function(){sa.remove(this,a)})}}),_.extend({queue:function(a,b,c){var d;return a?(b=(b||"fx")+"queue",d=ra.get(a,b),c&&(!d||_.isArray(c)?d=ra.access(a,b,_.makeArray(c)):d.push(c)),d||[]):void 0},dequeue:function(a,b){b=b||"fx";var c=_.queue(a,b),d=c.length,e=c.shift(),f=_._queueHooks(a,b),g=function(){_.dequeue(a,b)};"inprogress"===e&&(e=c.shift(),d--),e&&("fx"===b&&c.unshift("inprogress"),delete f.stop,e.call(a,g,f)),!d&&f&&f.empty.fire()},_queueHooks:function(a,b){var c=b+"queueHooks";return ra.get(a,c)||ra.access(a,c,{empty:_.Callbacks("once memory").add(function(){ra.remove(a,[b+"queue",c])})})}}),_.fn.extend({queue:function(a,b){var c=2;return"string"!=typeof a&&(b=a,a="fx",c--),arguments.length<c?_.queue(this[0],a):void 0===b?this:this.each(function(){var c=_.queue(this,a,b);_._queueHooks(this,a),"fx"===a&&"inprogress"!==c[0]&&_.dequeue(this,a)})},dequeue:function(a){return this.each(function(){_.dequeue(this,a)})},clearQueue:function(a){return this.queue(a||"fx",[])},promise:function(a,b){var c,d=1,e=_.Deferred(),f=this,g=this.length,h=function(){--d||e.resolveWith(f,[f])};for("string"!=typeof a&&(b=a,a=void 0),a=a||"fx";g--;)c=ra.get(f[g],a+"queueHooks"),c&&c.empty&&(d++,c.empty.add(h));return h(),e.promise(b)}});var va=/[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/.source,wa=["Top","Right","Bottom","Left"],xa=function(a,b){return a=b||a,"none"===_.css(a,"display")||!_.contains(a.ownerDocument,a)},ya=/^(?:checkbox|radio)$/i;!function(){var a=Z.createDocumentFragment(),b=a.appendChild(Z.createElement("div")),c=Z.createElement("input");c.setAttribute("type","radio"),c.setAttribute("checked","checked"),c.setAttribute("name","t"),b.appendChild(c),Y.checkClone=b.cloneNode(!0).cloneNode(!0).lastChild.checked,b.innerHTML="<textarea>x</textarea>",Y.noCloneChecked=!!b.cloneNode(!0).lastChild.defaultValue}();var za="undefined";Y.focusinBubbles="onfocusin"in a;var Aa=/^key/,Ba=/^(?:mouse|pointer|contextmenu)|click/,Ca=/^(?:focusinfocus|focusoutblur)$/,Da=/^([^.]*)(?:\.(.+)|)$/;_.event={global:{},add:function(a,b,c,d,e){var f,g,h,i,j,k,l,m,n,o,p,q=ra.get(a);if(q)for(c.handler&&(f=c,c=f.handler,e=f.selector),c.guid||(c.guid=_.guid++),(i=q.events)||(i=q.events={}),(g=q.handle)||(g=q.handle=function(b){return typeof _!==za&&_.event.triggered!==b.type?_.event.dispatch.apply(a,arguments):void 0}),b=(b||"").match(na)||[""],j=b.length;j--;)h=Da.exec(b[j])||[],n=p=h[1],o=(h[2]||"").split(".").sort(),n&&(l=_.event.special[n]||{},n=(e?l.delegateType:l.bindType)||n,l=_.event.special[n]||{},k=_.extend({type:n,origType:p,data:d,handler:c,guid:c.guid,selector:e,needsContext:e&&_.expr.match.needsContext.test(e),namespace:o.join(".")},f),(m=i[n])||(m=i[n]=[],m.delegateCount=0,l.setup&&l.setup.call(a,d,o,g)!==!1||a.addEventListener&&a.addEventListener(n,g,!1)),l.add&&(l.add.call(a,k),k.handler.guid||(k.handler.guid=c.guid)),e?m.splice(m.delegateCount++,0,k):m.push(k),_.event.global[n]=!0)},remove:function(a,b,c,d,e){var f,g,h,i,j,k,l,m,n,o,p,q=ra.hasData(a)&&ra.get(a);if(q&&(i=q.events)){for(b=(b||"").match(na)||[""],j=b.length;j--;)if(h=Da.exec(b[j])||[],n=p=h[1],o=(h[2]||"").split(".").sort(),n){for(l=_.event.special[n]||{},n=(d?l.delegateType:l.bindType)||n,m=i[n]||[],h=h[2]&&new RegExp("(^|\\.)"+o.join("\\.(?:.*\\.|)")+"(\\.|$)"),g=f=m.length;f--;)k=m[f],!e&&p!==k.origType||c&&c.guid!==k.guid||h&&!h.test(k.namespace)||d&&d!==k.selector&&("**"!==d||!k.selector)||(m.splice(f,1),k.selector&&m.delegateCount--,l.remove&&l.remove.call(a,k));g&&!m.length&&(l.teardown&&l.teardown.call(a,o,q.handle)!==!1||_.removeEvent(a,n,q.handle),delete i[n])}else for(n in i)_.event.remove(a,n+b[j],c,d,!0);_.isEmptyObject(i)&&(delete q.handle,ra.remove(a,"events"))}},trigger:function(b,c,d,e){var f,g,h,i,j,k,l,m=[d||Z],n=X.call(b,"type")?b.type:b,o=X.call(b,"namespace")?b.namespace.split("."):[];if(g=h=d=d||Z,3!==d.nodeType&&8!==d.nodeType&&!Ca.test(n+_.event.triggered)&&(n.indexOf(".")>=0&&(o=n.split("."),n=o.shift(),o.sort()),j=n.indexOf(":")<0&&"on"+n,b=b[_.expando]?b:new _.Event(n,"object"==typeof b&&b),b.isTrigger=e?2:3,b.namespace=o.join("."),b.namespace_re=b.namespace?new RegExp("(^|\\.)"+o.join("\\.(?:.*\\.|)")+"(\\.|$)"):null,b.result=void 0,b.target||(b.target=d),
-c=null==c?[b]:_.makeArray(c,[b]),l=_.event.special[n]||{},e||!l.trigger||l.trigger.apply(d,c)!==!1)){if(!e&&!l.noBubble&&!_.isWindow(d)){for(i=l.delegateType||n,Ca.test(i+n)||(g=g.parentNode);g;g=g.parentNode)m.push(g),h=g;h===(d.ownerDocument||Z)&&m.push(h.defaultView||h.parentWindow||a)}for(f=0;(g=m[f++])&&!b.isPropagationStopped();)b.type=f>1?i:l.bindType||n,k=(ra.get(g,"events")||{})[b.type]&&ra.get(g,"handle"),k&&k.apply(g,c),k=j&&g[j],k&&k.apply&&_.acceptData(g)&&(b.result=k.apply(g,c),b.result===!1&&b.preventDefault());return b.type=n,e||b.isDefaultPrevented()||l._default&&l._default.apply(m.pop(),c)!==!1||!_.acceptData(d)||j&&_.isFunction(d[n])&&!_.isWindow(d)&&(h=d[j],h&&(d[j]=null),_.event.triggered=n,d[n](),_.event.triggered=void 0,h&&(d[j]=h)),b.result}},dispatch:function(a){a=_.event.fix(a);var b,c,d,e,f,g=[],h=R.call(arguments),i=(ra.get(this,"events")||{})[a.type]||[],j=_.event.special[a.type]||{};if(h[0]=a,a.delegateTarget=this,!j.preDispatch||j.preDispatch.call(this,a)!==!1){for(g=_.event.handlers.call(this,a,i),b=0;(e=g[b++])&&!a.isPropagationStopped();)for(a.currentTarget=e.elem,c=0;(f=e.handlers[c++])&&!a.isImmediatePropagationStopped();)(!a.namespace_re||a.namespace_re.test(f.namespace))&&(a.handleObj=f,a.data=f.data,d=((_.event.special[f.origType]||{}).handle||f.handler).apply(e.elem,h),void 0!==d&&(a.result=d)===!1&&(a.preventDefault(),a.stopPropagation()));return j.postDispatch&&j.postDispatch.call(this,a),a.result}},handlers:function(a,b){var c,d,e,f,g=[],h=b.delegateCount,i=a.target;if(h&&i.nodeType&&(!a.button||"click"!==a.type))for(;i!==this;i=i.parentNode||this)if(i.disabled!==!0||"click"!==a.type){for(d=[],c=0;h>c;c++)f=b[c],e=f.selector+" ",void 0===d[e]&&(d[e]=f.needsContext?_(e,this).index(i)>=0:_.find(e,this,null,[i]).length),d[e]&&d.push(f);d.length&&g.push({elem:i,handlers:d})}return h<b.length&&g.push({elem:this,handlers:b.slice(h)}),g},props:"altKey bubbles cancelable ctrlKey currentTarget eventPhase metaKey relatedTarget shiftKey target timeStamp view which".split(" "),fixHooks:{},keyHooks:{props:"char charCode key keyCode".split(" "),filter:function(a,b){return null==a.which&&(a.which=null!=b.charCode?b.charCode:b.keyCode),a}},mouseHooks:{props:"button buttons clientX clientY offsetX offsetY pageX pageY screenX screenY toElement".split(" "),filter:function(a,b){var c,d,e,f=b.button;return null==a.pageX&&null!=b.clientX&&(c=a.target.ownerDocument||Z,d=c.documentElement,e=c.body,a.pageX=b.clientX+(d&&d.scrollLeft||e&&e.scrollLeft||0)-(d&&d.clientLeft||e&&e.clientLeft||0),a.pageY=b.clientY+(d&&d.scrollTop||e&&e.scrollTop||0)-(d&&d.clientTop||e&&e.clientTop||0)),a.which||void 0===f||(a.which=1&f?1:2&f?3:4&f?2:0),a}},fix:function(a){if(a[_.expando])return a;var b,c,d,e=a.type,f=a,g=this.fixHooks[e];for(g||(this.fixHooks[e]=g=Ba.test(e)?this.mouseHooks:Aa.test(e)?this.keyHooks:{}),d=g.props?this.props.concat(g.props):this.props,a=new _.Event(f),b=d.length;b--;)c=d[b],a[c]=f[c];return a.target||(a.target=Z),3===a.target.nodeType&&(a.target=a.target.parentNode),g.filter?g.filter(a,f):a},special:{load:{noBubble:!0},focus:{trigger:function(){return this!==l()&&this.focus?(this.focus(),!1):void 0},delegateType:"focusin"},blur:{trigger:function(){return this===l()&&this.blur?(this.blur(),!1):void 0},delegateType:"focusout"},click:{trigger:function(){return"checkbox"===this.type&&this.click&&_.nodeName(this,"input")?(this.click(),!1):void 0},_default:function(a){return _.nodeName(a.target,"a")}},beforeunload:{postDispatch:function(a){void 0!==a.result&&a.originalEvent&&(a.originalEvent.returnValue=a.result)}}},simulate:function(a,b,c,d){var e=_.extend(new _.Event,c,{type:a,isSimulated:!0,originalEvent:{}});d?_.event.trigger(e,null,b):_.event.dispatch.call(b,e),e.isDefaultPrevented()&&c.preventDefault()}},_.removeEvent=function(a,b,c){a.removeEventListener&&a.removeEventListener(b,c,!1)},_.Event=function(a,b){return this instanceof _.Event?(a&&a.type?(this.originalEvent=a,this.type=a.type,this.isDefaultPrevented=a.defaultPrevented||void 0===a.defaultPrevented&&a.returnValue===!1?j:k):this.type=a,b&&_.extend(this,b),this.timeStamp=a&&a.timeStamp||_.now(),void(this[_.expando]=!0)):new _.Event(a,b)},_.Event.prototype={isDefaultPrevented:k,isPropagationStopped:k,isImmediatePropagationStopped:k,preventDefault:function(){var a=this.originalEvent;this.isDefaultPrevented=j,a&&a.preventDefault&&a.preventDefault()},stopPropagation:function(){var a=this.originalEvent;this.isPropagationStopped=j,a&&a.stopPropagation&&a.stopPropagation()},stopImmediatePropagation:function(){var a=this.originalEvent;this.isImmediatePropagationStopped=j,a&&a.stopImmediatePropagation&&a.stopImmediatePropagation(),this.stopPropagation()}},_.each({mouseenter:"mouseover",mouseleave:"mouseout",pointerenter:"pointerover",pointerleave:"pointerout"},function(a,b){_.event.special[a]={delegateType:b,bindType:b,handle:function(a){var c,d=this,e=a.relatedTarget,f=a.handleObj;return(!e||e!==d&&!_.contains(d,e))&&(a.type=f.origType,c=f.handler.apply(this,arguments),a.type=b),c}}}),Y.focusinBubbles||_.each({focus:"focusin",blur:"focusout"},function(a,b){var c=function(a){_.event.simulate(b,a.target,_.event.fix(a),!0)};_.event.special[b]={setup:function(){var d=this.ownerDocument||this,e=ra.access(d,b);e||d.addEventListener(a,c,!0),ra.access(d,b,(e||0)+1)},teardown:function(){var d=this.ownerDocument||this,e=ra.access(d,b)-1;e?ra.access(d,b,e):(d.removeEventListener(a,c,!0),ra.remove(d,b))}}}),_.fn.extend({on:function(a,b,c,d,e){var f,g;if("object"==typeof a){"string"!=typeof b&&(c=c||b,b=void 0);for(g in a)this.on(g,b,c,a[g],e);return this}if(null==c&&null==d?(d=b,c=b=void 0):null==d&&("string"==typeof b?(d=c,c=void 0):(d=c,c=b,b=void 0)),d===!1)d=k;else if(!d)return this;return 1===e&&(f=d,d=function(a){return _().off(a),f.apply(this,arguments)},d.guid=f.guid||(f.guid=_.guid++)),this.each(function(){_.event.add(this,a,d,c,b)})},one:function(a,b,c,d){return this.on(a,b,c,d,1)},off:function(a,b,c){var d,e;if(a&&a.preventDefault&&a.handleObj)return d=a.handleObj,_(a.delegateTarget).off(d.namespace?d.origType+"."+d.namespace:d.origType,d.selector,d.handler),this;if("object"==typeof a){for(e in a)this.off(e,b,a[e]);return this}return(b===!1||"function"==typeof b)&&(c=b,b=void 0),c===!1&&(c=k),this.each(function(){_.event.remove(this,a,c,b)})},trigger:function(a,b){return this.each(function(){_.event.trigger(a,b,this)})},triggerHandler:function(a,b){var c=this[0];return c?_.event.trigger(a,b,c,!0):void 0}});var Ea=/<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/gi,Fa=/<([\w:]+)/,Ga=/<|&#?\w+;/,Ha=/<(?:script|style|link)/i,Ia=/checked\s*(?:[^=]|=\s*.checked.)/i,Ja=/^$|\/(?:java|ecma)script/i,Ka=/^true\/(.*)/,La=/^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g,Ma={option:[1,"<select multiple='multiple'>","</select>"],thead:[1,"<table>","</table>"],col:[2,"<table><colgroup>","</colgroup></table>"],tr:[2,"<table><tbody>","</tbody></table>"],td:[3,"<table><tbody><tr>","</tr></tbody></table>"],_default:[0,"",""]};Ma.optgroup=Ma.option,Ma.tbody=Ma.tfoot=Ma.colgroup=Ma.caption=Ma.thead,Ma.th=Ma.td,_.extend({clone:function(a,b,c){var d,e,f,g,h=a.cloneNode(!0),i=_.contains(a.ownerDocument,a);if(!(Y.noCloneChecked||1!==a.nodeType&&11!==a.nodeType||_.isXMLDoc(a)))for(g=r(h),f=r(a),d=0,e=f.length;e>d;d++)s(f[d],g[d]);if(b)if(c)for(f=f||r(a),g=g||r(h),d=0,e=f.length;e>d;d++)q(f[d],g[d]);else q(a,h);return g=r(h,"script"),g.length>0&&p(g,!i&&r(a,"script")),h},buildFragment:function(a,b,c,d){for(var e,f,g,h,i,j,k=b.createDocumentFragment(),l=[],m=0,n=a.length;n>m;m++)if(e=a[m],e||0===e)if("object"===_.type(e))_.merge(l,e.nodeType?[e]:e);else if(Ga.test(e)){for(f=f||k.appendChild(b.createElement("div")),g=(Fa.exec(e)||["",""])[1].toLowerCase(),h=Ma[g]||Ma._default,f.innerHTML=h[1]+e.replace(Ea,"<$1></$2>")+h[2],j=h[0];j--;)f=f.lastChild;_.merge(l,f.childNodes),f=k.firstChild,f.textContent=""}else l.push(b.createTextNode(e));for(k.textContent="",m=0;e=l[m++];)if((!d||-1===_.inArray(e,d))&&(i=_.contains(e.ownerDocument,e),f=r(k.appendChild(e),"script"),i&&p(f),c))for(j=0;e=f[j++];)Ja.test(e.type||"")&&c.push(e);return k},cleanData:function(a){for(var b,c,d,e,f=_.event.special,g=0;void 0!==(c=a[g]);g++){if(_.acceptData(c)&&(e=c[ra.expando],e&&(b=ra.cache[e]))){if(b.events)for(d in b.events)f[d]?_.event.remove(c,d):_.removeEvent(c,d,b.handle);ra.cache[e]&&delete ra.cache[e]}delete sa.cache[c[sa.expando]]}}}),_.fn.extend({text:function(a){return qa(this,function(a){return void 0===a?_.text(this):this.empty().each(function(){(1===this.nodeType||11===this.nodeType||9===this.nodeType)&&(this.textContent=a)})},null,a,arguments.length)},append:function(){return this.domManip(arguments,function(a){if(1===this.nodeType||11===this.nodeType||9===this.nodeType){var b=m(this,a);b.appendChild(a)}})},prepend:function(){return this.domManip(arguments,function(a){if(1===this.nodeType||11===this.nodeType||9===this.nodeType){var b=m(this,a);b.insertBefore(a,b.firstChild)}})},before:function(){return this.domManip(arguments,function(a){this.parentNode&&this.parentNode.insertBefore(a,this)})},after:function(){return this.domManip(arguments,function(a){this.parentNode&&this.parentNode.insertBefore(a,this.nextSibling)})},remove:function(a,b){for(var c,d=a?_.filter(a,this):this,e=0;null!=(c=d[e]);e++)b||1!==c.nodeType||_.cleanData(r(c)),c.parentNode&&(b&&_.contains(c.ownerDocument,c)&&p(r(c,"script")),c.parentNode.removeChild(c));return this},empty:function(){for(var a,b=0;null!=(a=this[b]);b++)1===a.nodeType&&(_.cleanData(r(a,!1)),a.textContent="");return this},clone:function(a,b){return a=null==a?!1:a,b=null==b?a:b,this.map(function(){return _.clone(this,a,b)})},html:function(a){return qa(this,function(a){var b=this[0]||{},c=0,d=this.length;if(void 0===a&&1===b.nodeType)return b.innerHTML;if("string"==typeof a&&!Ha.test(a)&&!Ma[(Fa.exec(a)||["",""])[1].toLowerCase()]){a=a.replace(Ea,"<$1></$2>");try{for(;d>c;c++)b=this[c]||{},1===b.nodeType&&(_.cleanData(r(b,!1)),b.innerHTML=a);b=0}catch(e){}}b&&this.empty().append(a)},null,a,arguments.length)},replaceWith:function(){var a=arguments[0];return this.domManip(arguments,function(b){a=this.parentNode,_.cleanData(r(this)),a&&a.replaceChild(b,this)}),a&&(a.length||a.nodeType)?this:this.remove()},detach:function(a){return this.remove(a,!0)},domManip:function(a,b){a=S.apply([],a);var c,d,e,f,g,h,i=0,j=this.length,k=this,l=j-1,m=a[0],p=_.isFunction(m);if(p||j>1&&"string"==typeof m&&!Y.checkClone&&Ia.test(m))return this.each(function(c){var d=k.eq(c);p&&(a[0]=m.call(this,c,d.html())),d.domManip(a,b)});if(j&&(c=_.buildFragment(a,this[0].ownerDocument,!1,this),d=c.firstChild,1===c.childNodes.length&&(c=d),d)){for(e=_.map(r(c,"script"),n),f=e.length;j>i;i++)g=c,i!==l&&(g=_.clone(g,!0,!0),f&&_.merge(e,r(g,"script"))),b.call(this[i],g,i);if(f)for(h=e[e.length-1].ownerDocument,_.map(e,o),i=0;f>i;i++)g=e[i],Ja.test(g.type||"")&&!ra.access(g,"globalEval")&&_.contains(h,g)&&(g.src?_._evalUrl&&_._evalUrl(g.src):_.globalEval(g.textContent.replace(La,"")))}return this}}),_.each({appendTo:"append",prependTo:"prepend",insertBefore:"before",insertAfter:"after",replaceAll:"replaceWith"},function(a,b){_.fn[a]=function(a){for(var c,d=[],e=_(a),f=e.length-1,g=0;f>=g;g++)c=g===f?this:this.clone(!0),_(e[g])[b](c),T.apply(d,c.get());return this.pushStack(d)}});var Na,Oa={},Pa=/^margin/,Qa=new RegExp("^("+va+")(?!px)[a-z%]+$","i"),Ra=function(b){return b.ownerDocument.defaultView.opener?b.ownerDocument.defaultView.getComputedStyle(b,null):a.getComputedStyle(b,null)};!function(){function b(){g.style.cssText="-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;display:block;margin-top:1%;top:1%;border:1px;padding:1px;width:4px;position:absolute",g.innerHTML="",e.appendChild(f);var b=a.getComputedStyle(g,null);c="1%"!==b.top,d="4px"===b.width,e.removeChild(f)}var c,d,e=Z.documentElement,f=Z.createElement("div"),g=Z.createElement("div");g.style&&(g.style.backgroundClip="content-box",g.cloneNode(!0).style.backgroundClip="",Y.clearCloneStyle="content-box"===g.style.backgroundClip,f.style.cssText="border:0;width:0;height:0;top:0;left:-9999px;margin-top:1px;position:absolute",f.appendChild(g),a.getComputedStyle&&_.extend(Y,{pixelPosition:function(){return b(),c},boxSizingReliable:function(){return null==d&&b(),d},reliableMarginRight:function(){var b,c=g.appendChild(Z.createElement("div"));return c.style.cssText=g.style.cssText="-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box;display:block;margin:0;border:0;padding:0",c.style.marginRight=c.style.width="0",g.style.width="1px",e.appendChild(f),b=!parseFloat(a.getComputedStyle(c,null).marginRight),e.removeChild(f),g.removeChild(c),b}}))}(),_.swap=function(a,b,c,d){var e,f,g={};for(f in b)g[f]=a.style[f],a.style[f]=b[f];e=c.apply(a,d||[]);for(f in b)a.style[f]=g[f];return e};var Sa=/^(none|table(?!-c[ea]).+)/,Ta=new RegExp("^("+va+")(.*)$","i"),Ua=new RegExp("^([+-])=("+va+")","i"),Va={position:"absolute",visibility:"hidden",display:"block"},Wa={letterSpacing:"0",fontWeight:"400"},Xa=["Webkit","O","Moz","ms"];_.extend({cssHooks:{opacity:{get:function(a,b){if(b){var c=v(a,"opacity");return""===c?"1":c}}}},cssNumber:{columnCount:!0,fillOpacity:!0,flexGrow:!0,flexShrink:!0,fontWeight:!0,lineHeight:!0,opacity:!0,order:!0,orphans:!0,widows:!0,zIndex:!0,zoom:!0},cssProps:{"float":"cssFloat"},style:function(a,b,c,d){if(a&&3!==a.nodeType&&8!==a.nodeType&&a.style){var e,f,g,h=_.camelCase(b),i=a.style;return b=_.cssProps[h]||(_.cssProps[h]=x(i,h)),g=_.cssHooks[b]||_.cssHooks[h],void 0===c?g&&"get"in g&&void 0!==(e=g.get(a,!1,d))?e:i[b]:(f=typeof c,"string"===f&&(e=Ua.exec(c))&&(c=(e[1]+1)*e[2]+parseFloat(_.css(a,b)),f="number"),null!=c&&c===c&&("number"!==f||_.cssNumber[h]||(c+="px"),Y.clearCloneStyle||""!==c||0!==b.indexOf("background")||(i[b]="inherit"),g&&"set"in g&&void 0===(c=g.set(a,c,d))||(i[b]=c)),void 0)}},css:function(a,b,c,d){var e,f,g,h=_.camelCase(b);return b=_.cssProps[h]||(_.cssProps[h]=x(a.style,h)),g=_.cssHooks[b]||_.cssHooks[h],g&&"get"in g&&(e=g.get(a,!0,c)),void 0===e&&(e=v(a,b,d)),"normal"===e&&b in Wa&&(e=Wa[b]),""===c||c?(f=parseFloat(e),c===!0||_.isNumeric(f)?f||0:e):e}}),_.each(["height","width"],function(a,b){_.cssHooks[b]={get:function(a,c,d){return c?Sa.test(_.css(a,"display"))&&0===a.offsetWidth?_.swap(a,Va,function(){return A(a,b,d)}):A(a,b,d):void 0},set:function(a,c,d){var e=d&&Ra(a);return y(a,c,d?z(a,b,d,"border-box"===_.css(a,"boxSizing",!1,e),e):0)}}}),_.cssHooks.marginRight=w(Y.reliableMarginRight,function(a,b){return b?_.swap(a,{display:"inline-block"},v,[a,"marginRight"]):void 0}),_.each({margin:"",padding:"",border:"Width"},function(a,b){_.cssHooks[a+b]={expand:function(c){for(var d=0,e={},f="string"==typeof c?c.split(" "):[c];4>d;d++)e[a+wa[d]+b]=f[d]||f[d-2]||f[0];return e}},Pa.test(a)||(_.cssHooks[a+b].set=y)}),_.fn.extend({css:function(a,b){return qa(this,function(a,b,c){var d,e,f={},g=0;if(_.isArray(b)){for(d=Ra(a),e=b.length;e>g;g++)f[b[g]]=_.css(a,b[g],!1,d);return f}return void 0!==c?_.style(a,b,c):_.css(a,b)},a,b,arguments.length>1)},show:function(){return B(this,!0)},hide:function(){return B(this)},toggle:function(a){return"boolean"==typeof a?a?this.show():this.hide():this.each(function(){xa(this)?_(this).show():_(this).hide()})}}),_.Tween=C,C.prototype={constructor:C,init:function(a,b,c,d,e,f){this.elem=a,this.prop=c,this.easing=e||"swing",this.options=b,this.start=this.now=this.cur(),this.end=d,this.unit=f||(_.cssNumber[c]?"":"px")},cur:function(){var a=C.propHooks[this.prop];return a&&a.get?a.get(this):C.propHooks._default.get(this)},run:function(a){var b,c=C.propHooks[this.prop];return this.options.duration?this.pos=b=_.easing[this.easing](a,this.options.duration*a,0,1,this.options.duration):this.pos=b=a,this.now=(this.end-this.start)*b+this.start,this.options.step&&this.options.step.call(this.elem,this.now,this),c&&c.set?c.set(this):C.propHooks._default.set(this),this}},C.prototype.init.prototype=C.prototype,C.propHooks={_default:{get:function(a){var b;return null==a.elem[a.prop]||a.elem.style&&null!=a.elem.style[a.prop]?(b=_.css(a.elem,a.prop,""),b&&"auto"!==b?b:0):a.elem[a.prop]},set:function(a){_.fx.step[a.prop]?_.fx.step[a.prop](a):a.elem.style&&(null!=a.elem.style[_.cssProps[a.prop]]||_.cssHooks[a.prop])?_.style(a.elem,a.prop,a.now+a.unit):a.elem[a.prop]=a.now}}},C.propHooks.scrollTop=C.propHooks.scrollLeft={set:function(a){a.elem.nodeType&&a.elem.parentNode&&(a.elem[a.prop]=a.now)}},_.easing={linear:function(a){return a},swing:function(a){return.5-Math.cos(a*Math.PI)/2}},_.fx=C.prototype.init,_.fx.step={};var Ya,Za,$a=/^(?:toggle|show|hide)$/,_a=new RegExp("^(?:([+-])=|)("+va+")([a-z%]*)$","i"),ab=/queueHooks$/,bb=[G],cb={"*":[function(a,b){var c=this.createTween(a,b),d=c.cur(),e=_a.exec(b),f=e&&e[3]||(_.cssNumber[a]?"":"px"),g=(_.cssNumber[a]||"px"!==f&&+d)&&_a.exec(_.css(c.elem,a)),h=1,i=20;if(g&&g[3]!==f){f=f||g[3],e=e||[],g=+d||1;do h=h||".5",g/=h,_.style(c.elem,a,g+f);while(h!==(h=c.cur()/d)&&1!==h&&--i)}return e&&(g=c.start=+g||+d||0,c.unit=f,c.end=e[1]?g+(e[1]+1)*e[2]:+e[2]),c}]};_.Animation=_.extend(I,{tweener:function(a,b){_.isFunction(a)?(b=a,a=["*"]):a=a.split(" ");for(var c,d=0,e=a.length;e>d;d++)c=a[d],cb[c]=cb[c]||[],cb[c].unshift(b)},prefilter:function(a,b){b?bb.unshift(a):bb.push(a)}}),_.speed=function(a,b,c){var d=a&&"object"==typeof a?_.extend({},a):{complete:c||!c&&b||_.isFunction(a)&&a,duration:a,easing:c&&b||b&&!_.isFunction(b)&&b};return d.duration=_.fx.off?0:"number"==typeof d.duration?d.duration:d.duration in _.fx.speeds?_.fx.speeds[d.duration]:_.fx.speeds._default,(null==d.queue||d.queue===!0)&&(d.queue="fx"),d.old=d.complete,d.complete=function(){_.isFunction(d.old)&&d.old.call(this),d.queue&&_.dequeue(this,d.queue)},d},_.fn.extend({fadeTo:function(a,b,c,d){return this.filter(xa).css("opacity",0).show().end().animate({opacity:b},a,c,d)},animate:function(a,b,c,d){var e=_.isEmptyObject(a),f=_.speed(b,c,d),g=function(){var b=I(this,_.extend({},a),f);(e||ra.get(this,"finish"))&&b.stop(!0)};return g.finish=g,e||f.queue===!1?this.each(g):this.queue(f.queue,g)},stop:function(a,b,c){var d=function(a){var b=a.stop;delete a.stop,b(c)};return"string"!=typeof a&&(c=b,b=a,a=void 0),b&&a!==!1&&this.queue(a||"fx",[]),this.each(function(){var b=!0,e=null!=a&&a+"queueHooks",f=_.timers,g=ra.get(this);if(e)g[e]&&g[e].stop&&d(g[e]);else for(e in g)g[e]&&g[e].stop&&ab.test(e)&&d(g[e]);for(e=f.length;e--;)f[e].elem!==this||null!=a&&f[e].queue!==a||(f[e].anim.stop(c),b=!1,f.splice(e,1));(b||!c)&&_.dequeue(this,a)})},finish:function(a){return a!==!1&&(a=a||"fx"),this.each(function(){var b,c=ra.get(this),d=c[a+"queue"],e=c[a+"queueHooks"],f=_.timers,g=d?d.length:0;for(c.finish=!0,_.queue(this,a,[]),e&&e.stop&&e.stop.call(this,!0),b=f.length;b--;)f[b].elem===this&&f[b].queue===a&&(f[b].anim.stop(!0),f.splice(b,1));for(b=0;g>b;b++)d[b]&&d[b].finish&&d[b].finish.call(this);delete c.finish})}}),_.each(["toggle","show","hide"],function(a,b){var c=_.fn[b];_.fn[b]=function(a,d,e){return null==a||"boolean"==typeof a?c.apply(this,arguments):this.animate(E(b,!0),a,d,e)}}),_.each({slideDown:E("show"),slideUp:E("hide"),slideToggle:E("toggle"),fadeIn:{opacity:"show"},fadeOut:{opacity:"hide"},fadeToggle:{opacity:"toggle"}},function(a,b){_.fn[a]=function(a,c,d){return this.animate(b,a,c,d)}}),_.timers=[],_.fx.tick=function(){var a,b=0,c=_.timers;for(Ya=_.now();b<c.length;b++)a=c[b],a()||c[b]!==a||c.splice(b--,1);c.length||_.fx.stop(),Ya=void 0},_.fx.timer=function(a){_.timers.push(a),a()?_.fx.start():_.timers.pop()},_.fx.interval=13,_.fx.start=function(){Za||(Za=setInterval(_.fx.tick,_.fx.interval))},_.fx.stop=function(){clearInterval(Za),Za=null},_.fx.speeds={slow:600,fast:200,_default:400},_.fn.delay=function(a,b){return a=_.fx?_.fx.speeds[a]||a:a,b=b||"fx",this.queue(b,function(b,c){var d=setTimeout(b,a);c.stop=function(){clearTimeout(d)}})},function(){var a=Z.createElement("input"),b=Z.createElement("select"),c=b.appendChild(Z.createElement("option"));a.type="checkbox",Y.checkOn=""!==a.value,Y.optSelected=c.selected,b.disabled=!0,Y.optDisabled=!c.disabled,a=Z.createElement("input"),a.value="t",a.type="radio",Y.radioValue="t"===a.value}();var db,eb,fb=_.expr.attrHandle;_.fn.extend({attr:function(a,b){return qa(this,_.attr,a,b,arguments.length>1)},removeAttr:function(a){return this.each(function(){_.removeAttr(this,a)})}}),_.extend({attr:function(a,b,c){var d,e,f=a.nodeType;if(a&&3!==f&&8!==f&&2!==f)return typeof a.getAttribute===za?_.prop(a,b,c):(1===f&&_.isXMLDoc(a)||(b=b.toLowerCase(),d=_.attrHooks[b]||(_.expr.match.bool.test(b)?eb:db)),void 0===c?d&&"get"in d&&null!==(e=d.get(a,b))?e:(e=_.find.attr(a,b),null==e?void 0:e):null!==c?d&&"set"in d&&void 0!==(e=d.set(a,c,b))?e:(a.setAttribute(b,c+""),c):void _.removeAttr(a,b))},removeAttr:function(a,b){var c,d,e=0,f=b&&b.match(na);if(f&&1===a.nodeType)for(;c=f[e++];)d=_.propFix[c]||c,_.expr.match.bool.test(c)&&(a[d]=!1),a.removeAttribute(c)},attrHooks:{type:{set:function(a,b){if(!Y.radioValue&&"radio"===b&&_.nodeName(a,"input")){var c=a.value;return a.setAttribute("type",b),c&&(a.value=c),b}}}}}),eb={set:function(a,b,c){return b===!1?_.removeAttr(a,c):a.setAttribute(c,c),c}},_.each(_.expr.match.bool.source.match(/\w+/g),function(a,b){var c=fb[b]||_.find.attr;fb[b]=function(a,b,d){var e,f;return d||(f=fb[b],fb[b]=e,e=null!=c(a,b,d)?b.toLowerCase():null,fb[b]=f),e}});var gb=/^(?:input|select|textarea|button)$/i;_.fn.extend({prop:function(a,b){return qa(this,_.prop,a,b,arguments.length>1)},removeProp:function(a){return this.each(function(){delete this[_.propFix[a]||a]})}}),_.extend({propFix:{"for":"htmlFor","class":"className"},prop:function(a,b,c){var d,e,f,g=a.nodeType;if(a&&3!==g&&8!==g&&2!==g)return f=1!==g||!_.isXMLDoc(a),f&&(b=_.propFix[b]||b,e=_.propHooks[b]),void 0!==c?e&&"set"in e&&void 0!==(d=e.set(a,c,b))?d:a[b]=c:e&&"get"in e&&null!==(d=e.get(a,b))?d:a[b]},propHooks:{tabIndex:{get:function(a){return a.hasAttribute("tabindex")||gb.test(a.nodeName)||a.href?a.tabIndex:-1}}}}),Y.optSelected||(_.propHooks.selected={get:function(a){var b=a.parentNode;return b&&b.parentNode&&b.parentNode.selectedIndex,null}}),_.each(["tabIndex","readOnly","maxLength","cellSpacing","cellPadding","rowSpan","colSpan","useMap","frameBorder","contentEditable"],function(){_.propFix[this.toLowerCase()]=this});var hb=/[\t\r\n\f]/g;_.fn.extend({addClass:function(a){var b,c,d,e,f,g,h="string"==typeof a&&a,i=0,j=this.length;if(_.isFunction(a))return this.each(function(b){_(this).addClass(a.call(this,b,this.className))});if(h)for(b=(a||"").match(na)||[];j>i;i++)if(c=this[i],d=1===c.nodeType&&(c.className?(" "+c.className+" ").replace(hb," "):" ")){for(f=0;e=b[f++];)d.indexOf(" "+e+" ")<0&&(d+=e+" ");g=_.trim(d),c.className!==g&&(c.className=g)}return this},removeClass:function(a){var b,c,d,e,f,g,h=0===arguments.length||"string"==typeof a&&a,i=0,j=this.length;if(_.isFunction(a))return this.each(function(b){_(this).removeClass(a.call(this,b,this.className))});if(h)for(b=(a||"").match(na)||[];j>i;i++)if(c=this[i],d=1===c.nodeType&&(c.className?(" "+c.className+" ").replace(hb," "):"")){for(f=0;e=b[f++];)for(;d.indexOf(" "+e+" ")>=0;)d=d.replace(" "+e+" "," ");g=a?_.trim(d):"",c.className!==g&&(c.className=g)}return this},toggleClass:function(a,b){var c=typeof a;return"boolean"==typeof b&&"string"===c?b?this.addClass(a):this.removeClass(a):this.each(_.isFunction(a)?function(c){_(this).toggleClass(a.call(this,c,this.className,b),b)}:function(){if("string"===c)for(var b,d=0,e=_(this),f=a.match(na)||[];b=f[d++];)e.hasClass(b)?e.removeClass(b):e.addClass(b);else(c===za||"boolean"===c)&&(this.className&&ra.set(this,"__className__",this.className),this.className=this.className||a===!1?"":ra.get(this,"__className__")||"")})},hasClass:function(a){for(var b=" "+a+" ",c=0,d=this.length;d>c;c++)if(1===this[c].nodeType&&(" "+this[c].className+" ").replace(hb," ").indexOf(b)>=0)return!0;return!1}});var ib=/\r/g;_.fn.extend({val:function(a){var b,c,d,e=this[0];{if(arguments.length)return d=_.isFunction(a),this.each(function(c){var e;1===this.nodeType&&(e=d?a.call(this,c,_(this).val()):a,null==e?e="":"number"==typeof e?e+="":_.isArray(e)&&(e=_.map(e,function(a){return null==a?"":a+""})),b=_.valHooks[this.type]||_.valHooks[this.nodeName.toLowerCase()],b&&"set"in b&&void 0!==b.set(this,e,"value")||(this.value=e))});if(e)return b=_.valHooks[e.type]||_.valHooks[e.nodeName.toLowerCase()],b&&"get"in b&&void 0!==(c=b.get(e,"value"))?c:(c=e.value,"string"==typeof c?c.replace(ib,""):null==c?"":c)}}}),_.extend({valHooks:{option:{get:function(a){var b=_.find.attr(a,"value");return null!=b?b:_.trim(_.text(a))}},select:{get:function(a){for(var b,c,d=a.options,e=a.selectedIndex,f="select-one"===a.type||0>e,g=f?null:[],h=f?e+1:d.length,i=0>e?h:f?e:0;h>i;i++)if(c=d[i],!(!c.selected&&i!==e||(Y.optDisabled?c.disabled:null!==c.getAttribute("disabled"))||c.parentNode.disabled&&_.nodeName(c.parentNode,"optgroup"))){if(b=_(c).val(),f)return b;g.push(b)}return g},set:function(a,b){for(var c,d,e=a.options,f=_.makeArray(b),g=e.length;g--;)d=e[g],(d.selected=_.inArray(d.value,f)>=0)&&(c=!0);return c||(a.selectedIndex=-1),f}}}}),_.each(["radio","checkbox"],function(){_.valHooks[this]={set:function(a,b){return _.isArray(b)?a.checked=_.inArray(_(a).val(),b)>=0:void 0}},Y.checkOn||(_.valHooks[this].get=function(a){return null===a.getAttribute("value")?"on":a.value})}),_.each("blur focus focusin focusout load resize scroll unload click dblclick mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave change select submit keydown keypress keyup error contextmenu".split(" "),function(a,b){_.fn[b]=function(a,c){return arguments.length>0?this.on(b,null,a,c):this.trigger(b)}}),_.fn.extend({hover:function(a,b){return this.mouseenter(a).mouseleave(b||a)},bind:function(a,b,c){return this.on(a,null,b,c)},unbind:function(a,b){return this.off(a,null,b)},delegate:function(a,b,c,d){return this.on(b,a,c,d)},undelegate:function(a,b,c){return 1===arguments.length?this.off(a,"**"):this.off(b,a||"**",c)}});var jb=_.now(),kb=/\?/;_.parseJSON=function(a){return JSON.parse(a+"")},_.parseXML=function(a){var b,c;if(!a||"string"!=typeof a)return null;try{c=new DOMParser,b=c.parseFromString(a,"text/xml")}catch(d){b=void 0}return(!b||b.getElementsByTagName("parsererror").length)&&_.error("Invalid XML: "+a),b};var lb=/#.*$/,mb=/([?&])_=[^&]*/,nb=/^(.*?):[ \t]*([^\r\n]*)$/gm,ob=/^(?:about|app|app-storage|.+-extension|file|res|widget):$/,pb=/^(?:GET|HEAD)$/,qb=/^\/\//,rb=/^([\w.+-]+:)(?:\/\/(?:[^\/?#]*@|)([^\/?#:]*)(?::(\d+)|)|)/,sb={},tb={},ub="*/".concat("*"),vb=a.location.href,wb=rb.exec(vb.toLowerCase())||[];_.extend({active:0,lastModified:{},etag:{},ajaxSettings:{url:vb,type:"GET",isLocal:ob.test(wb[1]),global:!0,processData:!0,async:!0,contentType:"application/x-www-form-urlencoded; charset=UTF-8",accepts:{"*":ub,text:"text/plain",html:"text/html",xml:"application/xml, text/xml",json:"application/json, text/javascript"},contents:{xml:/xml/,html:/html/,json:/json/},responseFields:{xml:"responseXML",text:"responseText",json:"responseJSON"},converters:{"* text":String,"text html":!0,"text json":_.parseJSON,"text xml":_.parseXML},flatOptions:{url:!0,context:!0}},ajaxSetup:function(a,b){return b?L(L(a,_.ajaxSettings),b):L(_.ajaxSettings,a)},ajaxPrefilter:J(sb),ajaxTransport:J(tb),ajax:function(a,b){function c(a,b,c,g){var i,k,r,s,u,w=b;2!==t&&(t=2,h&&clearTimeout(h),d=void 0,f=g||"",v.readyState=a>0?4:0,i=a>=200&&300>a||304===a,c&&(s=M(l,v,c)),s=N(l,s,v,i),i?(l.ifModified&&(u=v.getResponseHeader("Last-Modified"),u&&(_.lastModified[e]=u),u=v.getResponseHeader("etag"),u&&(_.etag[e]=u)),204===a||"HEAD"===l.type?w="nocontent":304===a?w="notmodified":(w=s.state,k=s.data,r=s.error,i=!r)):(r=w,(a||!w)&&(w="error",0>a&&(a=0))),v.status=a,v.statusText=(b||w)+"",i?o.resolveWith(m,[k,w,v]):o.rejectWith(m,[v,w,r]),v.statusCode(q),q=void 0,j&&n.trigger(i?"ajaxSuccess":"ajaxError",[v,l,i?k:r]),p.fireWith(m,[v,w]),j&&(n.trigger("ajaxComplete",[v,l]),--_.active||_.event.trigger("ajaxStop")))}"object"==typeof a&&(b=a,a=void 0),b=b||{};var d,e,f,g,h,i,j,k,l=_.ajaxSetup({},b),m=l.context||l,n=l.context&&(m.nodeType||m.jquery)?_(m):_.event,o=_.Deferred(),p=_.Callbacks("once memory"),q=l.statusCode||{},r={},s={},t=0,u="canceled",v={readyState:0,getResponseHeader:function(a){var b;if(2===t){if(!g)for(g={};b=nb.exec(f);)g[b[1].toLowerCase()]=b[2];b=g[a.toLowerCase()]}return null==b?null:b},getAllResponseHeaders:function(){return 2===t?f:null},setRequestHeader:function(a,b){var c=a.toLowerCase();return t||(a=s[c]=s[c]||a,r[a]=b),this},overrideMimeType:function(a){return t||(l.mimeType=a),this},statusCode:function(a){var b;if(a)if(2>t)for(b in a)q[b]=[q[b],a[b]];else v.always(a[v.status]);return this},abort:function(a){var b=a||u;return d&&d.abort(b),c(0,b),this}};if(o.promise(v).complete=p.add,v.success=v.done,v.error=v.fail,l.url=((a||l.url||vb)+"").replace(lb,"").replace(qb,wb[1]+"//"),l.type=b.method||b.type||l.method||l.type,l.dataTypes=_.trim(l.dataType||"*").toLowerCase().match(na)||[""],null==l.crossDomain&&(i=rb.exec(l.url.toLowerCase()),l.crossDomain=!(!i||i[1]===wb[1]&&i[2]===wb[2]&&(i[3]||("http:"===i[1]?"80":"443"))===(wb[3]||("http:"===wb[1]?"80":"443")))),l.data&&l.processData&&"string"!=typeof l.data&&(l.data=_.param(l.data,l.traditional)),K(sb,l,b,v),2===t)return v;j=_.event&&l.global,j&&0===_.active++&&_.event.trigger("ajaxStart"),l.type=l.type.toUpperCase(),l.hasContent=!pb.test(l.type),e=l.url,l.hasContent||(l.data&&(e=l.url+=(kb.test(e)?"&":"?")+l.data,delete l.data),l.cache===!1&&(l.url=mb.test(e)?e.replace(mb,"$1_="+jb++):e+(kb.test(e)?"&":"?")+"_="+jb++)),l.ifModified&&(_.lastModified[e]&&v.setRequestHeader("If-Modified-Since",_.lastModified[e]),_.etag[e]&&v.setRequestHeader("If-None-Match",_.etag[e])),(l.data&&l.hasContent&&l.contentType!==!1||b.contentType)&&v.setRequestHeader("Content-Type",l.contentType),v.setRequestHeader("Accept",l.dataTypes[0]&&l.accepts[l.dataTypes[0]]?l.accepts[l.dataTypes[0]]+("*"!==l.dataTypes[0]?", "+ub+"; q=0.01":""):l.accepts["*"]);for(k in l.headers)v.setRequestHeader(k,l.headers[k]);if(l.beforeSend&&(l.beforeSend.call(m,v,l)===!1||2===t))return v.abort();u="abort";for(k in{success:1,error:1,complete:1})v[k](l[k]);if(d=K(tb,l,b,v)){v.readyState=1,j&&n.trigger("ajaxSend",[v,l]),l.async&&l.timeout>0&&(h=setTimeout(function(){v.abort("timeout")},l.timeout));try{t=1,d.send(r,c)}catch(w){if(!(2>t))throw w;c(-1,w)}}else c(-1,"No Transport");return v},getJSON:function(a,b,c){return _.get(a,b,c,"json")},getScript:function(a,b){return _.get(a,void 0,b,"script")}}),_.each(["get","post"],function(a,b){_[b]=function(a,c,d,e){return _.isFunction(c)&&(e=e||d,d=c,c=void 0),_.ajax({url:a,type:b,dataType:e,data:c,success:d})}}),_._evalUrl=function(a){return _.ajax({url:a,type:"GET",dataType:"script",async:!1,global:!1,"throws":!0})},_.fn.extend({wrapAll:function(a){var b;return _.isFunction(a)?this.each(function(b){_(this).wrapAll(a.call(this,b))}):(this[0]&&(b=_(a,this[0].ownerDocument).eq(0).clone(!0),this[0].parentNode&&b.insertBefore(this[0]),b.map(function(){for(var a=this;a.firstElementChild;)a=a.firstElementChild;return a}).append(this)),this)},wrapInner:function(a){return this.each(_.isFunction(a)?function(b){_(this).wrapInner(a.call(this,b))}:function(){var b=_(this),c=b.contents();c.length?c.wrapAll(a):b.append(a)})},wrap:function(a){var b=_.isFunction(a);return this.each(function(c){_(this).wrapAll(b?a.call(this,c):a)})},unwrap:function(){return this.parent().each(function(){_.nodeName(this,"body")||_(this).replaceWith(this.childNodes)}).end()}}),_.expr.filters.hidden=function(a){return a.offsetWidth<=0&&a.offsetHeight<=0},_.expr.filters.visible=function(a){return!_.expr.filters.hidden(a)};var xb=/%20/g,yb=/\[\]$/,zb=/\r?\n/g,Ab=/^(?:submit|button|image|reset|file)$/i,Bb=/^(?:input|select|textarea|keygen)/i;_.param=function(a,b){var c,d=[],e=function(a,b){b=_.isFunction(b)?b():null==b?"":b,d[d.length]=encodeURIComponent(a)+"="+encodeURIComponent(b);
-
-};if(void 0===b&&(b=_.ajaxSettings&&_.ajaxSettings.traditional),_.isArray(a)||a.jquery&&!_.isPlainObject(a))_.each(a,function(){e(this.name,this.value)});else for(c in a)O(c,a[c],b,e);return d.join("&").replace(xb,"+")},_.fn.extend({serialize:function(){return _.param(this.serializeArray())},serializeArray:function(){return this.map(function(){var a=_.prop(this,"elements");return a?_.makeArray(a):this}).filter(function(){var a=this.type;return this.name&&!_(this).is(":disabled")&&Bb.test(this.nodeName)&&!Ab.test(a)&&(this.checked||!ya.test(a))}).map(function(a,b){var c=_(this).val();return null==c?null:_.isArray(c)?_.map(c,function(a){return{name:b.name,value:a.replace(zb,"\r\n")}}):{name:b.name,value:c.replace(zb,"\r\n")}}).get()}}),_.ajaxSettings.xhr=function(){try{return new XMLHttpRequest}catch(a){}};var Cb=0,Db={},Eb={0:200,1223:204},Fb=_.ajaxSettings.xhr();a.attachEvent&&a.attachEvent("onunload",function(){for(var a in Db)Db[a]()}),Y.cors=!!Fb&&"withCredentials"in Fb,Y.ajax=Fb=!!Fb,_.ajaxTransport(function(a){var b;return Y.cors||Fb&&!a.crossDomain?{send:function(c,d){var e,f=a.xhr(),g=++Cb;if(f.open(a.type,a.url,a.async,a.username,a.password),a.xhrFields)for(e in a.xhrFields)f[e]=a.xhrFields[e];a.mimeType&&f.overrideMimeType&&f.overrideMimeType(a.mimeType),a.crossDomain||c["X-Requested-With"]||(c["X-Requested-With"]="XMLHttpRequest");for(e in c)f.setRequestHeader(e,c[e]);b=function(a){return function(){b&&(delete Db[g],b=f.onload=f.onerror=null,"abort"===a?f.abort():"error"===a?d(f.status,f.statusText):d(Eb[f.status]||f.status,f.statusText,"string"==typeof f.responseText?{text:f.responseText}:void 0,f.getAllResponseHeaders()))}},f.onload=b(),f.onerror=b("error"),b=Db[g]=b("abort");try{f.send(a.hasContent&&a.data||null)}catch(h){if(b)throw h}},abort:function(){b&&b()}}:void 0}),_.ajaxSetup({accepts:{script:"text/javascript, application/javascript, application/ecmascript, application/x-ecmascript"},contents:{script:/(?:java|ecma)script/},converters:{"text script":function(a){return _.globalEval(a),a}}}),_.ajaxPrefilter("script",function(a){void 0===a.cache&&(a.cache=!1),a.crossDomain&&(a.type="GET")}),_.ajaxTransport("script",function(a){if(a.crossDomain){var b,c;return{send:function(d,e){b=_("<script>").prop({async:!0,charset:a.scriptCharset,src:a.url}).on("load error",c=function(a){b.remove(),c=null,a&&e("error"===a.type?404:200,a.type)}),Z.head.appendChild(b[0])},abort:function(){c&&c()}}}});var Gb=[],Hb=/(=)\?(?=&|$)|\?\?/;_.ajaxSetup({jsonp:"callback",jsonpCallback:function(){var a=Gb.pop()||_.expando+"_"+jb++;return this[a]=!0,a}}),_.ajaxPrefilter("json jsonp",function(b,c,d){var e,f,g,h=b.jsonp!==!1&&(Hb.test(b.url)?"url":"string"==typeof b.data&&!(b.contentType||"").indexOf("application/x-www-form-urlencoded")&&Hb.test(b.data)&&"data");return h||"jsonp"===b.dataTypes[0]?(e=b.jsonpCallback=_.isFunction(b.jsonpCallback)?b.jsonpCallback():b.jsonpCallback,h?b[h]=b[h].replace(Hb,"$1"+e):b.jsonp!==!1&&(b.url+=(kb.test(b.url)?"&":"?")+b.jsonp+"="+e),b.converters["script json"]=function(){return g||_.error(e+" was not called"),g[0]},b.dataTypes[0]="json",f=a[e],a[e]=function(){g=arguments},d.always(function(){a[e]=f,b[e]&&(b.jsonpCallback=c.jsonpCallback,Gb.push(e)),g&&_.isFunction(f)&&f(g[0]),g=f=void 0}),"script"):void 0}),_.parseHTML=function(a,b,c){if(!a||"string"!=typeof a)return null;"boolean"==typeof b&&(c=b,b=!1),b=b||Z;var d=ga.exec(a),e=!c&&[];return d?[b.createElement(d[1])]:(d=_.buildFragment([a],b,e),e&&e.length&&_(e).remove(),_.merge([],d.childNodes))};var Ib=_.fn.load;_.fn.load=function(a,b,c){if("string"!=typeof a&&Ib)return Ib.apply(this,arguments);var d,e,f,g=this,h=a.indexOf(" ");return h>=0&&(d=_.trim(a.slice(h)),a=a.slice(0,h)),_.isFunction(b)?(c=b,b=void 0):b&&"object"==typeof b&&(e="POST"),g.length>0&&_.ajax({url:a,type:e,dataType:"html",data:b}).done(function(a){f=arguments,g.html(d?_("<div>").append(_.parseHTML(a)).find(d):a)}).complete(c&&function(a,b){g.each(c,f||[a.responseText,b,a])}),this},_.each(["ajaxStart","ajaxStop","ajaxComplete","ajaxError","ajaxSuccess","ajaxSend"],function(a,b){_.fn[b]=function(a){return this.on(b,a)}}),_.expr.filters.animated=function(a){return _.grep(_.timers,function(b){return a===b.elem}).length};var Jb=a.document.documentElement;_.offset={setOffset:function(a,b,c){var d,e,f,g,h,i,j,k=_.css(a,"position"),l=_(a),m={};"static"===k&&(a.style.position="relative"),h=l.offset(),f=_.css(a,"top"),i=_.css(a,"left"),j=("absolute"===k||"fixed"===k)&&(f+i).indexOf("auto")>-1,j?(d=l.position(),g=d.top,e=d.left):(g=parseFloat(f)||0,e=parseFloat(i)||0),_.isFunction(b)&&(b=b.call(a,c,h)),null!=b.top&&(m.top=b.top-h.top+g),null!=b.left&&(m.left=b.left-h.left+e),"using"in b?b.using.call(a,m):l.css(m)}},_.fn.extend({offset:function(a){if(arguments.length)return void 0===a?this:this.each(function(b){_.offset.setOffset(this,a,b)});var b,c,d=this[0],e={top:0,left:0},f=d&&d.ownerDocument;if(f)return b=f.documentElement,_.contains(b,d)?(typeof d.getBoundingClientRect!==za&&(e=d.getBoundingClientRect()),c=P(f),{top:e.top+c.pageYOffset-b.clientTop,left:e.left+c.pageXOffset-b.clientLeft}):e},position:function(){if(this[0]){var a,b,c=this[0],d={top:0,left:0};return"fixed"===_.css(c,"position")?b=c.getBoundingClientRect():(a=this.offsetParent(),b=this.offset(),_.nodeName(a[0],"html")||(d=a.offset()),d.top+=_.css(a[0],"borderTopWidth",!0),d.left+=_.css(a[0],"borderLeftWidth",!0)),{top:b.top-d.top-_.css(c,"marginTop",!0),left:b.left-d.left-_.css(c,"marginLeft",!0)}}},offsetParent:function(){return this.map(function(){for(var a=this.offsetParent||Jb;a&&!_.nodeName(a,"html")&&"static"===_.css(a,"position");)a=a.offsetParent;return a||Jb})}}),_.each({scrollLeft:"pageXOffset",scrollTop:"pageYOffset"},function(b,c){var d="pageYOffset"===c;_.fn[b]=function(e){return qa(this,function(b,e,f){var g=P(b);return void 0===f?g?g[c]:b[e]:void(g?g.scrollTo(d?a.pageXOffset:f,d?f:a.pageYOffset):b[e]=f)},b,e,arguments.length,null)}}),_.each(["top","left"],function(a,b){_.cssHooks[b]=w(Y.pixelPosition,function(a,c){return c?(c=v(a,b),Qa.test(c)?_(a).position()[b]+"px":c):void 0})}),_.each({Height:"height",Width:"width"},function(a,b){_.each({padding:"inner"+a,content:b,"":"outer"+a},function(c,d){_.fn[d]=function(d,e){var f=arguments.length&&(c||"boolean"!=typeof d),g=c||(d===!0||e===!0?"margin":"border");return qa(this,function(b,c,d){var e;return _.isWindow(b)?b.document.documentElement["client"+a]:9===b.nodeType?(e=b.documentElement,Math.max(b.body["scroll"+a],e["scroll"+a],b.body["offset"+a],e["offset"+a],e["client"+a])):void 0===d?_.css(b,c,g):_.style(b,c,d,g)},b,f?d:void 0,f,null)}})}),_.fn.size=function(){return this.length},_.fn.andSelf=_.fn.addBack,"function"==typeof define&&define.amd&&define("jquery",[],function(){return _});var Kb=a.jQuery,Lb=a.$;return _.noConflict=function(b){return a.$===_&&(a.$=Lb),b&&a.jQuery===_&&(a.jQuery=Kb),_},typeof b===za&&(a.jQuery=a.$=_),_}),/** @license
+function(a){function b(a,b,c,d){var e,f,g,h,
+// QSA vars
+i,j,l,n,o,p;if((b?b.ownerDocument||b:O)!==G&&F(b),b=b||G,c=c||[],h=b.nodeType,"string"!=typeof a||!a||1!==h&&9!==h&&11!==h)return c;if(!d&&I){
+// Try to shortcut find operations when possible (e.g., not under DocumentFragment)
+if(11!==h&&(e=sa.exec(a)))
+// Speed-up: Sizzle("#ID")
+if(g=e[1]){if(9===h){
+// Check parentNode to catch when Blackberry 4.6 returns
+// nodes that are no longer in the document (jQuery #6963)
+if(f=b.getElementById(g),!f||!f.parentNode)return c;
+// Handle the case where IE, Opera, and Webkit return items
+// by name instead of ID
+if(f.id===g)return c.push(f),c}else
+// Context is not a document
+if(b.ownerDocument&&(f=b.ownerDocument.getElementById(g))&&M(b,f)&&f.id===g)return c.push(f),c}else{if(e[2])return $.apply(c,b.getElementsByTagName(a)),c;if((g=e[3])&&v.getElementsByClassName)return $.apply(c,b.getElementsByClassName(g)),c}
+// QSA path
+if(v.qsa&&(!J||!J.test(a))){
+// qSA works strangely on Element-rooted queries
+// We can work around this by specifying an extra ID on the root
+// and working up from there (Thanks to Andrew Dupont for the technique)
+// IE 8 doesn't work on object elements
+if(n=l=N,o=b,p=1!==h&&a,1===h&&"object"!==b.nodeName.toLowerCase()){for(j=z(a),(l=b.getAttribute("id"))?n=l.replace(ua,"\\$&"):b.setAttribute("id",n),n="[id='"+n+"'] ",i=j.length;i--;)j[i]=n+m(j[i]);o=ta.test(a)&&k(b.parentNode)||b,p=j.join(",")}if(p)try{return $.apply(c,o.querySelectorAll(p)),c}catch(q){}finally{l||b.removeAttribute("id")}}}
+// All others
+return B(a.replace(ia,"$1"),b,c,d)}/**
+ * Create key-value caches of limited size
+ * @returns {Function(string, Object)} Returns the Object data after storing it on itself with
+ *	property name the (space-suffixed) string and (if the cache is larger than Expr.cacheLength)
+ *	deleting the oldest entry
+ */
+function c(){function a(c,d){
+// Use (key + " ") to avoid collision with native prototype properties (see Issue #157)
+// Only keep the most recent entries
+return b.push(c+" ")>w.cacheLength&&delete a[b.shift()],a[c+" "]=d}var b=[];return a}/**
+ * Mark a function for special use by Sizzle
+ * @param {Function} fn The function to mark
+ */
+function d(a){return a[N]=!0,a}/**
+ * Support testing using an element
+ * @param {Function} fn Passed the created div and expects a boolean result
+ */
+function e(a){var b=G.createElement("div");try{return!!a(b)}catch(c){return!1}finally{
+// Remove from its parent by default
+b.parentNode&&b.parentNode.removeChild(b),
+// release memory in IE
+b=null}}/**
+ * Adds the same handler for all of the specified attrs
+ * @param {String} attrs Pipe-separated list of attributes
+ * @param {Function} handler The method that will be applied
+ */
+function f(a,b){for(var c=a.split("|"),d=a.length;d--;)w.attrHandle[c[d]]=b}/**
+ * Checks document order of two siblings
+ * @param {Element} a
+ * @param {Element} b
+ * @returns {Number} Returns less than 0 if a precedes b, greater than 0 if a follows b
+ */
+function g(a,b){var c=b&&a,d=c&&1===a.nodeType&&1===b.nodeType&&(~b.sourceIndex||V)-(~a.sourceIndex||V);
+// Use IE sourceIndex if available on both nodes
+if(d)return d;
+// Check if b follows a
+if(c)for(;c=c.nextSibling;)if(c===b)return-1;return a?1:-1}/**
+ * Returns a function to use in pseudos for input types
+ * @param {String} type
+ */
+function h(a){return function(b){var c=b.nodeName.toLowerCase();return"input"===c&&b.type===a}}/**
+ * Returns a function to use in pseudos for buttons
+ * @param {String} type
+ */
+function i(a){return function(b){var c=b.nodeName.toLowerCase();return("input"===c||"button"===c)&&b.type===a}}/**
+ * Returns a function to use in pseudos for positionals
+ * @param {Function} fn
+ */
+function j(a){return d(function(b){return b=+b,d(function(c,d){for(var e,f=a([],c.length,b),g=f.length;g--;)c[e=f[g]]&&(c[e]=!(d[e]=c[e]))})})}/**
+ * Checks a node for validity as a Sizzle context
+ * @param {Element|Object=} context
+ * @returns {Element|Object|Boolean} The input node if acceptable, otherwise a falsy value
+ */
+function k(a){return a&&"undefined"!=typeof a.getElementsByTagName&&a}
+// Easy API for creating new setFilters
+function l(){}function m(a){for(var b=0,c=a.length,d="";c>b;b++)d+=a[b].value;return d}function n(a,b,c){var d=b.dir,e=c&&"parentNode"===d,f=Q++;
+// Check against closest ancestor/preceding element
+// Check against all ancestor/preceding elements
+return b.first?function(b,c,f){for(;b=b[d];)if(1===b.nodeType||e)return a(b,c,f)}:function(b,c,g){var h,i,j=[P,f];
+// We can't set arbitrary data on XML nodes, so they don't benefit from dir caching
+if(g){for(;b=b[d];)if((1===b.nodeType||e)&&a(b,c,g))return!0}else for(;b=b[d];)if(1===b.nodeType||e){if(i=b[N]||(b[N]={}),(h=i[d])&&h[0]===P&&h[1]===f)
+// Assign to newCache so results back-propagate to previous elements
+return j[2]=h[2];
+// A match means we're done; a fail means we have to keep checking
+if(
+// Reuse newcache so results back-propagate to previous elements
+i[d]=j,j[2]=a(b,c,g))return!0}}}function o(a){return a.length>1?function(b,c,d){for(var e=a.length;e--;)if(!a[e](b,c,d))return!1;return!0}:a[0]}function p(a,c,d){for(var e=0,f=c.length;f>e;e++)b(a,c[e],d);return d}function q(a,b,c,d,e){for(var f,g=[],h=0,i=a.length,j=null!=b;i>h;h++)(f=a[h])&&(!c||c(f,d,e))&&(g.push(f),j&&b.push(h));return g}function r(a,b,c,e,f,g){return e&&!e[N]&&(e=r(e)),f&&!f[N]&&(f=r(f,g)),d(function(d,g,h,i){var j,k,l,m=[],n=[],o=g.length,
+// Get initial elements from seed or context
+r=d||p(b||"*",h.nodeType?[h]:h,[]),
+// Prefilter to get matcher input, preserving a map for seed-results synchronization
+s=!a||!d&&b?r:q(r,m,a,h,i),t=c?f||(d?a:o||e)?
+// ...intermediate processing is necessary
+[]:g:s;
+// Apply postFilter
+if(
+// Find primary matches
+c&&c(s,t,h,i),e)for(j=q(t,n),e(j,[],h,i),
+// Un-match failing elements by moving them back to matcherIn
+k=j.length;k--;)(l=j[k])&&(t[n[k]]=!(s[n[k]]=l));if(d){if(f||a){if(f){for(
+// Get the final matcherOut by condensing this intermediate into postFinder contexts
+j=[],k=t.length;k--;)(l=t[k])&&
+// Restore matcherIn since elem is not yet a final match
+j.push(s[k]=l);f(null,t=[],j,i)}for(
+// Move matched elements from seed to results to keep them synchronized
+k=t.length;k--;)(l=t[k])&&(j=f?aa(d,l):m[k])>-1&&(d[j]=!(g[j]=l))}}else t=q(t===g?t.splice(o,t.length):t),f?f(null,g,t,i):$.apply(g,t)})}function s(a){for(var b,c,d,e=a.length,f=w.relative[a[0].type],g=f||w.relative[" "],h=f?1:0,
+// The foundational matcher ensures that elements are reachable from top-level context(s)
+i=n(function(a){return a===b},g,!0),j=n(function(a){return aa(b,a)>-1},g,!0),k=[function(a,c,d){var e=!f&&(d||c!==C)||((b=c).nodeType?i(a,c,d):j(a,c,d));
+// Avoid hanging onto element (issue #299)
+return b=null,e}];e>h;h++)if(c=w.relative[a[h].type])k=[n(o(k),c)];else{
+// Return special upon seeing a positional matcher
+if(c=w.filter[a[h].type].apply(null,a[h].matches),c[N]){for(
+// Find the next relative operator (if any) for proper handling
+d=++h;e>d&&!w.relative[a[d].type];d++);
+// If the preceding token was a descendant combinator, insert an implicit any-element `*`
+return r(h>1&&o(k),h>1&&m(a.slice(0,h-1).concat({value:" "===a[h-2].type?"*":""})).replace(ia,"$1"),c,d>h&&s(a.slice(h,d)),e>d&&s(a=a.slice(d)),e>d&&m(a))}k.push(c)}return o(k)}function t(a,c){var e=c.length>0,f=a.length>0,g=function(d,g,h,i,j){var k,l,m,n=0,o="0",p=d&&[],r=[],s=C,
+// We must always have either seed elements or outermost context
+t=d||f&&w.find.TAG("*",j),
+// Use integer dirruns iff this is the outermost matcher
+u=P+=null==s?1:Math.random()||.1,v=t.length;
+// Add elements passing elementMatchers directly to results
+// Keep `i` a string if there are no elements so `matchedCount` will be "00" below
+// Support: IE<9, Safari
+// Tolerate NodeList properties (IE: "length"; Safari: <number>) matching elements by id
+for(j&&(C=g!==G&&g);o!==v&&null!=(k=t[o]);o++){if(f&&k){for(l=0;m=a[l++];)if(m(k,g,h)){i.push(k);break}j&&(P=u)}
+// Track unmatched elements for set filters
+e&&(
+// They will have gone through all possible matchers
+(k=!m&&k)&&n--,
+// Lengthen the array for every element, matched or not
+d&&p.push(k))}if(n+=o,e&&o!==n){for(l=0;m=c[l++];)m(p,r,g,h);if(d){
+// Reintegrate element matches to eliminate the need for sorting
+if(n>0)for(;o--;)p[o]||r[o]||(r[o]=Y.call(i));
+// Discard index placeholder values to get only actual matches
+r=q(r)}
+// Add matches to results
+$.apply(i,r),
+// Seedless set matches succeeding multiple successful matchers stipulate sorting
+j&&!d&&r.length>0&&n+c.length>1&&b.uniqueSort(i)}
+// Override manipulation of globals by nested matchers
+return j&&(P=u,C=s),p};return e?d(g):g}var u,v,w,x,y,z,A,B,C,D,E,
+// Local document vars
+F,G,H,I,J,K,L,M,
+// Instance-specific data
+N="sizzle"+1*new Date,O=a.document,P=0,Q=0,R=c(),S=c(),T=c(),U=function(a,b){return a===b&&(E=!0),0},
+// General-purpose constants
+V=1<<31,
+// Instance methods
+W={}.hasOwnProperty,X=[],Y=X.pop,Z=X.push,$=X.push,_=X.slice,
+// Use a stripped-down indexOf as it's faster than native
+// http://jsperf.com/thor-indexof-vs-for/5
+aa=function(a,b){for(var c=0,d=a.length;d>c;c++)if(a[c]===b)return c;return-1},ba="checked|selected|async|autofocus|autoplay|controls|defer|disabled|hidden|ismap|loop|multiple|open|readonly|required|scoped",
+// Regular expressions
+// Whitespace characters http://www.w3.org/TR/css3-selectors/#whitespace
+ca="[\\x20\\t\\r\\n\\f]",
+// http://www.w3.org/TR/css3-syntax/#characters
+da="(?:\\\\.|[\\w-]|[^\\x00-\\xa0])+",
+// Loosely modeled on CSS identifier characters
+// An unquoted value should be a CSS identifier http://www.w3.org/TR/css3-selectors/#attribute-selectors
+// Proper syntax: http://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
+ea=da.replace("w","w#"),
+// Attribute selectors: http://www.w3.org/TR/selectors/#attribute-selectors
+fa="\\["+ca+"*("+da+")(?:"+ca+
+// Operator (capture 2)
+"*([*^$|!~]?=)"+ca+
+// "Attribute values must be CSS identifiers [capture 5] or strings [capture 3 or capture 4]"
+"*(?:'((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\"|("+ea+"))|)"+ca+"*\\]",ga=":("+da+")(?:\\((('((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\")|((?:\\\\.|[^\\\\()[\\]]|"+fa+")*)|.*)\\)|)",
+// Leading and non-escaped trailing whitespace, capturing some non-whitespace characters preceding the latter
+ha=new RegExp(ca+"+","g"),ia=new RegExp("^"+ca+"+|((?:^|[^\\\\])(?:\\\\.)*)"+ca+"+$","g"),ja=new RegExp("^"+ca+"*,"+ca+"*"),ka=new RegExp("^"+ca+"*([>+~]|"+ca+")"+ca+"*"),la=new RegExp("="+ca+"*([^\\]'\"]*?)"+ca+"*\\]","g"),ma=new RegExp(ga),na=new RegExp("^"+ea+"$"),oa={ID:new RegExp("^#("+da+")"),CLASS:new RegExp("^\\.("+da+")"),TAG:new RegExp("^("+da.replace("w","w*")+")"),ATTR:new RegExp("^"+fa),PSEUDO:new RegExp("^"+ga),CHILD:new RegExp("^:(only|first|last|nth|nth-last)-(child|of-type)(?:\\("+ca+"*(even|odd|(([+-]|)(\\d*)n|)"+ca+"*(?:([+-]|)"+ca+"*(\\d+)|))"+ca+"*\\)|)","i"),bool:new RegExp("^(?:"+ba+")$","i"),
+// For use in libraries implementing .is()
+// We use this for POS matching in `select`
+needsContext:new RegExp("^"+ca+"*[>+~]|:(even|odd|eq|gt|lt|nth|first|last)(?:\\("+ca+"*((?:-\\d)?\\d*)"+ca+"*\\)|)(?=[^-]|$)","i")},pa=/^(?:input|select|textarea|button)$/i,qa=/^h\d$/i,ra=/^[^{]+\{\s*\[native \w/,
+// Easily-parseable/retrievable ID or TAG or CLASS selectors
+sa=/^(?:#([\w-]+)|(\w+)|\.([\w-]+))$/,ta=/[+~]/,ua=/'|\\/g,
+// CSS escapes http://www.w3.org/TR/CSS21/syndata.html#escaped-characters
+va=new RegExp("\\\\([\\da-f]{1,6}"+ca+"?|("+ca+")|.)","ig"),wa=function(a,b,c){var d="0x"+b-65536;
+// NaN means non-codepoint
+// Support: Firefox<24
+// Workaround erroneous numeric interpretation of +"0x"
+// BMP codepoint
+// Supplemental Plane codepoint (surrogate pair)
+return d!==d||c?b:0>d?String.fromCharCode(d+65536):String.fromCharCode(d>>10|55296,1023&d|56320)},
+// Used for iframes
+// See setDocument()
+// Removing the function wrapper causes a "Permission Denied"
+// error in IE
+xa=function(){F()};
+// Optimize for push.apply( _, NodeList )
+try{$.apply(X=_.call(O.childNodes),O.childNodes),
+// Support: Android<4.0
+// Detect silently failing push.apply
+X[O.childNodes.length].nodeType}catch(ya){$={apply:X.length?
+// Leverage slice if possible
+function(a,b){Z.apply(a,_.call(b))}:
+// Support: IE<9
+// Otherwise append directly
+function(a,b){
+// Can't trust NodeList.length
+for(var c=a.length,d=0;a[c++]=b[d++];);a.length=c-1}}}v=b.support={},y=b.isXML=function(a){var b=a&&(a.ownerDocument||a).documentElement;return b?"HTML"!==b.nodeName:!1},F=b.setDocument=function(a){var b,c,d=a?a.ownerDocument||a:O;return d!==G&&9===d.nodeType&&d.documentElement?(G=d,H=d.documentElement,c=d.defaultView,c&&c!==c.top&&(c.addEventListener?c.addEventListener("unload",xa,!1):c.attachEvent&&c.attachEvent("onunload",xa)),I=!y(d),v.attributes=e(function(a){return a.className="i",!a.getAttribute("className")}),v.getElementsByTagName=e(function(a){return a.appendChild(d.createComment("")),!a.getElementsByTagName("*").length}),v.getElementsByClassName=ra.test(d.getElementsByClassName),v.getById=e(function(a){return H.appendChild(a).id=N,!d.getElementsByName||!d.getElementsByName(N).length}),v.getById?(w.find.ID=function(a,b){if("undefined"!=typeof b.getElementById&&I){var c=b.getElementById(a);return c&&c.parentNode?[c]:[]}},w.filter.ID=function(a){var b=a.replace(va,wa);return function(a){return a.getAttribute("id")===b}}):(delete w.find.ID,w.filter.ID=function(a){var b=a.replace(va,wa);return function(a){var c="undefined"!=typeof a.getAttributeNode&&a.getAttributeNode("id");return c&&c.value===b}}),w.find.TAG=v.getElementsByTagName?function(a,b){return"undefined"!=typeof b.getElementsByTagName?b.getElementsByTagName(a):v.qsa?b.querySelectorAll(a):void 0}:function(a,b){var c,d=[],e=0,f=b.getElementsByTagName(a);if("*"===a){for(;c=f[e++];)1===c.nodeType&&d.push(c);return d}return f},w.find.CLASS=v.getElementsByClassName&&function(a,b){return I?b.getElementsByClassName(a):void 0},K=[],J=[],(v.qsa=ra.test(d.querySelectorAll))&&(e(function(a){H.appendChild(a).innerHTML="<a id='"+N+"'></a><select id='"+N+"-\f]' msallowcapture=''><option selected=''></option></select>",a.querySelectorAll("[msallowcapture^='']").length&&J.push("[*^$]="+ca+"*(?:''|\"\")"),a.querySelectorAll("[selected]").length||J.push("\\["+ca+"*(?:value|"+ba+")"),a.querySelectorAll("[id~="+N+"-]").length||J.push("~="),a.querySelectorAll(":checked").length||J.push(":checked"),a.querySelectorAll("a#"+N+"+*").length||J.push(".#.+[+~]")}),e(function(a){var b=d.createElement("input");b.setAttribute("type","hidden"),a.appendChild(b).setAttribute("name","D"),a.querySelectorAll("[name=d]").length&&J.push("name"+ca+"*[*^$|!~]?="),a.querySelectorAll(":enabled").length||J.push(":enabled",":disabled"),a.querySelectorAll("*,:x"),J.push(",.*:")})),(v.matchesSelector=ra.test(L=H.matches||H.webkitMatchesSelector||H.mozMatchesSelector||H.oMatchesSelector||H.msMatchesSelector))&&e(function(a){v.disconnectedMatch=L.call(a,"div"),L.call(a,"[s!='']:x"),K.push("!=",ga)}),J=J.length&&new RegExp(J.join("|")),K=K.length&&new RegExp(K.join("|")),b=ra.test(H.compareDocumentPosition),M=b||ra.test(H.contains)?function(a,b){var c=9===a.nodeType?a.documentElement:a,d=b&&b.parentNode;return a===d||!(!d||1!==d.nodeType||!(c.contains?c.contains(d):a.compareDocumentPosition&&16&a.compareDocumentPosition(d)))}:function(a,b){if(b)for(;b=b.parentNode;)if(b===a)return!0;return!1},U=b?function(a,b){if(a===b)return E=!0,0;var c=!a.compareDocumentPosition-!b.compareDocumentPosition;return c?c:(c=(a.ownerDocument||a)===(b.ownerDocument||b)?a.compareDocumentPosition(b):1,1&c||!v.sortDetached&&b.compareDocumentPosition(a)===c?a===d||a.ownerDocument===O&&M(O,a)?-1:b===d||b.ownerDocument===O&&M(O,b)?1:D?aa(D,a)-aa(D,b):0:4&c?-1:1)}:function(a,b){if(a===b)return E=!0,0;var c,e=0,f=a.parentNode,h=b.parentNode,i=[a],j=[b];if(!f||!h)return a===d?-1:b===d?1:f?-1:h?1:D?aa(D,a)-aa(D,b):0;if(f===h)return g(a,b);for(c=a;c=c.parentNode;)i.unshift(c);for(c=b;c=c.parentNode;)j.unshift(c);for(;i[e]===j[e];)e++;return e?g(i[e],j[e]):i[e]===O?-1:j[e]===O?1:0},d):G},b.matches=function(a,c){return b(a,null,null,c)},b.matchesSelector=function(a,c){if((a.ownerDocument||a)!==G&&F(a),c=c.replace(la,"='$1']"),v.matchesSelector&&I&&(!K||!K.test(c))&&(!J||!J.test(c)))try{var d=L.call(a,c);if(d||v.disconnectedMatch||a.document&&11!==a.document.nodeType)return d}catch(e){}return b(c,G,null,[a]).length>0},b.contains=function(a,b){return(a.ownerDocument||a)!==G&&F(a),M(a,b)},b.attr=function(a,b){(a.ownerDocument||a)!==G&&F(a);var c=w.attrHandle[b.toLowerCase()],d=c&&W.call(w.attrHandle,b.toLowerCase())?c(a,b,!I):void 0;return void 0!==d?d:v.attributes||!I?a.getAttribute(b):(d=a.getAttributeNode(b))&&d.specified?d.value:null},b.error=function(a){throw new Error("Syntax error, unrecognized expression: "+a)},b.uniqueSort=function(a){var b,c=[],d=0,e=0;if(E=!v.detectDuplicates,D=!v.sortStable&&a.slice(0),a.sort(U),E){for(;b=a[e++];)b===a[e]&&(d=c.push(e));for(;d--;)a.splice(c[d],1)}return D=null,a},x=b.getText=function(a){var b,c="",d=0,e=a.nodeType;if(e){if(1===e||9===e||11===e){if("string"==typeof a.textContent)return a.textContent;for(a=a.firstChild;a;a=a.nextSibling)c+=x(a)}else if(3===e||4===e)return a.nodeValue}else for(;b=a[d++];)c+=x(b);return c},w=b.selectors={cacheLength:50,createPseudo:d,match:oa,attrHandle:{},find:{},relative:{">":{dir:"parentNode",first:!0}," ":{dir:"parentNode"},"+":{dir:"previousSibling",first:!0},"~":{dir:"previousSibling"}},preFilter:{ATTR:function(a){return a[1]=a[1].replace(va,wa),a[3]=(a[3]||a[4]||a[5]||"").replace(va,wa),"~="===a[2]&&(a[3]=" "+a[3]+" "),a.slice(0,4)},CHILD:function(a){return a[1]=a[1].toLowerCase(),"nth"===a[1].slice(0,3)?(a[3]||b.error(a[0]),a[4]=+(a[4]?a[5]+(a[6]||1):2*("even"===a[3]||"odd"===a[3])),a[5]=+(a[7]+a[8]||"odd"===a[3])):a[3]&&b.error(a[0]),a},PSEUDO:function(a){var b,c=!a[6]&&a[2];return oa.CHILD.test(a[0])?null:(a[3]?a[2]=a[4]||a[5]||"":c&&ma.test(c)&&(b=z(c,!0))&&(b=c.indexOf(")",c.length-b)-c.length)&&(a[0]=a[0].slice(0,b),a[2]=c.slice(0,b)),a.slice(0,3))}},filter:{TAG:function(a){var b=a.replace(va,wa).toLowerCase();return"*"===a?function(){return!0}:function(a){return a.nodeName&&a.nodeName.toLowerCase()===b}},CLASS:function(a){var b=R[a+" "];return b||(b=new RegExp("(^|"+ca+")"+a+"("+ca+"|$)"))&&R(a,function(a){return b.test("string"==typeof a.className&&a.className||"undefined"!=typeof a.getAttribute&&a.getAttribute("class")||"")})},ATTR:function(a,c,d){return function(e){var f=b.attr(e,a);return null==f?"!="===c:c?(f+="","="===c?f===d:"!="===c?f!==d:"^="===c?d&&0===f.indexOf(d):"*="===c?d&&f.indexOf(d)>-1:"$="===c?d&&f.slice(-d.length)===d:"~="===c?(" "+f.replace(ha," ")+" ").indexOf(d)>-1:"|="===c?f===d||f.slice(0,d.length+1)===d+"-":!1):!0}},CHILD:function(a,b,c,d,e){var f="nth"!==a.slice(0,3),g="last"!==a.slice(-4),h="of-type"===b;return 1===d&&0===e?function(a){return!!a.parentNode}:function(b,c,i){var j,k,l,m,n,o,p=f!==g?"nextSibling":"previousSibling",q=b.parentNode,r=h&&b.nodeName.toLowerCase(),s=!i&&!h;if(q){if(f){for(;p;){for(l=b;l=l[p];)if(h?l.nodeName.toLowerCase()===r:1===l.nodeType)return!1;o=p="only"===a&&!o&&"nextSibling"}return!0}if(o=[g?q.firstChild:q.lastChild],g&&s){for(k=q[N]||(q[N]={}),j=k[a]||[],n=j[0]===P&&j[1],m=j[0]===P&&j[2],l=n&&q.childNodes[n];l=++n&&l&&l[p]||(m=n=0)||o.pop();)if(1===l.nodeType&&++m&&l===b){k[a]=[P,n,m];break}}else if(s&&(j=(b[N]||(b[N]={}))[a])&&j[0]===P)m=j[1];else for(;(l=++n&&l&&l[p]||(m=n=0)||o.pop())&&((h?l.nodeName.toLowerCase()!==r:1!==l.nodeType)||!++m||(s&&((l[N]||(l[N]={}))[a]=[P,m]),l!==b)););return m-=e,m===d||m%d===0&&m/d>=0}}},PSEUDO:function(a,c){var e,f=w.pseudos[a]||w.setFilters[a.toLowerCase()]||b.error("unsupported pseudo: "+a);return f[N]?f(c):f.length>1?(e=[a,a,"",c],w.setFilters.hasOwnProperty(a.toLowerCase())?d(function(a,b){for(var d,e=f(a,c),g=e.length;g--;)d=aa(a,e[g]),a[d]=!(b[d]=e[g])}):function(a){return f(a,0,e)}):f}},pseudos:{not:d(function(a){var b=[],c=[],e=A(a.replace(ia,"$1"));return e[N]?d(function(a,b,c,d){for(var f,g=e(a,null,d,[]),h=a.length;h--;)(f=g[h])&&(a[h]=!(b[h]=f))}):function(a,d,f){return b[0]=a,e(b,null,f,c),b[0]=null,!c.pop()}}),has:d(function(a){return function(c){return b(a,c).length>0}}),contains:d(function(a){return a=a.replace(va,wa),function(b){return(b.textContent||b.innerText||x(b)).indexOf(a)>-1}}),lang:d(function(a){return na.test(a||"")||b.error("unsupported lang: "+a),a=a.replace(va,wa).toLowerCase(),function(b){var c;do if(c=I?b.lang:b.getAttribute("xml:lang")||b.getAttribute("lang"))return c=c.toLowerCase(),c===a||0===c.indexOf(a+"-");while((b=b.parentNode)&&1===b.nodeType);return!1}}),target:function(b){var c=a.location&&a.location.hash;return c&&c.slice(1)===b.id},root:function(a){return a===H},focus:function(a){return a===G.activeElement&&(!G.hasFocus||G.hasFocus())&&!!(a.type||a.href||~a.tabIndex)},enabled:function(a){return a.disabled===!1},disabled:function(a){return a.disabled===!0},checked:function(a){var b=a.nodeName.toLowerCase();return"input"===b&&!!a.checked||"option"===b&&!!a.selected},selected:function(a){return a.parentNode&&a.parentNode.selectedIndex,a.selected===!0},empty:function(a){for(a=a.firstChild;a;a=a.nextSibling)if(a.nodeType<6)return!1;return!0},parent:function(a){return!w.pseudos.empty(a)},header:function(a){return qa.test(a.nodeName)},input:function(a){return pa.test(a.nodeName)},button:function(a){var b=a.nodeName.toLowerCase();return"input"===b&&"button"===a.type||"button"===b},text:function(a){var b;return"input"===a.nodeName.toLowerCase()&&"text"===a.type&&(null==(b=a.getAttribute("type"))||"text"===b.toLowerCase())},first:j(function(){return[0]}),last:j(function(a,b){return[b-1]}),eq:j(function(a,b,c){return[0>c?c+b:c]}),even:j(function(a,b){for(var c=0;b>c;c+=2)a.push(c);return a}),odd:j(function(a,b){for(var c=1;b>c;c+=2)a.push(c);return a}),lt:j(function(a,b,c){for(var d=0>c?c+b:c;--d>=0;)a.push(d);return a}),gt:j(function(a,b,c){for(var d=0>c?c+b:c;++d<b;)a.push(d);return a})}},w.pseudos.nth=w.pseudos.eq;
+// Add button/input type pseudos
+for(u in{radio:!0,checkbox:!0,file:!0,password:!0,image:!0})w.pseudos[u]=h(u);for(u in{submit:!0,reset:!0})w.pseudos[u]=i(u);/**
+ * A low-level selection function that works with Sizzle's compiled
+ *  selector functions
+ * @param {String|Function} selector A selector or a pre-compiled
+ *  selector function built with Sizzle.compile
+ * @param {Element} context
+ * @param {Array} [results]
+ * @param {Array} [seed] A set of elements to match against
+ */
+// One-time assignments
+// Sort stability
+// Support: Chrome 14-35+
+// Always assume duplicates if they aren't passed to the comparison function
+// Initialize against the default document
+// Support: Webkit<537.32 - Safari 6.0.3/Chrome 25 (fixed in Chrome 27)
+// Detached nodes confoundingly follow *each other*
+// Support: IE<8
+// Prevent attribute/property "interpolation"
+// http://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
+// Support: IE<9
+// Use defaultValue in place of getAttribute("value")
+// Support: IE<9
+// Use getAttributeNode to fetch booleans when getAttribute lies
+return l.prototype=w.filters=w.pseudos,w.setFilters=new l,z=b.tokenize=function(a,c){var d,e,f,g,h,i,j,k=S[a+" "];if(k)return c?0:k.slice(0);for(h=a,i=[],j=w.preFilter;h;){
+// Comma and first run
+(!d||(e=ja.exec(h)))&&(e&&(
+// Don't consume trailing commas as valid
+h=h.slice(e[0].length)||h),i.push(f=[])),d=!1,
+// Combinators
+(e=ka.exec(h))&&(d=e.shift(),f.push({value:d,type:e[0].replace(ia," ")}),h=h.slice(d.length));
+// Filters
+for(g in w.filter)!(e=oa[g].exec(h))||j[g]&&!(e=j[g](e))||(d=e.shift(),f.push({value:d,type:g,matches:e}),h=h.slice(d.length));if(!d)break}
+// Return the length of the invalid excess
+// if we're just parsing
+// Otherwise, throw an error or return tokens
+// Cache the tokens
+return c?h.length:h?b.error(a):S(a,i).slice(0)},A=b.compile=function(a,b){var c,d=[],e=[],f=T[a+" "];if(!f){for(b||(b=z(a)),c=b.length;c--;)f=s(b[c]),f[N]?d.push(f):e.push(f);f=T(a,t(e,d)),f.selector=a}return f},B=b.select=function(a,b,c,d){var e,f,g,h,i,j="function"==typeof a&&a,l=!d&&z(a=j.selector||a);if(c=c||[],1===l.length){if(f=l[0]=l[0].slice(0),f.length>2&&"ID"===(g=f[0]).type&&v.getById&&9===b.nodeType&&I&&w.relative[f[1].type]){if(b=(w.find.ID(g.matches[0].replace(va,wa),b)||[])[0],!b)return c;j&&(b=b.parentNode),a=a.slice(f.shift().value.length)}for(e=oa.needsContext.test(a)?0:f.length;e--&&(g=f[e],!w.relative[h=g.type]);)if((i=w.find[h])&&(d=i(g.matches[0].replace(va,wa),ta.test(f[0].type)&&k(b.parentNode)||b))){if(f.splice(e,1),a=d.length&&m(f),!a)return $.apply(c,d),c;break}}return(j||A(a,l))(d,b,!I,c,ta.test(a)&&k(b.parentNode)||b),c},v.sortStable=N.split("").sort(U).join("")===N,v.detectDuplicates=!!E,F(),v.sortDetached=e(function(a){return 1&a.compareDocumentPosition(G.createElement("div"))}),e(function(a){return a.innerHTML="<a href='#'></a>","#"===a.firstChild.getAttribute("href")})||f("type|href|height|width",function(a,b,c){return c?void 0:a.getAttribute(b,"type"===b.toLowerCase()?1:2)}),v.attributes&&e(function(a){return a.innerHTML="<input/>",a.firstChild.setAttribute("value",""),""===a.firstChild.getAttribute("value")})||f("value",function(a,b,c){return c||"input"!==a.nodeName.toLowerCase()?void 0:a.defaultValue}),e(function(a){return null==a.getAttribute("disabled")})||f(ba,function(a,b,c){var d;return c?void 0:a[b]===!0?b.toLowerCase():(d=a.getAttributeNode(b))&&d.specified?d.value:null}),b}(a);_.find=ea,_.expr=ea.selectors,_.expr[":"]=_.expr.pseudos,_.unique=ea.uniqueSort,_.text=ea.getText,_.isXMLDoc=ea.isXML,_.contains=ea.contains;var fa=_.expr.match.needsContext,ga=/^<(\w+)\s*\/?>(?:<\/\1>|)$/,ha=/^.[^:#\[\.,]*$/;_.filter=function(a,b,c){var d=b[0];return c&&(a=":not("+a+")"),1===b.length&&1===d.nodeType?_.find.matchesSelector(d,a)?[d]:[]:_.find.matches(a,_.grep(b,function(a){return 1===a.nodeType}))},_.fn.extend({find:function(a){var b,c=this.length,d=[],e=this;if("string"!=typeof a)return this.pushStack(_(a).filter(function(){for(b=0;c>b;b++)if(_.contains(e[b],this))return!0}));for(b=0;c>b;b++)_.find(a,e[b],d);
+// Needed because $( selector, context ) becomes $( context ).find( selector )
+return d=this.pushStack(c>1?_.unique(d):d),d.selector=this.selector?this.selector+" "+a:a,d},filter:function(a){return this.pushStack(d(this,a||[],!1))},not:function(a){return this.pushStack(d(this,a||[],!0))},is:function(a){
+// If this is a positional/relative selector, check membership in the returned set
+// so $("p:first").is("p:last") won't return true for a doc with two "p".
+return!!d(this,"string"==typeof a&&fa.test(a)?_(a):a||[],!1).length}});
+// Initialize a jQuery object
+// A central reference to the root jQuery(document)
+var ia,
+// A simple way to check for HTML strings
+// Prioritize #id over <tag> to avoid XSS via location.hash (#9521)
+// Strict HTML recognition (#11290: must start with <)
+ja=/^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/,ka=_.fn.init=function(a,b){var c,d;
+// HANDLE: $(""), $(null), $(undefined), $(false)
+if(!a)return this;
+// Handle HTML strings
+if("string"==typeof a){
+// Match html or make sure no context is specified for #id
+if(c="<"===a[0]&&">"===a[a.length-1]&&a.length>=3?[null,a,null]:ja.exec(a),!c||!c[1]&&b)return!b||b.jquery?(b||ia).find(a):this.constructor(b).find(a);
+// HANDLE: $(html) -> $(array)
+if(c[1]){
+// HANDLE: $(html, props)
+if(b=b instanceof _?b[0]:b,_.merge(this,_.parseHTML(c[1],b&&b.nodeType?b.ownerDocument||b:Z,!0)),ga.test(c[1])&&_.isPlainObject(b))for(c in b)
+// Properties of context are called as methods if possible
+_.isFunction(this[c])?this[c](b[c]):this.attr(c,b[c]);return this}
+// Support: Blackberry 4.6
+// gEBID returns nodes no longer in the document (#6963)
+// Inject the element directly into the jQuery object
+return d=Z.getElementById(c[2]),d&&d.parentNode&&(this.length=1,this[0]=d),this.context=Z,this.selector=a,this}
+// Execute immediately if ready is not present
+return a.nodeType?(this.context=this[0]=a,this.length=1,this):_.isFunction(a)?"undefined"!=typeof ia.ready?ia.ready(a):a(_):(void 0!==a.selector&&(this.selector=a.selector,this.context=a.context),_.makeArray(a,this))};
+// Give the init function the jQuery prototype for later instantiation
+ka.prototype=_.fn,
+// Initialize central reference
+ia=_(Z);var la=/^(?:parents|prev(?:Until|All))/,
+// Methods guaranteed to produce a unique set when starting from a unique set
+ma={children:!0,contents:!0,next:!0,prev:!0};_.extend({dir:function(a,b,c){for(var d=[],e=void 0!==c;(a=a[b])&&9!==a.nodeType;)if(1===a.nodeType){if(e&&_(a).is(c))break;d.push(a)}return d},sibling:function(a,b){for(var c=[];a;a=a.nextSibling)1===a.nodeType&&a!==b&&c.push(a);return c}}),_.fn.extend({has:function(a){var b=_(a,this),c=b.length;return this.filter(function(){for(var a=0;c>a;a++)if(_.contains(this,b[a]))return!0})},closest:function(a,b){for(var c,d=0,e=this.length,f=[],g=fa.test(a)||"string"!=typeof a?_(a,b||this.context):0;e>d;d++)for(c=this[d];c&&c!==b;c=c.parentNode)
+// Always skip document fragments
+if(c.nodeType<11&&(g?g.index(c)>-1:1===c.nodeType&&_.find.matchesSelector(c,a))){f.push(c);break}return this.pushStack(f.length>1?_.unique(f):f)},
+// Determine the position of an element within the set
+index:function(a){
+// No argument, return index in parent
+// No argument, return index in parent
+// Index in selector
+// If it receives a jQuery object, the first element is used
+return a?"string"==typeof a?U.call(_(a),this[0]):U.call(this,a.jquery?a[0]:a):this[0]&&this[0].parentNode?this.first().prevAll().length:-1},add:function(a,b){return this.pushStack(_.unique(_.merge(this.get(),_(a,b))))},addBack:function(a){return this.add(null==a?this.prevObject:this.prevObject.filter(a))}}),_.each({parent:function(a){var b=a.parentNode;return b&&11!==b.nodeType?b:null},parents:function(a){return _.dir(a,"parentNode")},parentsUntil:function(a,b,c){return _.dir(a,"parentNode",c)},next:function(a){return e(a,"nextSibling")},prev:function(a){return e(a,"previousSibling")},nextAll:function(a){return _.dir(a,"nextSibling")},prevAll:function(a){return _.dir(a,"previousSibling")},nextUntil:function(a,b,c){return _.dir(a,"nextSibling",c)},prevUntil:function(a,b,c){return _.dir(a,"previousSibling",c)},siblings:function(a){return _.sibling((a.parentNode||{}).firstChild,a)},children:function(a){return _.sibling(a.firstChild)},contents:function(a){return a.contentDocument||_.merge([],a.childNodes)}},function(a,b){_.fn[a]=function(c,d){var e=_.map(this,b,c);
+// Remove duplicates
+// Reverse order for parents* and prev-derivatives
+return"Until"!==a.slice(-5)&&(d=c),d&&"string"==typeof d&&(e=_.filter(d,e)),this.length>1&&(ma[a]||_.unique(e),la.test(a)&&e.reverse()),this.pushStack(e)}});var na=/\S+/g,oa={};/*
+ * Create a callback list using the following parameters:
+ *
+ *	options: an optional list of space-separated options that will change how
+ *			the callback list behaves or a more traditional option object
+ *
+ * By default a callback list will act like an event callback list and can be
+ * "fired" multiple times.
+ *
+ * Possible options:
+ *
+ *	once:			will ensure the callback list can only be fired once (like a Deferred)
+ *
+ *	memory:			will keep track of previous values and will call any callback added
+ *					after the list has been fired right away with the latest "memorized"
+ *					values (like a Deferred)
+ *
+ *	unique:			will ensure a callback can only be added once (no duplicate in the list)
+ *
+ *	stopOnFalse:	interrupt callings when a callback returns false
+ *
+ */
+_.Callbacks=function(a){
+// Convert options from String-formatted to Object-formatted if needed
+// (we check in cache first)
+a="string"==typeof a?oa[a]||f(a):_.extend({},a);var// Last fire value (for non-forgettable lists)
+b,
+// Flag to know if list was already fired
+c,
+// Flag to know if list is currently firing
+d,
+// First callback to fire (used internally by add and fireWith)
+e,
+// End of the loop when firing
+g,
+// Index of currently firing callback (modified by remove if needed)
+h,
+// Actual callback list
+i=[],
+// Stack of fire calls for repeatable lists
+j=!a.once&&[],
+// Fire callbacks
+k=function(f){for(b=a.memory&&f,c=!0,h=e||0,e=0,g=i.length,d=!0;i&&g>h;h++)if(i[h].apply(f[0],f[1])===!1&&a.stopOnFalse){b=!1;// To prevent further calls using add
+break}d=!1,i&&(j?j.length&&k(j.shift()):b?i=[]:l.disable())},
+// Actual Callbacks object
+l={
+// Add a callback or a collection of callbacks to the list
+add:function(){if(i){
+// First, we save the current length
+var c=i.length;!function f(b){_.each(b,function(b,c){var d=_.type(c);"function"===d?a.unique&&l.has(c)||i.push(c):c&&c.length&&"string"!==d&&
+// Inspect recursively
+f(c)})}(arguments),
+// Do we need to add the callbacks to the
+// current firing batch?
+d?g=i.length:b&&(e=c,k(b))}return this},
+// Remove a callback from the list
+remove:function(){return i&&_.each(arguments,function(a,b){for(var c;(c=_.inArray(b,i,c))>-1;)i.splice(c,1),
+// Handle firing indexes
+d&&(g>=c&&g--,h>=c&&h--)}),this},
+// Check if a given callback is in the list.
+// If no argument is given, return whether or not list has callbacks attached.
+has:function(a){return a?_.inArray(a,i)>-1:!(!i||!i.length)},
+// Remove all callbacks from the list
+empty:function(){return i=[],g=0,this},
+// Have the list do nothing anymore
+disable:function(){return i=j=b=void 0,this},
+// Is it disabled?
+disabled:function(){return!i},
+// Lock the list in its current state
+lock:function(){return j=void 0,b||l.disable(),this},
+// Is it locked?
+locked:function(){return!j},
+// Call all callbacks with the given context and arguments
+fireWith:function(a,b){return!i||c&&!j||(b=b||[],b=[a,b.slice?b.slice():b],d?j.push(b):k(b)),this},
+// Call all the callbacks with the given arguments
+fire:function(){return l.fireWith(this,arguments),this},
+// To know if the callbacks have already been called at least once
+fired:function(){return!!c}};return l},_.extend({Deferred:function(a){var b=[
+// action, add listener, listener list, final state
+["resolve","done",_.Callbacks("once memory"),"resolved"],["reject","fail",_.Callbacks("once memory"),"rejected"],["notify","progress",_.Callbacks("memory")]],c="pending",d={state:function(){return c},always:function(){return e.done(arguments).fail(arguments),this},then:function(){var a=arguments;return _.Deferred(function(c){_.each(b,function(b,f){var g=_.isFunction(a[b])&&a[b];
+// deferred[ done | fail | progress ] for forwarding actions to newDefer
+e[f[1]](function(){var a=g&&g.apply(this,arguments);a&&_.isFunction(a.promise)?a.promise().done(c.resolve).fail(c.reject).progress(c.notify):c[f[0]+"With"](this===d?c.promise():this,g?[a]:arguments)})}),a=null}).promise()},
+// Get a promise for this deferred
+// If obj is provided, the promise aspect is added to the object
+promise:function(a){return null!=a?_.extend(a,d):d}},e={};
+// All done!
+// Keep pipe for back-compat
+// Add list-specific methods
+// Make the deferred a promise
+// Call given func if any
+return d.pipe=d.then,_.each(b,function(a,f){var g=f[2],h=f[3];
+// promise[ done | fail | progress ] = list.add
+d[f[1]]=g.add,
+// Handle state
+h&&g.add(function(){
+// state = [ resolved | rejected ]
+c=h},b[1^a][2].disable,b[2][2].lock),
+// deferred[ resolve | reject | notify ]
+e[f[0]]=function(){return e[f[0]+"With"](this===e?d:this,arguments),this},e[f[0]+"With"]=g.fireWith}),d.promise(e),a&&a.call(e,e),e},
+// Deferred helper
+when:function(a){var b,c,d,e=0,f=R.call(arguments),g=f.length,
+// the count of uncompleted subordinates
+h=1!==g||a&&_.isFunction(a.promise)?g:0,
+// the master Deferred. If resolveValues consist of only a single Deferred, just use that.
+i=1===h?a:_.Deferred(),
+// Update function for both resolve and progress values
+j=function(a,c,d){return function(e){c[a]=this,d[a]=arguments.length>1?R.call(arguments):e,d===b?i.notifyWith(c,d):--h||i.resolveWith(c,d)}};
+// Add listeners to Deferred subordinates; treat others as resolved
+if(g>1)for(b=new Array(g),c=new Array(g),d=new Array(g);g>e;e++)f[e]&&_.isFunction(f[e].promise)?f[e].promise().done(j(e,d,f)).fail(i.reject).progress(j(e,c,b)):--h;
+// If we're not waiting on anything, resolve the master
+return h||i.resolveWith(d,f),i.promise()}});
+// The deferred used on DOM ready
+var pa;_.fn.ready=function(a){
+// Add the callback
+return _.ready.promise().done(a),this},_.extend({
+// Is the DOM ready to be used? Set to true once it occurs.
+isReady:!1,
+// A counter to track how many items to wait for before
+// the ready event fires. See #6781
+readyWait:1,
+// Hold (or release) the ready event
+holdReady:function(a){a?_.readyWait++:_.ready(!0)},
+// Handle when the DOM is ready
+ready:function(a){
+// Abort if there are pending holds or we're already ready
+(a===!0?--_.readyWait:_.isReady)||(
+// Remember that the DOM is ready
+_.isReady=!0,
+// If a normal DOM Ready event fired, decrement, and wait if need be
+a!==!0&&--_.readyWait>0||(
+// If there are functions bound, to execute
+pa.resolveWith(Z,[_]),
+// Trigger any bound ready events
+_.fn.triggerHandler&&(_(Z).triggerHandler("ready"),_(Z).off("ready"))))}}),_.ready.promise=function(b){
+// Catch cases where $(document).ready() is called after the browser event has already occurred.
+// We once tried to use readyState "interactive" here, but it caused issues like the one
+// discovered by ChrisS here: http://bugs.jquery.com/ticket/12282#comment:15
+// Handle it asynchronously to allow scripts the opportunity to delay ready
+// Use the handy event callback
+// A fallback to window.onload, that will always work
+return pa||(pa=_.Deferred(),"complete"===Z.readyState?setTimeout(_.ready):(Z.addEventListener("DOMContentLoaded",g,!1),a.addEventListener("load",g,!1))),pa.promise(b)},
+// Kick off the DOM ready check even if the user does not
+_.ready.promise();
+// Multifunctional method to get and set values of a collection
+// The value/s can optionally be executed if it's a function
+var qa=_.access=function(a,b,c,d,e,f,g){var h=0,i=a.length,j=null==c;
+// Sets many values
+if("object"===_.type(c)){e=!0;for(h in c)_.access(a,b,h,c[h],!0,f,g)}else if(void 0!==d&&(e=!0,_.isFunction(d)||(g=!0),j&&(g?(b.call(a,d),b=null):(j=b,b=function(a,b,c){return j.call(_(a),c)})),b))for(;i>h;h++)b(a[h],c,g?d:d.call(a[h],h,b(a[h],c)));
+// Gets
+return e?a:j?b.call(a):i?b(a[0],c):f};/**
+ * Determines whether an object can have data
+ */
+_.acceptData=function(a){
+// Accepts only:
+//  - Node
+//    - Node.ELEMENT_NODE
+//    - Node.DOCUMENT_NODE
+//  - Object
+//    - Any
+/* jshint -W018 */
+return 1===a.nodeType||9===a.nodeType||!+a.nodeType},h.uid=1,h.accepts=_.acceptData,h.prototype={key:function(a){
+// We can accept data for non-element nodes in modern browsers,
+// but we should not, see #8335.
+// Always return the key for a frozen object.
+if(!h.accepts(a))return 0;var b={},
+// Check if the owner object already has a cache key
+c=a[this.expando];
+// If not, create one
+if(!c){c=h.uid++;
+// Secure it in a non-enumerable, non-writable property
+try{b[this.expando]={value:c},Object.defineProperties(a,b)}catch(d){b[this.expando]=c,_.extend(a,b)}}
+// Ensure the cache object
+return this.cache[c]||(this.cache[c]={}),c},set:function(a,b,c){var d,
+// There may be an unlock assigned to this node,
+// if there is no entry for this "owner", create one inline
+// and set the unlock as though an owner entry had always existed
+e=this.key(a),f=this.cache[e];
+// Handle: [ owner, key, value ] args
+if("string"==typeof b)f[b]=c;else
+// Fresh assignments by object are shallow copied
+if(_.isEmptyObject(f))_.extend(this.cache[e],b);else for(d in b)f[d]=b[d];return f},get:function(a,b){
+// Either a valid cache is found, or will be created.
+// New caches will be created and the unlock returned,
+// allowing direct access to the newly created
+// empty data object. A valid owner object must be provided.
+var c=this.cache[this.key(a)];return void 0===b?c:c[b]},access:function(a,b,c){var d;
+// In cases where either:
+//
+//   1. No key was specified
+//   2. A string key was specified, but no value provided
+//
+// Take the "read" path and allow the get method to determine
+// which value to return, respectively either:
+//
+//   1. The entire cache object
+//   2. The data stored at the key
+//
+// In cases where either:
+//
+//   1. No key was specified
+//   2. A string key was specified, but no value provided
+//
+// Take the "read" path and allow the get method to determine
+// which value to return, respectively either:
+//
+//   1. The entire cache object
+//   2. The data stored at the key
+//
+// [*]When the key is not a string, or both a key and value
+// are specified, set or extend (existing objects) with either:
+//
+//   1. An object of properties
+//   2. A key and value
+//
+return void 0===b||b&&"string"==typeof b&&void 0===c?(d=this.get(a,b),void 0!==d?d:this.get(a,_.camelCase(b))):(this.set(a,b,c),void 0!==c?c:b)},remove:function(a,b){var c,d,e,f=this.key(a),g=this.cache[f];if(void 0===b)this.cache[f]={};else{
+// Support array or space separated string of keys
+_.isArray(b)?
+// If "name" is an array of keys...
+// When data is initially created, via ("key", "val") signature,
+// keys will be converted to camelCase.
+// Since there is no way to tell _how_ a key was added, remove
+// both plain key and camelCase key. #12786
+// This will only penalize the array argument path.
+d=b.concat(b.map(_.camelCase)):(e=_.camelCase(b),b in g?d=[b,e]:(d=e,d=d in g?[d]:d.match(na)||[])),c=d.length;for(;c--;)delete g[d[c]]}},hasData:function(a){return!_.isEmptyObject(this.cache[a[this.expando]]||{})},discard:function(a){a[this.expando]&&delete this.cache[a[this.expando]]}};var ra=new h,sa=new h,ta=/^(?:\{[\w\W]*\}|\[[\w\W]*\])$/,ua=/([A-Z])/g;_.extend({hasData:function(a){return sa.hasData(a)||ra.hasData(a)},data:function(a,b,c){return sa.access(a,b,c)},removeData:function(a,b){sa.remove(a,b)},
+// TODO: Now that all calls to _data and _removeData have been replaced
+// with direct calls to data_priv methods, these can be deprecated.
+_data:function(a,b,c){return ra.access(a,b,c)},_removeData:function(a,b){ra.remove(a,b)}}),_.fn.extend({data:function(a,b){var c,d,e,f=this[0],g=f&&f.attributes;
+// Gets all values
+if(void 0===a){if(this.length&&(e=sa.get(f),1===f.nodeType&&!ra.get(f,"hasDataAttrs"))){for(c=g.length;c--;)
+// Support: IE11+
+// The attrs elements can be null (#14894)
+g[c]&&(d=g[c].name,0===d.indexOf("data-")&&(d=_.camelCase(d.slice(5)),i(f,d,e[d])));ra.set(f,"hasDataAttrs",!0)}return e}
+// Sets multiple values
+// Sets multiple values
+return"object"==typeof a?this.each(function(){sa.set(this,a)}):qa(this,function(b){var c,d=_.camelCase(a);
+// The calling jQuery object (element matches) is not empty
+// (and therefore has an element appears at this[ 0 ]) and the
+// `value` parameter was not undefined. An empty jQuery object
+// will result in `undefined` for elem = this[ 0 ] which will
+// throw an exception if an attempt to read a data cache is made.
+if(f&&void 0===b){if(c=sa.get(f,a),void 0!==c)return c;if(c=sa.get(f,d),void 0!==c)return c;if(c=i(f,d,void 0),void 0!==c)return c}else
+// Set the data...
+this.each(function(){
+// First, attempt to store a copy or reference of any
+// data that might've been store with a camelCased key.
+var c=sa.get(this,d);
+// For HTML5 data-* attribute interop, we have to
+// store property names with dashes in a camelCase form.
+// This might not apply to all properties...*
+sa.set(this,d,b),
+// *... In the case of properties that might _actually_
+// have dashes, we need to also store a copy of that
+// unchanged property.
+-1!==a.indexOf("-")&&void 0!==c&&sa.set(this,a,b)})},null,b,arguments.length>1,null,!0)},removeData:function(a){return this.each(function(){sa.remove(this,a)})}}),_.extend({queue:function(a,b,c){var d;
+// Speed up dequeue by getting out quickly if this is just a lookup
+return a?(b=(b||"fx")+"queue",d=ra.get(a,b),c&&(!d||_.isArray(c)?d=ra.access(a,b,_.makeArray(c)):d.push(c)),d||[]):void 0},dequeue:function(a,b){b=b||"fx";var c=_.queue(a,b),d=c.length,e=c.shift(),f=_._queueHooks(a,b),g=function(){_.dequeue(a,b)};
+// If the fx queue is dequeued, always remove the progress sentinel
+"inprogress"===e&&(e=c.shift(),d--),e&&(
+// Add a progress sentinel to prevent the fx queue from being
+// automatically dequeued
+"fx"===b&&c.unshift("inprogress"),
+// Clear up the last queue stop function
+delete f.stop,e.call(a,g,f)),!d&&f&&f.empty.fire()},
+// Not public - generate a queueHooks object, or return the current one
+_queueHooks:function(a,b){var c=b+"queueHooks";return ra.get(a,c)||ra.access(a,c,{empty:_.Callbacks("once memory").add(function(){ra.remove(a,[b+"queue",c])})})}}),_.fn.extend({queue:function(a,b){var c=2;return"string"!=typeof a&&(b=a,a="fx",c--),arguments.length<c?_.queue(this[0],a):void 0===b?this:this.each(function(){var c=_.queue(this,a,b);
+// Ensure a hooks for this queue
+_._queueHooks(this,a),"fx"===a&&"inprogress"!==c[0]&&_.dequeue(this,a)})},dequeue:function(a){return this.each(function(){_.dequeue(this,a)})},clearQueue:function(a){return this.queue(a||"fx",[])},
+// Get a promise resolved when queues of a certain type
+// are emptied (fx is the type by default)
+promise:function(a,b){var c,d=1,e=_.Deferred(),f=this,g=this.length,h=function(){--d||e.resolveWith(f,[f])};for("string"!=typeof a&&(b=a,a=void 0),a=a||"fx";g--;)c=ra.get(f[g],a+"queueHooks"),c&&c.empty&&(d++,c.empty.add(h));return h(),e.promise(b)}});var va=/[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/.source,wa=["Top","Right","Bottom","Left"],xa=function(a,b){
+// isHidden might be called from jQuery#filter function;
+// in that case, element will be second argument
+return a=b||a,"none"===_.css(a,"display")||!_.contains(a.ownerDocument,a)},ya=/^(?:checkbox|radio)$/i;!function(){var a=Z.createDocumentFragment(),b=a.appendChild(Z.createElement("div")),c=Z.createElement("input");
+// Support: Safari<=5.1
+// Check state lost if the name is set (#11217)
+// Support: Windows Web Apps (WWA)
+// `name` and `type` must use .setAttribute for WWA (#14901)
+c.setAttribute("type","radio"),c.setAttribute("checked","checked"),c.setAttribute("name","t"),b.appendChild(c),
+// Support: Safari<=5.1, Android<4.2
+// Older WebKit doesn't clone checked state correctly in fragments
+Y.checkClone=b.cloneNode(!0).cloneNode(!0).lastChild.checked,
+// Support: IE<=11+
+// Make sure textarea (and checkbox) defaultValue is properly cloned
+b.innerHTML="<textarea>x</textarea>",Y.noCloneChecked=!!b.cloneNode(!0).lastChild.defaultValue}();var za="undefined";Y.focusinBubbles="onfocusin"in a;var Aa=/^key/,Ba=/^(?:mouse|pointer|contextmenu)|click/,Ca=/^(?:focusinfocus|focusoutblur)$/,Da=/^([^.]*)(?:\.(.+)|)$/;/*
+ * Helper functions for managing events -- not part of the public interface.
+ * Props to Dean Edwards' addEvent library for many of the ideas.
+ */
+_.event={global:{},add:function(a,b,c,d,e){var f,g,h,i,j,k,l,m,n,o,p,q=ra.get(a);
+// Don't attach events to noData or text/comment nodes (but allow plain objects)
+if(q)for(
+// Caller can pass in an object of custom data in lieu of the handler
+c.handler&&(f=c,c=f.handler,e=f.selector),
+// Make sure that the handler has a unique ID, used to find/remove it later
+c.guid||(c.guid=_.guid++),
+// Init the element's event structure and main handler, if this is the first
+(i=q.events)||(i=q.events={}),(g=q.handle)||(g=q.handle=function(b){
+// Discard the second event of a jQuery.event.trigger() and
+// when an event is called after a page has unloaded
+return typeof _!==za&&_.event.triggered!==b.type?_.event.dispatch.apply(a,arguments):void 0}),
+// Handle multiple events separated by a space
+b=(b||"").match(na)||[""],j=b.length;j--;)h=Da.exec(b[j])||[],n=p=h[1],o=(h[2]||"").split(".").sort(),n&&(l=_.event.special[n]||{},n=(e?l.delegateType:l.bindType)||n,l=_.event.special[n]||{},k=_.extend({type:n,origType:p,data:d,handler:c,guid:c.guid,selector:e,needsContext:e&&_.expr.match.needsContext.test(e),namespace:o.join(".")},f),(m=i[n])||(m=i[n]=[],m.delegateCount=0,l.setup&&l.setup.call(a,d,o,g)!==!1||a.addEventListener&&a.addEventListener(n,g,!1)),l.add&&(l.add.call(a,k),k.handler.guid||(k.handler.guid=c.guid)),e?m.splice(m.delegateCount++,0,k):m.push(k),_.event.global[n]=!0)},
+// Detach an event or set of events from an element
+remove:function(a,b,c,d,e){var f,g,h,i,j,k,l,m,n,o,p,q=ra.hasData(a)&&ra.get(a);if(q&&(i=q.events)){for(
+// Once for each type.namespace in types; type may be omitted
+b=(b||"").match(na)||[""],j=b.length;j--;)
+// Unbind all events (on this namespace, if provided) for the element
+if(h=Da.exec(b[j])||[],n=p=h[1],o=(h[2]||"").split(".").sort(),n){for(l=_.event.special[n]||{},n=(d?l.delegateType:l.bindType)||n,m=i[n]||[],h=h[2]&&new RegExp("(^|\\.)"+o.join("\\.(?:.*\\.|)")+"(\\.|$)"),
+// Remove matching events
+g=f=m.length;f--;)k=m[f],!e&&p!==k.origType||c&&c.guid!==k.guid||h&&!h.test(k.namespace)||d&&d!==k.selector&&("**"!==d||!k.selector)||(m.splice(f,1),k.selector&&m.delegateCount--,l.remove&&l.remove.call(a,k));
+// Remove generic event handler if we removed something and no more handlers exist
+// (avoids potential for endless recursion during removal of special event handlers)
+g&&!m.length&&(l.teardown&&l.teardown.call(a,o,q.handle)!==!1||_.removeEvent(a,n,q.handle),delete i[n])}else for(n in i)_.event.remove(a,n+b[j],c,d,!0);
+// Remove the expando if it's no longer used
+_.isEmptyObject(i)&&(delete q.handle,ra.remove(a,"events"))}},trigger:function(b,c,d,e){var f,g,h,i,j,k,l,m=[d||Z],n=X.call(b,"type")?b.type:b,o=X.call(b,"namespace")?b.namespace.split("."):[];
+// Don't do events on text and comment nodes
+if(g=h=d=d||Z,3!==d.nodeType&&8!==d.nodeType&&!Ca.test(n+_.event.triggered)&&(n.indexOf(".")>=0&&(o=n.split("."),n=o.shift(),o.sort()),j=n.indexOf(":")<0&&"on"+n,b=b[_.expando]?b:new _.Event(n,"object"==typeof b&&b),b.isTrigger=e?2:3,b.namespace=o.join("."),b.namespace_re=b.namespace?new RegExp("(^|\\.)"+o.join("\\.(?:.*\\.|)")+"(\\.|$)"):null,b.result=void 0,b.target||(b.target=d),c=null==c?[b]:_.makeArray(c,[b]),l=_.event.special[n]||{},e||!l.trigger||l.trigger.apply(d,c)!==!1)){
+// Determine event propagation path in advance, per W3C events spec (#9951)
+// Bubble up to document, then to window; watch for a global ownerDocument var (#9724)
+if(!e&&!l.noBubble&&!_.isWindow(d)){for(i=l.delegateType||n,Ca.test(i+n)||(g=g.parentNode);g;g=g.parentNode)m.push(g),h=g;
+// Only add window if we got to document (e.g., not plain obj or detached DOM)
+h===(d.ownerDocument||Z)&&m.push(h.defaultView||h.parentWindow||a)}for(
+// Fire handlers on the event path
+f=0;(g=m[f++])&&!b.isPropagationStopped();)b.type=f>1?i:l.bindType||n,k=(ra.get(g,"events")||{})[b.type]&&ra.get(g,"handle"),k&&k.apply(g,c),k=j&&g[j],k&&k.apply&&_.acceptData(g)&&(b.result=k.apply(g,c),b.result===!1&&b.preventDefault());
+// If nobody prevented the default action, do it now
+// Call a native DOM method on the target with the same name name as the event.
+// Don't do default actions on window, that's where global variables be (#6170)
+// Don't re-trigger an onFOO event when we call its FOO() method
+// Prevent re-triggering of the same event, since we already bubbled it above
+return b.type=n,e||b.isDefaultPrevented()||l._default&&l._default.apply(m.pop(),c)!==!1||!_.acceptData(d)||j&&_.isFunction(d[n])&&!_.isWindow(d)&&(h=d[j],h&&(d[j]=null),_.event.triggered=n,d[n](),_.event.triggered=void 0,h&&(d[j]=h)),b.result}},dispatch:function(a){
+// Make a writable jQuery.Event from the native event object
+a=_.event.fix(a);var b,c,d,e,f,g=[],h=R.call(arguments),i=(ra.get(this,"events")||{})[a.type]||[],j=_.event.special[a.type]||{};
+// Call the preDispatch hook for the mapped type, and let it bail if desired
+if(
+// Use the fix-ed jQuery.Event rather than the (read-only) native event
+h[0]=a,a.delegateTarget=this,!j.preDispatch||j.preDispatch.call(this,a)!==!1){for(
+// Determine handlers
+g=_.event.handlers.call(this,a,i),
+// Run delegates first; they may want to stop propagation beneath us
+b=0;(e=g[b++])&&!a.isPropagationStopped();)for(a.currentTarget=e.elem,c=0;(f=e.handlers[c++])&&!a.isImmediatePropagationStopped();)
+// Triggered event must either 1) have no namespace, or 2) have namespace(s)
+// a subset or equal to those in the bound event (both can have no namespace).
+(!a.namespace_re||a.namespace_re.test(f.namespace))&&(a.handleObj=f,a.data=f.data,d=((_.event.special[f.origType]||{}).handle||f.handler).apply(e.elem,h),void 0!==d&&(a.result=d)===!1&&(a.preventDefault(),a.stopPropagation()));
+// Call the postDispatch hook for the mapped type
+return j.postDispatch&&j.postDispatch.call(this,a),a.result}},handlers:function(a,b){var c,d,e,f,g=[],h=b.delegateCount,i=a.target;
+// Find delegate handlers
+// Black-hole SVG <use> instance trees (#13180)
+// Avoid non-left-click bubbling in Firefox (#3861)
+if(h&&i.nodeType&&(!a.button||"click"!==a.type))for(;i!==this;i=i.parentNode||this)
+// Don't process clicks on disabled elements (#6911, #8165, #11382, #11764)
+if(i.disabled!==!0||"click"!==a.type){for(d=[],c=0;h>c;c++)f=b[c],e=f.selector+" ",void 0===d[e]&&(d[e]=f.needsContext?_(e,this).index(i)>=0:_.find(e,this,null,[i]).length),d[e]&&d.push(f);d.length&&g.push({elem:i,handlers:d})}
+// Add the remaining (directly-bound) handlers
+return h<b.length&&g.push({elem:this,handlers:b.slice(h)}),g},
+// Includes some event props shared by KeyEvent and MouseEvent
+props:"altKey bubbles cancelable ctrlKey currentTarget eventPhase metaKey relatedTarget shiftKey target timeStamp view which".split(" "),fixHooks:{},keyHooks:{props:"char charCode key keyCode".split(" "),filter:function(a,b){
+// Add which for key events
+return null==a.which&&(a.which=null!=b.charCode?b.charCode:b.keyCode),a}},mouseHooks:{props:"button buttons clientX clientY offsetX offsetY pageX pageY screenX screenY toElement".split(" "),filter:function(a,b){var c,d,e,f=b.button;
+// Calculate pageX/Y if missing and clientX/Y available
+// Add which for click: 1 === left; 2 === middle; 3 === right
+// Note: button is not normalized, so don't use it
+return null==a.pageX&&null!=b.clientX&&(c=a.target.ownerDocument||Z,d=c.documentElement,e=c.body,a.pageX=b.clientX+(d&&d.scrollLeft||e&&e.scrollLeft||0)-(d&&d.clientLeft||e&&e.clientLeft||0),a.pageY=b.clientY+(d&&d.scrollTop||e&&e.scrollTop||0)-(d&&d.clientTop||e&&e.clientTop||0)),a.which||void 0===f||(a.which=1&f?1:2&f?3:4&f?2:0),a}},fix:function(a){if(a[_.expando])return a;
+// Create a writable copy of the event object and normalize some properties
+var b,c,d,e=a.type,f=a,g=this.fixHooks[e];for(g||(this.fixHooks[e]=g=Ba.test(e)?this.mouseHooks:Aa.test(e)?this.keyHooks:{}),d=g.props?this.props.concat(g.props):this.props,a=new _.Event(f),b=d.length;b--;)c=d[b],a[c]=f[c];
+// Support: Cordova 2.5 (WebKit) (#13255)
+// All events should have a target; Cordova deviceready doesn't
+// Support: Safari 6.0+, Chrome<28
+// Target should not be a text node (#504, #13143)
+return a.target||(a.target=Z),3===a.target.nodeType&&(a.target=a.target.parentNode),g.filter?g.filter(a,f):a},special:{load:{
+// Prevent triggered image.load events from bubbling to window.load
+noBubble:!0},focus:{
+// Fire native event if possible so blur/focus sequence is correct
+trigger:function(){return this!==l()&&this.focus?(this.focus(),!1):void 0},delegateType:"focusin"},blur:{trigger:function(){return this===l()&&this.blur?(this.blur(),!1):void 0},delegateType:"focusout"},click:{
+// For checkbox, fire native event so checked state will be right
+trigger:function(){return"checkbox"===this.type&&this.click&&_.nodeName(this,"input")?(this.click(),!1):void 0},
+// For cross-browser consistency, don't fire native .click() on links
+_default:function(a){return _.nodeName(a.target,"a")}},beforeunload:{postDispatch:function(a){
+// Support: Firefox 20+
+// Firefox doesn't alert if the returnValue field is not set.
+void 0!==a.result&&a.originalEvent&&(a.originalEvent.returnValue=a.result)}}},simulate:function(a,b,c,d){
+// Piggyback on a donor event to simulate a different one.
+// Fake originalEvent to avoid donor's stopPropagation, but if the
+// simulated event prevents default then we do the same on the donor.
+var e=_.extend(new _.Event,c,{type:a,isSimulated:!0,originalEvent:{}});d?_.event.trigger(e,null,b):_.event.dispatch.call(b,e),e.isDefaultPrevented()&&c.preventDefault()}},_.removeEvent=function(a,b,c){a.removeEventListener&&a.removeEventListener(b,c,!1)},_.Event=function(a,b){
+// Allow instantiation without the 'new' keyword
+// Allow instantiation without the 'new' keyword
+// Event object
+// Events bubbling up the document may have been marked as prevented
+// by a handler lower down the tree; reflect the correct value.
+// Support: Android<4.0
+// Put explicitly provided properties onto the event object
+// Create a timestamp if incoming event doesn't have one
+// Mark it as fixed
+return this instanceof _.Event?(a&&a.type?(this.originalEvent=a,this.type=a.type,this.isDefaultPrevented=a.defaultPrevented||void 0===a.defaultPrevented&&a.returnValue===!1?j:k):this.type=a,b&&_.extend(this,b),this.timeStamp=a&&a.timeStamp||_.now(),void(this[_.expando]=!0)):new _.Event(a,b)},
+// jQuery.Event is based on DOM3 Events as specified by the ECMAScript Language Binding
+// http://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
+_.Event.prototype={isDefaultPrevented:k,isPropagationStopped:k,isImmediatePropagationStopped:k,preventDefault:function(){var a=this.originalEvent;this.isDefaultPrevented=j,a&&a.preventDefault&&a.preventDefault()},stopPropagation:function(){var a=this.originalEvent;this.isPropagationStopped=j,a&&a.stopPropagation&&a.stopPropagation()},stopImmediatePropagation:function(){var a=this.originalEvent;this.isImmediatePropagationStopped=j,a&&a.stopImmediatePropagation&&a.stopImmediatePropagation(),this.stopPropagation()}},
+// Create mouseenter/leave events using mouseover/out and event-time checks
+// Support: Chrome 15+
+_.each({mouseenter:"mouseover",mouseleave:"mouseout",pointerenter:"pointerover",pointerleave:"pointerout"},function(a,b){_.event.special[a]={delegateType:b,bindType:b,handle:function(a){var c,d=this,e=a.relatedTarget,f=a.handleObj;
+// For mousenter/leave call the handler if related is outside the target.
+// NB: No relatedTarget if the mouse left/entered the browser window
+return(!e||e!==d&&!_.contains(d,e))&&(a.type=f.origType,c=f.handler.apply(this,arguments),a.type=b),c}}}),
+// Support: Firefox, Chrome, Safari
+// Create "bubbling" focus and blur events
+Y.focusinBubbles||_.each({focus:"focusin",blur:"focusout"},function(a,b){
+// Attach a single capturing handler on the document while someone wants focusin/focusout
+var c=function(a){_.event.simulate(b,a.target,_.event.fix(a),!0)};_.event.special[b]={setup:function(){var d=this.ownerDocument||this,e=ra.access(d,b);e||d.addEventListener(a,c,!0),ra.access(d,b,(e||0)+1)},teardown:function(){var d=this.ownerDocument||this,e=ra.access(d,b)-1;e?ra.access(d,b,e):(d.removeEventListener(a,c,!0),ra.remove(d,b))}}}),_.fn.extend({on:function(a,b,c,d,/*INTERNAL*/e){var f,g;
+// Types can be a map of types/handlers
+if("object"==typeof a){
+// ( types-Object, selector, data )
+"string"!=typeof b&&(c=c||b,b=void 0);for(g in a)this.on(g,b,c,a[g],e);return this}if(null==c&&null==d?(d=b,c=b=void 0):null==d&&("string"==typeof b?(d=c,c=void 0):(d=c,c=b,b=void 0)),d===!1)d=k;else if(!d)return this;
+// Use same guid so caller can remove using origFn
+return 1===e&&(f=d,d=function(a){return _().off(a),f.apply(this,arguments)},d.guid=f.guid||(f.guid=_.guid++)),this.each(function(){_.event.add(this,a,d,c,b)})},one:function(a,b,c,d){return this.on(a,b,c,d,1)},off:function(a,b,c){var d,e;if(a&&a.preventDefault&&a.handleObj)
+// ( event )  dispatched jQuery.Event
+return d=a.handleObj,_(a.delegateTarget).off(d.namespace?d.origType+"."+d.namespace:d.origType,d.selector,d.handler),this;if("object"==typeof a){
+// ( types-object [, selector] )
+for(e in a)this.off(e,b,a[e]);return this}
+// ( types [, fn] )
+return(b===!1||"function"==typeof b)&&(c=b,b=void 0),c===!1&&(c=k),this.each(function(){_.event.remove(this,a,c,b)})},trigger:function(a,b){return this.each(function(){_.event.trigger(a,b,this)})},triggerHandler:function(a,b){var c=this[0];return c?_.event.trigger(a,b,c,!0):void 0}});var Ea=/<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/gi,Fa=/<([\w:]+)/,Ga=/<|&#?\w+;/,Ha=/<(?:script|style|link)/i,
+// checked="checked" or checked
+Ia=/checked\s*(?:[^=]|=\s*.checked.)/i,Ja=/^$|\/(?:java|ecma)script/i,Ka=/^true\/(.*)/,La=/^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g,
+// We have to close these tags to support XHTML (#13200)
+Ma={
+// Support: IE9
+option:[1,"<select multiple='multiple'>","</select>"],thead:[1,"<table>","</table>"],col:[2,"<table><colgroup>","</colgroup></table>"],tr:[2,"<table><tbody>","</tbody></table>"],td:[3,"<table><tbody><tr>","</tr></tbody></table>"],_default:[0,"",""]};
+// Support: IE9
+Ma.optgroup=Ma.option,Ma.tbody=Ma.tfoot=Ma.colgroup=Ma.caption=Ma.thead,Ma.th=Ma.td,_.extend({clone:function(a,b,c){var d,e,f,g,h=a.cloneNode(!0),i=_.contains(a.ownerDocument,a);
+// Fix IE cloning issues
+if(!(Y.noCloneChecked||1!==a.nodeType&&11!==a.nodeType||_.isXMLDoc(a)))for(g=r(h),f=r(a),d=0,e=f.length;e>d;d++)s(f[d],g[d]);
+// Copy the events from the original to the clone
+if(b)if(c)for(f=f||r(a),g=g||r(h),d=0,e=f.length;e>d;d++)q(f[d],g[d]);else q(a,h);
+// Return the cloned set
+// Preserve script evaluation history
+return g=r(h,"script"),g.length>0&&p(g,!i&&r(a,"script")),h},buildFragment:function(a,b,c,d){for(var e,f,g,h,i,j,k=b.createDocumentFragment(),l=[],m=0,n=a.length;n>m;m++)if(e=a[m],e||0===e)
+// Add nodes directly
+if("object"===_.type(e))
+// Support: QtWebKit, PhantomJS
+// push.apply(_, arraylike) throws on ancient WebKit
+_.merge(l,e.nodeType?[e]:e);else if(Ga.test(e)){for(f=f||k.appendChild(b.createElement("div")),
+// Deserialize a standard representation
+g=(Fa.exec(e)||["",""])[1].toLowerCase(),h=Ma[g]||Ma._default,f.innerHTML=h[1]+e.replace(Ea,"<$1></$2>")+h[2],
+// Descend through wrappers to the right content
+j=h[0];j--;)f=f.lastChild;
+// Support: QtWebKit, PhantomJS
+// push.apply(_, arraylike) throws on ancient WebKit
+_.merge(l,f.childNodes),
+// Remember the top-level container
+f=k.firstChild,
+// Ensure the created nodes are orphaned (#12392)
+f.textContent=""}else l.push(b.createTextNode(e));for(
+// Remove wrapper from fragment
+k.textContent="",m=0;e=l[m++];)
+// #4087 - If origin and destination elements are the same, and this is
+// that element, do not do anything
+if((!d||-1===_.inArray(e,d))&&(i=_.contains(e.ownerDocument,e),f=r(k.appendChild(e),"script"),i&&p(f),c))for(j=0;e=f[j++];)Ja.test(e.type||"")&&c.push(e);return k},cleanData:function(a){for(var b,c,d,e,f=_.event.special,g=0;void 0!==(c=a[g]);g++){if(_.acceptData(c)&&(e=c[ra.expando],e&&(b=ra.cache[e]))){if(b.events)for(d in b.events)f[d]?_.event.remove(c,d):_.removeEvent(c,d,b.handle);ra.cache[e]&&
+// Discard any remaining `private` data
+delete ra.cache[e]}
+// Discard any remaining `user` data
+delete sa.cache[c[sa.expando]]}}}),_.fn.extend({text:function(a){return qa(this,function(a){return void 0===a?_.text(this):this.empty().each(function(){(1===this.nodeType||11===this.nodeType||9===this.nodeType)&&(this.textContent=a)})},null,a,arguments.length)},append:function(){return this.domManip(arguments,function(a){if(1===this.nodeType||11===this.nodeType||9===this.nodeType){var b=m(this,a);b.appendChild(a)}})},prepend:function(){return this.domManip(arguments,function(a){if(1===this.nodeType||11===this.nodeType||9===this.nodeType){var b=m(this,a);b.insertBefore(a,b.firstChild)}})},before:function(){return this.domManip(arguments,function(a){this.parentNode&&this.parentNode.insertBefore(a,this)})},after:function(){return this.domManip(arguments,function(a){this.parentNode&&this.parentNode.insertBefore(a,this.nextSibling)})},remove:function(a,b){for(var c,d=a?_.filter(a,this):this,e=0;null!=(c=d[e]);e++)b||1!==c.nodeType||_.cleanData(r(c)),c.parentNode&&(b&&_.contains(c.ownerDocument,c)&&p(r(c,"script")),c.parentNode.removeChild(c));return this},empty:function(){for(var a,b=0;null!=(a=this[b]);b++)1===a.nodeType&&(
+// Prevent memory leaks
+_.cleanData(r(a,!1)),
+// Remove any remaining nodes
+a.textContent="");return this},clone:function(a,b){return a=null==a?!1:a,b=null==b?a:b,this.map(function(){return _.clone(this,a,b)})},html:function(a){return qa(this,function(a){var b=this[0]||{},c=0,d=this.length;if(void 0===a&&1===b.nodeType)return b.innerHTML;
+// See if we can take a shortcut and just use innerHTML
+if("string"==typeof a&&!Ha.test(a)&&!Ma[(Fa.exec(a)||["",""])[1].toLowerCase()]){a=a.replace(Ea,"<$1></$2>");try{for(;d>c;c++)b=this[c]||{},1===b.nodeType&&(_.cleanData(r(b,!1)),b.innerHTML=a);b=0}catch(e){}}b&&this.empty().append(a)},null,a,arguments.length)},replaceWith:function(){var a=arguments[0];
+// Force removal if there was no new content (e.g., from empty arguments)
+// Make the changes, replacing each context element with the new content
+return this.domManip(arguments,function(b){a=this.parentNode,_.cleanData(r(this)),a&&a.replaceChild(b,this)}),a&&(a.length||a.nodeType)?this:this.remove()},detach:function(a){return this.remove(a,!0)},domManip:function(a,b){
+// Flatten any nested arrays
+a=S.apply([],a);var c,d,e,f,g,h,i=0,j=this.length,k=this,l=j-1,m=a[0],p=_.isFunction(m);
+// We can't cloneNode fragments that contain checked, in WebKit
+if(p||j>1&&"string"==typeof m&&!Y.checkClone&&Ia.test(m))return this.each(function(c){var d=k.eq(c);p&&(a[0]=m.call(this,c,d.html())),d.domManip(a,b)});if(j&&(c=_.buildFragment(a,this[0].ownerDocument,!1,this),d=c.firstChild,1===c.childNodes.length&&(c=d),d)){
+// Use the original fragment for the last item instead of the first because it can end up
+// being emptied incorrectly in certain situations (#8070).
+for(e=_.map(r(c,"script"),n),f=e.length;j>i;i++)g=c,i!==l&&(g=_.clone(g,!0,!0),f&&_.merge(e,r(g,"script"))),b.call(this[i],g,i);if(f)
+// Evaluate executable scripts on first document insertion
+for(h=e[e.length-1].ownerDocument,_.map(e,o),i=0;f>i;i++)g=e[i],Ja.test(g.type||"")&&!ra.access(g,"globalEval")&&_.contains(h,g)&&(g.src?_._evalUrl&&_._evalUrl(g.src):_.globalEval(g.textContent.replace(La,"")))}return this}}),_.each({appendTo:"append",prependTo:"prepend",insertBefore:"before",insertAfter:"after",replaceAll:"replaceWith"},function(a,b){_.fn[a]=function(a){for(var c,d=[],e=_(a),f=e.length-1,g=0;f>=g;g++)c=g===f?this:this.clone(!0),_(e[g])[b](c),T.apply(d,c.get());return this.pushStack(d)}});var Na,Oa={},Pa=/^margin/,Qa=new RegExp("^("+va+")(?!px)[a-z%]+$","i"),Ra=function(b){
+// Support: IE<=11+, Firefox<=30+ (#15098, #14150)
+// IE throws on elements created in popups
+// FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
+// Support: IE<=11+, Firefox<=30+ (#15098, #14150)
+// IE throws on elements created in popups
+// FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
+return b.ownerDocument.defaultView.opener?b.ownerDocument.defaultView.getComputedStyle(b,null):a.getComputedStyle(b,null)};!function(){
+// Executing both pixelPosition & boxSizingReliable tests require only one layout
+// so they're executed at the same time to save the second computation.
+function b(){g.style.cssText="-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;display:block;margin-top:1%;top:1%;border:1px;padding:1px;width:4px;position:absolute",g.innerHTML="",e.appendChild(f);var b=a.getComputedStyle(g,null);c="1%"!==b.top,d="4px"===b.width,e.removeChild(f)}var c,d,e=Z.documentElement,f=Z.createElement("div"),g=Z.createElement("div");g.style&&(
+// Support: IE9-11+
+// Style of cloned element affects source element cloned (#8908)
+g.style.backgroundClip="content-box",g.cloneNode(!0).style.backgroundClip="",Y.clearCloneStyle="content-box"===g.style.backgroundClip,f.style.cssText="border:0;width:0;height:0;top:0;left:-9999px;margin-top:1px;position:absolute",f.appendChild(g),
+// Support: node.js jsdom
+// Don't assume that getComputedStyle is a property of the global object
+a.getComputedStyle&&_.extend(Y,{pixelPosition:function(){
+// This test is executed only once but we still do memoizing
+// since we can use the boxSizingReliable pre-computing.
+// No need to check if the test was already performed, though.
+return b(),c},boxSizingReliable:function(){return null==d&&b(),d},reliableMarginRight:function(){
+// Support: Android 2.3
+// Check if div with explicit width and no margin-right incorrectly
+// gets computed margin-right based on width of container. (#3333)
+// WebKit Bug 13343 - getComputedStyle returns wrong value for margin-right
+// This support function is only executed once so no memoizing is needed.
+var b,c=g.appendChild(Z.createElement("div"));
+// Reset CSS: box-sizing; display; margin; border; padding
+// Support: Firefox<29, Android 2.3
+// Vendor-prefix box-sizing
+return c.style.cssText=g.style.cssText="-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box;display:block;margin:0;border:0;padding:0",c.style.marginRight=c.style.width="0",g.style.width="1px",e.appendChild(f),b=!parseFloat(a.getComputedStyle(c,null).marginRight),e.removeChild(f),g.removeChild(c),b}}))}(),
+// A method for quickly swapping in/out CSS properties to get correct calculations.
+_.swap=function(a,b,c,d){var e,f,g={};
+// Remember the old values, and insert the new ones
+for(f in b)g[f]=a.style[f],a.style[f]=b[f];e=c.apply(a,d||[]);
+// Revert the old values
+for(f in b)a.style[f]=g[f];return e};var
+// Swappable if display is none or starts with table except "table", "table-cell", or "table-caption"
+// See here for display values: https://developer.mozilla.org/en-US/docs/CSS/display
+Sa=/^(none|table(?!-c[ea]).+)/,Ta=new RegExp("^("+va+")(.*)$","i"),Ua=new RegExp("^([+-])=("+va+")","i"),Va={position:"absolute",visibility:"hidden",display:"block"},Wa={letterSpacing:"0",fontWeight:"400"},Xa=["Webkit","O","Moz","ms"];_.extend({
+// Add in style property hooks for overriding the default
+// behavior of getting and setting a style property
+cssHooks:{opacity:{get:function(a,b){if(b){
+// We should always get a number back from opacity
+var c=v(a,"opacity");return""===c?"1":c}}}},
+// Don't automatically add "px" to these possibly-unitless properties
+cssNumber:{columnCount:!0,fillOpacity:!0,flexGrow:!0,flexShrink:!0,fontWeight:!0,lineHeight:!0,opacity:!0,order:!0,orphans:!0,widows:!0,zIndex:!0,zoom:!0},
+// Add in properties whose names you wish to fix before
+// setting or getting the value
+cssProps:{"float":"cssFloat"},
+// Get and set the style property on a DOM Node
+style:function(a,b,c,d){
+// Don't set styles on text and comment nodes
+if(a&&3!==a.nodeType&&8!==a.nodeType&&a.style){
+// Make sure that we're working with the right name
+var e,f,g,h=_.camelCase(b),i=a.style;
+// Check if we're setting a value
+// Gets hook for the prefixed version, then unprefixed version
+// Check if we're setting a value
+// If a hook was provided get the non-computed value from there
+// Convert "+=" or "-=" to relative numbers (#7345)
+// Fixes bug #9237
+// Make sure that null and NaN values aren't set (#7116)
+// If a number, add 'px' to the (except for certain CSS properties)
+// Support: IE9-11+
+// background-* props affect original clone's values
+// If a hook was provided, use that value, otherwise just set the specified value
+return b=_.cssProps[h]||(_.cssProps[h]=x(i,h)),g=_.cssHooks[b]||_.cssHooks[h],void 0===c?g&&"get"in g&&void 0!==(e=g.get(a,!1,d))?e:i[b]:(f=typeof c,"string"===f&&(e=Ua.exec(c))&&(c=(e[1]+1)*e[2]+parseFloat(_.css(a,b)),f="number"),null!=c&&c===c&&("number"!==f||_.cssNumber[h]||(c+="px"),Y.clearCloneStyle||""!==c||0!==b.indexOf("background")||(i[b]="inherit"),g&&"set"in g&&void 0===(c=g.set(a,c,d))||(i[b]=c)),void 0)}},css:function(a,b,c,d){var e,f,g,h=_.camelCase(b);return b=_.cssProps[h]||(_.cssProps[h]=x(a.style,h)),g=_.cssHooks[b]||_.cssHooks[h],g&&"get"in g&&(e=g.get(a,!0,c)),void 0===e&&(e=v(a,b,d)),"normal"===e&&b in Wa&&(e=Wa[b]),""===c||c?(f=parseFloat(e),c===!0||_.isNumeric(f)?f||0:e):e}}),_.each(["height","width"],function(a,b){_.cssHooks[b]={get:function(a,c,d){return c?Sa.test(_.css(a,"display"))&&0===a.offsetWidth?_.swap(a,Va,function(){return A(a,b,d)}):A(a,b,d):void 0},set:function(a,c,d){var e=d&&Ra(a);return y(a,c,d?z(a,b,d,"border-box"===_.css(a,"boxSizing",!1,e),e):0)}}}),
+// Support: Android 2.3
+_.cssHooks.marginRight=w(Y.reliableMarginRight,function(a,b){return b?_.swap(a,{display:"inline-block"},v,[a,"marginRight"]):void 0}),
+// These hooks are used by animate to expand properties
+_.each({margin:"",padding:"",border:"Width"},function(a,b){_.cssHooks[a+b]={expand:function(c){for(var d=0,e={},
+// Assumes a single number if not a string
+f="string"==typeof c?c.split(" "):[c];4>d;d++)e[a+wa[d]+b]=f[d]||f[d-2]||f[0];return e}},Pa.test(a)||(_.cssHooks[a+b].set=y)}),_.fn.extend({css:function(a,b){return qa(this,function(a,b,c){var d,e,f={},g=0;if(_.isArray(b)){for(d=Ra(a),e=b.length;e>g;g++)f[b[g]]=_.css(a,b[g],!1,d);return f}return void 0!==c?_.style(a,b,c):_.css(a,b)},a,b,arguments.length>1)},show:function(){return B(this,!0)},hide:function(){return B(this)},toggle:function(a){return"boolean"==typeof a?a?this.show():this.hide():this.each(function(){xa(this)?_(this).show():_(this).hide()})}}),_.Tween=C,C.prototype={constructor:C,init:function(a,b,c,d,e,f){this.elem=a,this.prop=c,this.easing=e||"swing",this.options=b,this.start=this.now=this.cur(),this.end=d,this.unit=f||(_.cssNumber[c]?"":"px")},cur:function(){var a=C.propHooks[this.prop];return a&&a.get?a.get(this):C.propHooks._default.get(this)},run:function(a){var b,c=C.propHooks[this.prop];return this.options.duration?this.pos=b=_.easing[this.easing](a,this.options.duration*a,0,1,this.options.duration):this.pos=b=a,this.now=(this.end-this.start)*b+this.start,this.options.step&&this.options.step.call(this.elem,this.now,this),c&&c.set?c.set(this):C.propHooks._default.set(this),this}},C.prototype.init.prototype=C.prototype,C.propHooks={_default:{get:function(a){var b;
+// Passing an empty string as a 3rd parameter to .css will automatically
+// attempt a parseFloat and fallback to a string if the parse fails.
+// Simple values such as "10px" are parsed to Float;
+// complex values such as "rotate(1rad)" are returned as-is.
+return null==a.elem[a.prop]||a.elem.style&&null!=a.elem.style[a.prop]?(b=_.css(a.elem,a.prop,""),b&&"auto"!==b?b:0):a.elem[a.prop]},set:function(a){
+// Use step hook for back compat.
+// Use cssHook if its there.
+// Use .style if available and use plain properties where available.
+_.fx.step[a.prop]?_.fx.step[a.prop](a):a.elem.style&&(null!=a.elem.style[_.cssProps[a.prop]]||_.cssHooks[a.prop])?_.style(a.elem,a.prop,a.now+a.unit):a.elem[a.prop]=a.now}}},
+// Support: IE9
+// Panic based approach to setting things on disconnected nodes
+C.propHooks.scrollTop=C.propHooks.scrollLeft={set:function(a){a.elem.nodeType&&a.elem.parentNode&&(a.elem[a.prop]=a.now)}},_.easing={linear:function(a){return a},swing:function(a){return.5-Math.cos(a*Math.PI)/2}},_.fx=C.prototype.init,
+// Back Compat <1.8 extension point
+_.fx.step={};var Ya,Za,$a=/^(?:toggle|show|hide)$/,_a=new RegExp("^(?:([+-])=|)("+va+")([a-z%]*)$","i"),ab=/queueHooks$/,bb=[G],cb={"*":[function(a,b){var c=this.createTween(a,b),d=c.cur(),e=_a.exec(b),f=e&&e[3]||(_.cssNumber[a]?"":"px"),
+// Starting value computation is required for potential unit mismatches
+g=(_.cssNumber[a]||"px"!==f&&+d)&&_a.exec(_.css(c.elem,a)),h=1,i=20;if(g&&g[3]!==f){
+// Trust units reported by jQuery.css
+f=f||g[3],
+// Make sure we update the tween properties later on
+e=e||[],
+// Iteratively approximate from a nonzero starting point
+g=+d||1;do h=h||".5",g/=h,_.style(c.elem,a,g+f);while(h!==(h=c.cur()/d)&&1!==h&&--i)}
+// Update tween properties
+// If a +=/-= token was provided, we're doing a relative animation
+return e&&(g=c.start=+g||+d||0,c.unit=f,c.end=e[1]?g+(e[1]+1)*e[2]:+e[2]),c}]};_.Animation=_.extend(I,{tweener:function(a,b){_.isFunction(a)?(b=a,a=["*"]):a=a.split(" ");for(var c,d=0,e=a.length;e>d;d++)c=a[d],cb[c]=cb[c]||[],cb[c].unshift(b)},prefilter:function(a,b){b?bb.unshift(a):bb.push(a)}}),_.speed=function(a,b,c){var d=a&&"object"==typeof a?_.extend({},a):{complete:c||!c&&b||_.isFunction(a)&&a,duration:a,easing:c&&b||b&&!_.isFunction(b)&&b};
+// Normalize opt.queue - true/undefined/null -> "fx"
+// Queueing
+return d.duration=_.fx.off?0:"number"==typeof d.duration?d.duration:d.duration in _.fx.speeds?_.fx.speeds[d.duration]:_.fx.speeds._default,(null==d.queue||d.queue===!0)&&(d.queue="fx"),d.old=d.complete,d.complete=function(){_.isFunction(d.old)&&d.old.call(this),d.queue&&_.dequeue(this,d.queue)},d},_.fn.extend({fadeTo:function(a,b,c,d){
+// Show any hidden elements after setting opacity to 0
+return this.filter(xa).css("opacity",0).show().end().animate({opacity:b},a,c,d)},animate:function(a,b,c,d){var e=_.isEmptyObject(a),f=_.speed(b,c,d),g=function(){
+// Operate on a copy of prop so per-property easing won't be lost
+var b=I(this,_.extend({},a),f);
+// Empty animations, or finishing resolves immediately
+(e||ra.get(this,"finish"))&&b.stop(!0)};return g.finish=g,e||f.queue===!1?this.each(g):this.queue(f.queue,g)},stop:function(a,b,c){var d=function(a){var b=a.stop;delete a.stop,b(c)};return"string"!=typeof a&&(c=b,b=a,a=void 0),b&&a!==!1&&this.queue(a||"fx",[]),this.each(function(){var b=!0,e=null!=a&&a+"queueHooks",f=_.timers,g=ra.get(this);if(e)g[e]&&g[e].stop&&d(g[e]);else for(e in g)g[e]&&g[e].stop&&ab.test(e)&&d(g[e]);for(e=f.length;e--;)f[e].elem!==this||null!=a&&f[e].queue!==a||(f[e].anim.stop(c),b=!1,f.splice(e,1));
+// Start the next in the queue if the last step wasn't forced.
+// Timers currently will call their complete callbacks, which
+// will dequeue but only if they were gotoEnd.
+(b||!c)&&_.dequeue(this,a)})},finish:function(a){return a!==!1&&(a=a||"fx"),this.each(function(){var b,c=ra.get(this),d=c[a+"queue"],e=c[a+"queueHooks"],f=_.timers,g=d?d.length:0;
+// Look for any active animations, and finish them
+for(
+// Enable finishing flag on private data
+c.finish=!0,
+// Empty the queue first
+_.queue(this,a,[]),e&&e.stop&&e.stop.call(this,!0),b=f.length;b--;)f[b].elem===this&&f[b].queue===a&&(f[b].anim.stop(!0),f.splice(b,1));
+// Look for any animations in the old queue and finish them
+for(b=0;g>b;b++)d[b]&&d[b].finish&&d[b].finish.call(this);
+// Turn off finishing flag
+delete c.finish})}}),_.each(["toggle","show","hide"],function(a,b){var c=_.fn[b];_.fn[b]=function(a,d,e){return null==a||"boolean"==typeof a?c.apply(this,arguments):this.animate(E(b,!0),a,d,e)}}),
+// Generate shortcuts for custom animations
+_.each({slideDown:E("show"),slideUp:E("hide"),slideToggle:E("toggle"),fadeIn:{opacity:"show"},fadeOut:{opacity:"hide"},fadeToggle:{opacity:"toggle"}},function(a,b){_.fn[a]=function(a,c,d){return this.animate(b,a,c,d)}}),_.timers=[],_.fx.tick=function(){var a,b=0,c=_.timers;for(Ya=_.now();b<c.length;b++)a=c[b],a()||c[b]!==a||c.splice(b--,1);c.length||_.fx.stop(),Ya=void 0},_.fx.timer=function(a){_.timers.push(a),a()?_.fx.start():_.timers.pop()},_.fx.interval=13,_.fx.start=function(){Za||(Za=setInterval(_.fx.tick,_.fx.interval))},_.fx.stop=function(){clearInterval(Za),Za=null},_.fx.speeds={slow:600,fast:200,
+// Default speed
+_default:400},
+// Based off of the plugin by Clint Helfers, with permission.
+// http://blindsignals.com/index.php/2009/07/jquery-delay/
+_.fn.delay=function(a,b){return a=_.fx?_.fx.speeds[a]||a:a,b=b||"fx",this.queue(b,function(b,c){var d=setTimeout(b,a);c.stop=function(){clearTimeout(d)}})},function(){var a=Z.createElement("input"),b=Z.createElement("select"),c=b.appendChild(Z.createElement("option"));a.type="checkbox",
+// Support: iOS<=5.1, Android<=4.2+
+// Default value for a checkbox should be "on"
+Y.checkOn=""!==a.value,
+// Support: IE<=11+
+// Must access selectedIndex to make default options select
+Y.optSelected=c.selected,
+// Support: Android<=2.3
+// Options inside disabled selects are incorrectly marked as disabled
+b.disabled=!0,Y.optDisabled=!c.disabled,a=Z.createElement("input"),a.value="t",a.type="radio",Y.radioValue="t"===a.value}();var db,eb,fb=_.expr.attrHandle;_.fn.extend({attr:function(a,b){return qa(this,_.attr,a,b,arguments.length>1)},removeAttr:function(a){return this.each(function(){_.removeAttr(this,a)})}}),_.extend({attr:function(a,b,c){var d,e,f=a.nodeType;
+// don't get/set attributes on text, comment and attribute nodes
+if(a&&3!==f&&8!==f&&2!==f)
+// Fallback to prop when attributes are not supported
+// Fallback to prop when attributes are not supported
+// All attributes are lowercase
+// Grab necessary hook if one is defined
+return typeof a.getAttribute===za?_.prop(a,b,c):(1===f&&_.isXMLDoc(a)||(b=b.toLowerCase(),d=_.attrHooks[b]||(_.expr.match.bool.test(b)?eb:db)),void 0===c?d&&"get"in d&&null!==(e=d.get(a,b))?e:(e=_.find.attr(a,b),null==e?void 0:e):null!==c?d&&"set"in d&&void 0!==(e=d.set(a,c,b))?e:(a.setAttribute(b,c+""),c):void _.removeAttr(a,b))},removeAttr:function(a,b){var c,d,e=0,f=b&&b.match(na);if(f&&1===a.nodeType)for(;c=f[e++];)d=_.propFix[c]||c,_.expr.match.bool.test(c)&&(a[d]=!1),a.removeAttribute(c)},attrHooks:{type:{set:function(a,b){if(!Y.radioValue&&"radio"===b&&_.nodeName(a,"input")){var c=a.value;return a.setAttribute("type",b),c&&(a.value=c),b}}}}}),eb={set:function(a,b,c){
+// Remove boolean attributes when set to false
+return b===!1?_.removeAttr(a,c):a.setAttribute(c,c),c}},_.each(_.expr.match.bool.source.match(/\w+/g),function(a,b){var c=fb[b]||_.find.attr;fb[b]=function(a,b,d){var e,f;return d||(f=fb[b],fb[b]=e,e=null!=c(a,b,d)?b.toLowerCase():null,fb[b]=f),e}});var gb=/^(?:input|select|textarea|button)$/i;_.fn.extend({prop:function(a,b){return qa(this,_.prop,a,b,arguments.length>1)},removeProp:function(a){return this.each(function(){delete this[_.propFix[a]||a]})}}),_.extend({propFix:{"for":"htmlFor","class":"className"},prop:function(a,b,c){var d,e,f,g=a.nodeType;
+// Don't get/set properties on text, comment and attribute nodes
+if(a&&3!==g&&8!==g&&2!==g)return f=1!==g||!_.isXMLDoc(a),f&&(b=_.propFix[b]||b,e=_.propHooks[b]),void 0!==c?e&&"set"in e&&void 0!==(d=e.set(a,c,b))?d:a[b]=c:e&&"get"in e&&null!==(d=e.get(a,b))?d:a[b]},propHooks:{tabIndex:{get:function(a){return a.hasAttribute("tabindex")||gb.test(a.nodeName)||a.href?a.tabIndex:-1}}}}),Y.optSelected||(_.propHooks.selected={get:function(a){var b=a.parentNode;return b&&b.parentNode&&b.parentNode.selectedIndex,null}}),_.each(["tabIndex","readOnly","maxLength","cellSpacing","cellPadding","rowSpan","colSpan","useMap","frameBorder","contentEditable"],function(){_.propFix[this.toLowerCase()]=this});var hb=/[\t\r\n\f]/g;_.fn.extend({addClass:function(a){var b,c,d,e,f,g,h="string"==typeof a&&a,i=0,j=this.length;if(_.isFunction(a))return this.each(function(b){_(this).addClass(a.call(this,b,this.className))});if(h)for(
+// The disjunction here is for better compressibility (see removeClass)
+b=(a||"").match(na)||[];j>i;i++)if(c=this[i],d=1===c.nodeType&&(c.className?(" "+c.className+" ").replace(hb," "):" ")){for(f=0;e=b[f++];)d.indexOf(" "+e+" ")<0&&(d+=e+" ");
+// only assign if different to avoid unneeded rendering.
+g=_.trim(d),c.className!==g&&(c.className=g)}return this},removeClass:function(a){var b,c,d,e,f,g,h=0===arguments.length||"string"==typeof a&&a,i=0,j=this.length;if(_.isFunction(a))return this.each(function(b){_(this).removeClass(a.call(this,b,this.className))});if(h)for(b=(a||"").match(na)||[];j>i;i++)if(c=this[i],d=1===c.nodeType&&(c.className?(" "+c.className+" ").replace(hb," "):"")){for(f=0;e=b[f++];)
+// Remove *all* instances
+for(;d.indexOf(" "+e+" ")>=0;)d=d.replace(" "+e+" "," ");
+// Only assign if different to avoid unneeded rendering.
+g=a?_.trim(d):"",c.className!==g&&(c.className=g)}return this},toggleClass:function(a,b){var c=typeof a;return"boolean"==typeof b&&"string"===c?b?this.addClass(a):this.removeClass(a):_.isFunction(a)?this.each(function(c){_(this).toggleClass(a.call(this,c,this.className,b),b)}):this.each(function(){if("string"===c)for(var b,d=0,e=_(this),f=a.match(na)||[];b=f[d++];)e.hasClass(b)?e.removeClass(b):e.addClass(b);else(c===za||"boolean"===c)&&(this.className&&ra.set(this,"__className__",this.className),this.className=this.className||a===!1?"":ra.get(this,"__className__")||"")})},hasClass:function(a){for(var b=" "+a+" ",c=0,d=this.length;d>c;c++)if(1===this[c].nodeType&&(" "+this[c].className+" ").replace(hb," ").indexOf(b)>=0)return!0;return!1}});var ib=/\r/g;_.fn.extend({val:function(a){var b,c,d,e=this[0];{if(arguments.length)return d=_.isFunction(a),this.each(function(c){var e;1===this.nodeType&&(e=d?a.call(this,c,_(this).val()):a,null==e?e="":"number"==typeof e?e+="":_.isArray(e)&&(e=_.map(e,function(a){return null==a?"":a+""})),b=_.valHooks[this.type]||_.valHooks[this.nodeName.toLowerCase()],b&&"set"in b&&void 0!==b.set(this,e,"value")||(this.value=e))});if(e)
+// Handle most common string cases
+// Handle cases where value is null/undef or number
+return b=_.valHooks[e.type]||_.valHooks[e.nodeName.toLowerCase()],b&&"get"in b&&void 0!==(c=b.get(e,"value"))?c:(c=e.value,"string"==typeof c?c.replace(ib,""):null==c?"":c)}}}),_.extend({valHooks:{option:{get:function(a){var b=_.find.attr(a,"value");
+// Support: IE10-11+
+// option.text throws exceptions (#14686, #14858)
+return null!=b?b:_.trim(_.text(a))}},select:{get:function(a){
+// Loop through all the selected options
+for(var b,c,d=a.options,e=a.selectedIndex,f="select-one"===a.type||0>e,g=f?null:[],h=f?e+1:d.length,i=0>e?h:f?e:0;h>i;i++)
+// IE6-9 doesn't update selected after form reset (#2551)
+if(c=d[i],(c.selected||i===e)&&(Y.optDisabled?!c.disabled:null===c.getAttribute("disabled"))&&(!c.parentNode.disabled||!_.nodeName(c.parentNode,"optgroup"))){
+// We don't need an array for one selects
+if(b=_(c).val(),f)return b;
+// Multi-Selects return an array
+g.push(b)}return g},set:function(a,b){for(var c,d,e=a.options,f=_.makeArray(b),g=e.length;g--;)d=e[g],(d.selected=_.inArray(d.value,f)>=0)&&(c=!0);
+// Force browsers to behave consistently when non-matching value is set
+return c||(a.selectedIndex=-1),f}}}}),
+// Radios and checkboxes getter/setter
+_.each(["radio","checkbox"],function(){_.valHooks[this]={set:function(a,b){return _.isArray(b)?a.checked=_.inArray(_(a).val(),b)>=0:void 0}},Y.checkOn||(_.valHooks[this].get=function(a){return null===a.getAttribute("value")?"on":a.value})}),
+// Return jQuery for attributes-only inclusion
+_.each("blur focus focusin focusout load resize scroll unload click dblclick mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave change select submit keydown keypress keyup error contextmenu".split(" "),function(a,b){
+// Handle event binding
+_.fn[b]=function(a,c){return arguments.length>0?this.on(b,null,a,c):this.trigger(b)}}),_.fn.extend({hover:function(a,b){return this.mouseenter(a).mouseleave(b||a)},bind:function(a,b,c){return this.on(a,null,b,c)},unbind:function(a,b){return this.off(a,null,b)},delegate:function(a,b,c,d){return this.on(b,a,c,d)},undelegate:function(a,b,c){
+// ( namespace ) or ( selector, types [, fn] )
+return 1===arguments.length?this.off(a,"**"):this.off(b,a||"**",c)}});var jb=_.now(),kb=/\?/;
+// Support: Android 2.3
+// Workaround failure to string-cast null input
+_.parseJSON=function(a){return JSON.parse(a+"")},
+// Cross-browser xml parsing
+_.parseXML=function(a){var b,c;if(!a||"string"!=typeof a)return null;
+// Support: IE9
+try{c=new DOMParser,b=c.parseFromString(a,"text/xml")}catch(d){b=void 0}return(!b||b.getElementsByTagName("parsererror").length)&&_.error("Invalid XML: "+a),b};var lb=/#.*$/,mb=/([?&])_=[^&]*/,nb=/^(.*?):[ \t]*([^\r\n]*)$/gm,
+// #7653, #8125, #8152: local protocol detection
+ob=/^(?:about|app|app-storage|.+-extension|file|res|widget):$/,pb=/^(?:GET|HEAD)$/,qb=/^\/\//,rb=/^([\w.+-]+:)(?:\/\/(?:[^\/?#]*@|)([^\/?#:]*)(?::(\d+)|)|)/,/* Prefilters
+	 * 1) They are useful to introduce custom dataTypes (see ajax/jsonp.js for an example)
+	 * 2) These are called:
+	 *    - BEFORE asking for a transport
+	 *    - AFTER param serialization (s.data is a string if s.processData is true)
+	 * 3) key is the dataType
+	 * 4) the catchall symbol "*" can be used
+	 * 5) execution will start with transport dataType and THEN continue down to "*" if needed
+	 */
+sb={},/* Transports bindings
+	 * 1) key is the dataType
+	 * 2) the catchall symbol "*" can be used
+	 * 3) selection will start with transport dataType and THEN go to "*" if needed
+	 */
+tb={},
+// Avoid comment-prolog char sequence (#10098); must appease lint and evade compression
+ub="*/".concat("*"),
+// Document location
+vb=a.location.href,
+// Segment location into parts
+wb=rb.exec(vb.toLowerCase())||[];_.extend({
+// Counter for holding the number of active queries
+active:0,
+// Last-Modified header cache for next request
+lastModified:{},etag:{},ajaxSettings:{url:vb,type:"GET",isLocal:ob.test(wb[1]),global:!0,processData:!0,async:!0,contentType:"application/x-www-form-urlencoded; charset=UTF-8",/*
+		timeout: 0,
+		data: null,
+		dataType: null,
+		username: null,
+		password: null,
+		cache: null,
+		throws: false,
+		traditional: false,
+		headers: {},
+		*/
+accepts:{"*":ub,text:"text/plain",html:"text/html",xml:"application/xml, text/xml",json:"application/json, text/javascript"},contents:{xml:/xml/,html:/html/,json:/json/},responseFields:{xml:"responseXML",text:"responseText",json:"responseJSON"},
+// Data converters
+// Keys separate source (or catchall "*") and destination types with a single space
+converters:{
+// Convert anything to text
+"* text":String,
+// Text to html (true = no transformation)
+"text html":!0,
+// Evaluate text as a json expression
+"text json":_.parseJSON,
+// Parse text as xml
+"text xml":_.parseXML},
+// For options that shouldn't be deep extended:
+// you can add your own custom options here if
+// and when you create one that shouldn't be
+// deep extended (see ajaxExtend)
+flatOptions:{url:!0,context:!0}},
+// Creates a full fledged settings object into target
+// with both ajaxSettings and settings fields.
+// If target is omitted, writes into ajaxSettings.
+ajaxSetup:function(a,b){
+// Building a settings object
+// Extending ajaxSettings
+return b?L(L(a,_.ajaxSettings),b):L(_.ajaxSettings,a)},ajaxPrefilter:J(sb),ajaxTransport:J(tb),
+// Main method
+ajax:function(a,b){
+// Callback for when everything is done
+function c(a,b,c,g){var i,k,r,s,u,w=b;
+// Called once
+2!==t&&(t=2,h&&clearTimeout(h),d=void 0,f=g||"",v.readyState=a>0?4:0,i=a>=200&&300>a||304===a,c&&(s=M(l,v,c)),s=N(l,s,v,i),i?(l.ifModified&&(u=v.getResponseHeader("Last-Modified"),u&&(_.lastModified[e]=u),u=v.getResponseHeader("etag"),u&&(_.etag[e]=u)),204===a||"HEAD"===l.type?w="nocontent":304===a?w="notmodified":(w=s.state,k=s.data,r=s.error,i=!r)):(r=w,(a||!w)&&(w="error",0>a&&(a=0))),v.status=a,v.statusText=(b||w)+"",i?o.resolveWith(m,[k,w,v]):o.rejectWith(m,[v,w,r]),v.statusCode(q),q=void 0,j&&n.trigger(i?"ajaxSuccess":"ajaxError",[v,l,i?k:r]),p.fireWith(m,[v,w]),j&&(n.trigger("ajaxComplete",[v,l]),--_.active||_.event.trigger("ajaxStop")))}
+// If url is an object, simulate pre-1.5 signature
+"object"==typeof a&&(b=a,a=void 0),
+// Force options to be an object
+b=b||{};var d,
+// URL without anti-cache param
+e,
+// Response headers
+f,g,
+// timeout handle
+h,
+// Cross-domain detection vars
+i,
+// To know if global events are to be dispatched
+j,
+// Loop variable
+k,
+// Create the final options object
+l=_.ajaxSetup({},b),
+// Callbacks context
+m=l.context||l,
+// Context for global events is callbackContext if it is a DOM node or jQuery collection
+n=l.context&&(m.nodeType||m.jquery)?_(m):_.event,
+// Deferreds
+o=_.Deferred(),p=_.Callbacks("once memory"),
+// Status-dependent callbacks
+q=l.statusCode||{},
+// Headers (they are sent all at once)
+r={},s={},
+// The jqXHR state
+t=0,
+// Default abort message
+u="canceled",
+// Fake xhr
+v={readyState:0,
+// Builds headers hashtable if needed
+getResponseHeader:function(a){var b;if(2===t){if(!g)for(g={};b=nb.exec(f);)g[b[1].toLowerCase()]=b[2];b=g[a.toLowerCase()]}return null==b?null:b},
+// Raw string
+getAllResponseHeaders:function(){return 2===t?f:null},
+// Caches the header
+setRequestHeader:function(a,b){var c=a.toLowerCase();return t||(a=s[c]=s[c]||a,r[a]=b),this},
+// Overrides response content-type header
+overrideMimeType:function(a){return t||(l.mimeType=a),this},
+// Status-dependent callbacks
+statusCode:function(a){var b;if(a)if(2>t)for(b in a)
+// Lazy-add the new callback in a way that preserves old ones
+q[b]=[q[b],a[b]];else
+// Execute the appropriate callbacks
+v.always(a[v.status]);return this},
+// Cancel the request
+abort:function(a){var b=a||u;return d&&d.abort(b),c(0,b),this}};
+// If request was aborted inside a prefilter, stop there
+if(
+// Attach deferreds
+o.promise(v).complete=p.add,v.success=v.done,v.error=v.fail,
+// Remove hash character (#7531: and string promotion)
+// Add protocol if not provided (prefilters might expect it)
+// Handle falsy url in the settings object (#10093: consistency with old signature)
+// We also use the url parameter if available
+l.url=((a||l.url||vb)+"").replace(lb,"").replace(qb,wb[1]+"//"),
+// Alias method option to type as per ticket #12004
+l.type=b.method||b.type||l.method||l.type,
+// Extract dataTypes list
+l.dataTypes=_.trim(l.dataType||"*").toLowerCase().match(na)||[""],null==l.crossDomain&&(i=rb.exec(l.url.toLowerCase()),l.crossDomain=!(!i||i[1]===wb[1]&&i[2]===wb[2]&&(i[3]||("http:"===i[1]?"80":"443"))===(wb[3]||("http:"===wb[1]?"80":"443")))),
+// Convert data if not already a string
+l.data&&l.processData&&"string"!=typeof l.data&&(l.data=_.param(l.data,l.traditional)),
+// Apply prefilters
+K(sb,l,b,v),2===t)return v;j=_.event&&l.global,j&&0===_.active++&&_.event.trigger("ajaxStart"),l.type=l.type.toUpperCase(),l.hasContent=!pb.test(l.type),e=l.url,l.hasContent||(l.data&&(e=l.url+=(kb.test(e)?"&":"?")+l.data,delete l.data),l.cache===!1&&(l.url=mb.test(e)?e.replace(mb,"$1_="+jb++):e+(kb.test(e)?"&":"?")+"_="+jb++)),l.ifModified&&(_.lastModified[e]&&v.setRequestHeader("If-Modified-Since",_.lastModified[e]),_.etag[e]&&v.setRequestHeader("If-None-Match",_.etag[e])),(l.data&&l.hasContent&&l.contentType!==!1||b.contentType)&&v.setRequestHeader("Content-Type",l.contentType),v.setRequestHeader("Accept",l.dataTypes[0]&&l.accepts[l.dataTypes[0]]?l.accepts[l.dataTypes[0]]+("*"!==l.dataTypes[0]?", "+ub+"; q=0.01":""):l.accepts["*"]);
+// Check for headers option
+for(k in l.headers)v.setRequestHeader(k,l.headers[k]);
+// Allow custom headers/mimetypes and early abort
+if(l.beforeSend&&(l.beforeSend.call(m,v,l)===!1||2===t))
+// Abort if not done already and return
+return v.abort();
+// Aborting is no longer a cancellation
+u="abort";
+// Install callbacks on deferreds
+for(k in{success:1,error:1,complete:1})v[k](l[k]);
+// If no transport, we auto-abort
+if(d=K(tb,l,b,v)){v.readyState=1,
+// Send global event
+j&&n.trigger("ajaxSend",[v,l]),
+// Timeout
+l.async&&l.timeout>0&&(h=setTimeout(function(){v.abort("timeout")},l.timeout));try{t=1,d.send(r,c)}catch(w){
+// Propagate exception as error if not done
+if(!(2>t))throw w;c(-1,w)}}else c(-1,"No Transport");return v},getJSON:function(a,b,c){return _.get(a,b,c,"json")},getScript:function(a,b){return _.get(a,void 0,b,"script")}}),_.each(["get","post"],function(a,b){_[b]=function(a,c,d,e){
+// Shift arguments if data argument was omitted
+return _.isFunction(c)&&(e=e||d,d=c,c=void 0),_.ajax({url:a,type:b,dataType:e,data:c,success:d})}}),_._evalUrl=function(a){return _.ajax({url:a,type:"GET",dataType:"script",async:!1,global:!1,"throws":!0})},_.fn.extend({wrapAll:function(a){var b;
+// The elements to wrap the target around
+return _.isFunction(a)?this.each(function(b){_(this).wrapAll(a.call(this,b))}):(this[0]&&(b=_(a,this[0].ownerDocument).eq(0).clone(!0),this[0].parentNode&&b.insertBefore(this[0]),b.map(function(){for(var a=this;a.firstElementChild;)a=a.firstElementChild;return a}).append(this)),this)},wrapInner:function(a){return _.isFunction(a)?this.each(function(b){_(this).wrapInner(a.call(this,b))}):this.each(function(){var b=_(this),c=b.contents();c.length?c.wrapAll(a):b.append(a)})},wrap:function(a){var b=_.isFunction(a);return this.each(function(c){_(this).wrapAll(b?a.call(this,c):a)})},unwrap:function(){return this.parent().each(function(){_.nodeName(this,"body")||_(this).replaceWith(this.childNodes)}).end()}}),_.expr.filters.hidden=function(a){
+// Support: Opera <= 12.12
+// Opera reports offsetWidths and offsetHeights less than zero on some elements
+return a.offsetWidth<=0&&a.offsetHeight<=0},_.expr.filters.visible=function(a){return!_.expr.filters.hidden(a)};var xb=/%20/g,yb=/\[\]$/,zb=/\r?\n/g,Ab=/^(?:submit|button|image|reset|file)$/i,Bb=/^(?:input|select|textarea|keygen)/i;
+// Serialize an array of form elements or a set of
+// key/values into a query string
+_.param=function(a,b){var c,d=[],e=function(a,b){b=_.isFunction(b)?b():null==b?"":b,d[d.length]=encodeURIComponent(a)+"="+encodeURIComponent(b)};
+// If an array was passed in, assume that it is an array of form elements.
+if(
+// Set traditional to true for jQuery <= 1.3.2 behavior.
+void 0===b&&(b=_.ajaxSettings&&_.ajaxSettings.traditional),_.isArray(a)||a.jquery&&!_.isPlainObject(a))
+// Serialize the form elements
+_.each(a,function(){e(this.name,this.value)});else
+// If traditional, encode the "old" way (the way 1.3.2 or older
+// did it), otherwise encode params recursively.
+for(c in a)O(c,a[c],b,e);
+// Return the resulting serialization
+return d.join("&").replace(xb,"+")},_.fn.extend({serialize:function(){return _.param(this.serializeArray())},serializeArray:function(){return this.map(function(){
+// Can add propHook for "elements" to filter or add form elements
+var a=_.prop(this,"elements");return a?_.makeArray(a):this}).filter(function(){var a=this.type;
+// Use .is( ":disabled" ) so that fieldset[disabled] works
+return this.name&&!_(this).is(":disabled")&&Bb.test(this.nodeName)&&!Ab.test(a)&&(this.checked||!ya.test(a))}).map(function(a,b){var c=_(this).val();return null==c?null:_.isArray(c)?_.map(c,function(a){return{name:b.name,value:a.replace(zb,"\r\n")}}):{name:b.name,value:c.replace(zb,"\r\n")}}).get()}}),_.ajaxSettings.xhr=function(){try{return new XMLHttpRequest}catch(a){}};var Cb=0,Db={},Eb={
+// file protocol always yields status code 0, assume 200
+0:200,
+// Support: IE9
+// #1450: sometimes IE returns 1223 when it should be 204
+1223:204},Fb=_.ajaxSettings.xhr();
+// Support: IE9
+// Open requests must be manually aborted on unload (#5280)
+// See https://support.microsoft.com/kb/2856746 for more info
+a.attachEvent&&a.attachEvent("onunload",function(){for(var a in Db)Db[a]()}),Y.cors=!!Fb&&"withCredentials"in Fb,Y.ajax=Fb=!!Fb,_.ajaxTransport(function(a){var b;
+// Cross domain only allowed if supported through XMLHttpRequest
+// Cross domain only allowed if supported through XMLHttpRequest
+return Y.cors||Fb&&!a.crossDomain?{send:function(c,d){var e,f=a.xhr(),g=++Cb;
+// Apply custom fields if provided
+if(f.open(a.type,a.url,a.async,a.username,a.password),a.xhrFields)for(e in a.xhrFields)f[e]=a.xhrFields[e];
+// Override mime type if needed
+a.mimeType&&f.overrideMimeType&&f.overrideMimeType(a.mimeType),
+// X-Requested-With header
+// For cross-domain requests, seeing as conditions for a preflight are
+// akin to a jigsaw puzzle, we simply never set it to be sure.
+// (it can always be set on a per-request basis or even using ajaxSetup)
+// For same-domain requests, won't change header if already provided.
+a.crossDomain||c["X-Requested-With"]||(c["X-Requested-With"]="XMLHttpRequest");
+// Set headers
+for(e in c)f.setRequestHeader(e,c[e]);b=function(a){return function(){b&&(delete Db[g],b=f.onload=f.onerror=null,"abort"===a?f.abort():"error"===a?d(f.status,f.statusText):d(Eb[f.status]||f.status,f.statusText,"string"==typeof f.responseText?{text:f.responseText}:void 0,f.getAllResponseHeaders()))}},f.onload=b(),f.onerror=b("error"),b=Db[g]=b("abort");try{
+// Do send the request (this may raise an exception)
+f.send(a.hasContent&&a.data||null)}catch(h){
+// #14683: Only rethrow if this hasn't been notified as an error yet
+if(b)throw h}},abort:function(){b&&b()}}:void 0}),
+// Install script dataType
+_.ajaxSetup({accepts:{script:"text/javascript, application/javascript, application/ecmascript, application/x-ecmascript"},contents:{script:/(?:java|ecma)script/},converters:{"text script":function(a){return _.globalEval(a),a}}}),
+// Handle cache's special case and crossDomain
+_.ajaxPrefilter("script",function(a){void 0===a.cache&&(a.cache=!1),a.crossDomain&&(a.type="GET")}),
+// Bind script tag hack transport
+_.ajaxTransport("script",function(a){
+// This transport only deals with cross domain requests
+if(a.crossDomain){var b,c;return{send:function(d,e){b=_("<script>").prop({async:!0,charset:a.scriptCharset,src:a.url}).on("load error",c=function(a){b.remove(),c=null,a&&e("error"===a.type?404:200,a.type)}),Z.head.appendChild(b[0])},abort:function(){c&&c()}}}});var Gb=[],Hb=/(=)\?(?=&|$)|\?\?/;
+// Default jsonp settings
+_.ajaxSetup({jsonp:"callback",jsonpCallback:function(){var a=Gb.pop()||_.expando+"_"+jb++;return this[a]=!0,a}}),
+// Detect, normalize options and install callbacks for jsonp requests
+_.ajaxPrefilter("json jsonp",function(b,c,d){var e,f,g,h=b.jsonp!==!1&&(Hb.test(b.url)?"url":"string"==typeof b.data&&!(b.contentType||"").indexOf("application/x-www-form-urlencoded")&&Hb.test(b.data)&&"data");
+// Handle iff the expected data type is "jsonp" or we have a parameter to set
+// Handle iff the expected data type is "jsonp" or we have a parameter to set
+// Get callback name, remembering preexisting value associated with it
+// Insert callback into url or form data
+// Use data converter to retrieve json after script execution
+// force json dataType
+// Install callback
+// Clean-up function (fires after converters)
+return h||"jsonp"===b.dataTypes[0]?(e=b.jsonpCallback=_.isFunction(b.jsonpCallback)?b.jsonpCallback():b.jsonpCallback,h?b[h]=b[h].replace(Hb,"$1"+e):b.jsonp!==!1&&(b.url+=(kb.test(b.url)?"&":"?")+b.jsonp+"="+e),b.converters["script json"]=function(){return g||_.error(e+" was not called"),g[0]},b.dataTypes[0]="json",f=a[e],a[e]=function(){g=arguments},d.always(function(){a[e]=f,b[e]&&(b.jsonpCallback=c.jsonpCallback,Gb.push(e)),g&&_.isFunction(f)&&f(g[0]),g=f=void 0}),"script"):void 0}),
+// data: string of html
+// context (optional): If specified, the fragment will be created in this context, defaults to document
+// keepScripts (optional): If true, will include scripts passed in the html string
+_.parseHTML=function(a,b,c){if(!a||"string"!=typeof a)return null;"boolean"==typeof b&&(c=b,b=!1),b=b||Z;var d=ga.exec(a),e=!c&&[];
+// Single tag
+// Single tag
+return d?[b.createElement(d[1])]:(d=_.buildFragment([a],b,e),e&&e.length&&_(e).remove(),_.merge([],d.childNodes))};
+// Keep a copy of the old load method
+var Ib=_.fn.load;/**
+ * Load a url into a page
+ */
+_.fn.load=function(a,b,c){if("string"!=typeof a&&Ib)return Ib.apply(this,arguments);var d,e,f,g=this,h=a.indexOf(" ");
+// If it's a function
+// We assume that it's the callback
+// If we have elements to modify, make the request
+return h>=0&&(d=_.trim(a.slice(h)),a=a.slice(0,h)),_.isFunction(b)?(c=b,b=void 0):b&&"object"==typeof b&&(e="POST"),g.length>0&&_.ajax({url:a,
+// if "type" variable is undefined, then "GET" method will be used
+type:e,dataType:"html",data:b}).done(function(a){f=arguments,g.html(d?_("<div>").append(_.parseHTML(a)).find(d):a)}).complete(c&&function(a,b){g.each(c,f||[a.responseText,b,a])}),this},
+// Attach a bunch of functions for handling common AJAX events
+_.each(["ajaxStart","ajaxStop","ajaxComplete","ajaxError","ajaxSuccess","ajaxSend"],function(a,b){_.fn[b]=function(a){return this.on(b,a)}}),_.expr.filters.animated=function(a){return _.grep(_.timers,function(b){return a===b.elem}).length};var Jb=a.document.documentElement;_.offset={setOffset:function(a,b,c){var d,e,f,g,h,i,j,k=_.css(a,"position"),l=_(a),m={};
+// Set position first, in-case top/left are set even on static elem
+"static"===k&&(a.style.position="relative"),h=l.offset(),f=_.css(a,"top"),i=_.css(a,"left"),j=("absolute"===k||"fixed"===k)&&(f+i).indexOf("auto")>-1,j?(d=l.position(),g=d.top,e=d.left):(g=parseFloat(f)||0,e=parseFloat(i)||0),_.isFunction(b)&&(b=b.call(a,c,h)),null!=b.top&&(m.top=b.top-h.top+g),null!=b.left&&(m.left=b.left-h.left+e),"using"in b?b.using.call(a,m):l.css(m)}},_.fn.extend({offset:function(a){if(arguments.length)return void 0===a?this:this.each(function(b){_.offset.setOffset(this,a,b)});var b,c,d=this[0],e={top:0,left:0},f=d&&d.ownerDocument;if(f)
+// Make sure it's not a disconnected DOM node
+// Make sure it's not a disconnected DOM node
+// Support: BlackBerry 5, iOS 3 (original iPhone)
+// If we don't have gBCR, just use 0,0 rather than error
+return b=f.documentElement,_.contains(b,d)?(typeof d.getBoundingClientRect!==za&&(e=d.getBoundingClientRect()),c=P(f),{top:e.top+c.pageYOffset-b.clientTop,left:e.left+c.pageXOffset-b.clientLeft}):e},position:function(){if(this[0]){var a,b,c=this[0],d={top:0,left:0};
+// Subtract parent offsets and element margins
+// Fixed elements are offset from window (parentOffset = {top:0, left: 0}, because it is its only offset parent
+// Assume getBoundingClientRect is there when computed position is fixed
+// Get *real* offsetParent
+// Get correct offsets
+// Add offsetParent borders
+return"fixed"===_.css(c,"position")?b=c.getBoundingClientRect():(a=this.offsetParent(),b=this.offset(),_.nodeName(a[0],"html")||(d=a.offset()),d.top+=_.css(a[0],"borderTopWidth",!0),d.left+=_.css(a[0],"borderLeftWidth",!0)),{top:b.top-d.top-_.css(c,"marginTop",!0),left:b.left-d.left-_.css(c,"marginLeft",!0)}}},offsetParent:function(){return this.map(function(){for(var a=this.offsetParent||Jb;a&&!_.nodeName(a,"html")&&"static"===_.css(a,"position");)a=a.offsetParent;return a||Jb})}}),
+// Create scrollLeft and scrollTop methods
+_.each({scrollLeft:"pageXOffset",scrollTop:"pageYOffset"},function(b,c){var d="pageYOffset"===c;_.fn[b]=function(e){return qa(this,function(b,e,f){var g=P(b);return void 0===f?g?g[c]:b[e]:void(g?g.scrollTo(d?a.pageXOffset:f,d?f:a.pageYOffset):b[e]=f)},b,e,arguments.length,null)}}),
+// Support: Safari<7+, Chrome<37+
+// Add the top/left cssHooks using jQuery.fn.position
+// Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=29084
+// Blink bug: https://code.google.com/p/chromium/issues/detail?id=229280
+// getComputedStyle returns percent when specified for top/left/bottom/right;
+// rather than make the css module depend on the offset module, just check for it here
+_.each(["top","left"],function(a,b){_.cssHooks[b]=w(Y.pixelPosition,function(a,c){return c?(c=v(a,b),Qa.test(c)?_(a).position()[b]+"px":c):void 0})}),
+// Create innerHeight, innerWidth, height, width, outerHeight and outerWidth methods
+_.each({Height:"height",Width:"width"},function(a,b){_.each({padding:"inner"+a,content:b,"":"outer"+a},function(c,d){
+// Margin is only for outerHeight, outerWidth
+_.fn[d]=function(d,e){var f=arguments.length&&(c||"boolean"!=typeof d),g=c||(d===!0||e===!0?"margin":"border");return qa(this,function(b,c,d){var e;
+// Get document width or height
+// Get width or height on the element, requesting but not forcing parseFloat
+// Set width or height on the element
+return _.isWindow(b)?b.document.documentElement["client"+a]:9===b.nodeType?(e=b.documentElement,Math.max(b.body["scroll"+a],e["scroll"+a],b.body["offset"+a],e["offset"+a],e["client"+a])):void 0===d?_.css(b,c,g):_.style(b,c,d,g)},b,f?d:void 0,f,null)}})}),
+// The number of elements contained in the matched element set
+_.fn.size=function(){return this.length},_.fn.andSelf=_.fn.addBack,
+// Register as a named AMD module, since jQuery can be concatenated with other
+// files that may use define, but not via a proper concatenation script that
+// understands anonymous AMD modules. A named AMD is safest and most robust
+// way to register. Lowercase jquery is used because AMD module names are
+// derived from file names, and jQuery is normally delivered in a lowercase
+// file name. Do this after creating the global so that if an AMD module wants
+// to call noConflict to hide this version of jQuery, it will work.
+// Note that for maximum portability, libraries that are not jQuery should
+// declare themselves as anonymous modules, and avoid setting a global if an
+// AMD loader is present. jQuery is a special case. For more information, see
+// https://github.com/jrburke/requirejs/wiki/Updating-existing-libraries#wiki-anon
+"function"==typeof define&&define.amd&&define("jquery",[],function(){return _});var
+// Map over jQuery in case of overwrite
+Kb=a.jQuery,
+// Map over the $ in case of overwrite
+Lb=a.$;
+// Expose jQuery and $ identifiers, even in AMD
+// (#7102#comment:10, https://github.com/jquery/jquery/pull/557)
+// and CommonJS for browser emulators (#13566)
+return _.noConflict=function(b){return a.$===_&&(a.$=Lb),b&&a.jQuery===_&&(a.jQuery=Kb),_},typeof b===za&&(a.jQuery=a.$=_),_}),/*jslint onevar:true, undef:true, newcap:true, regexp:true, bitwise:true, maxerr:50, indent:4, white:false, nomen:false, plusplus:false */
+/*global define:false, require:false, exports:false, module:false, signals:false */
+/** @license
  * JS Signals <http://millermedeiros.github.com/js-signals/>
  * Released under the MIT license
  * Author: Miller Medeiros
  * Version: 1.0.0 - Build: 268 (2012/11/29 05:48 PM)
  */
-function(a){function b(a,b,c,d,e){this._listener=b,this._isOnce=c,this.context=d,this._signal=a,this._priority=e||0}function c(a,b){if("function"!=typeof a)throw new Error("listener is a required param of {fn}() and should be a Function.".replace("{fn}",b))}function d(){this._bindings=[],this._prevParams=null;var a=this;this.dispatch=function(){d.prototype.dispatch.apply(a,arguments)}}b.prototype={active:!0,params:null,execute:function(a){var b,c;return this.active&&this._listener&&(c=this.params?this.params.concat(a):a,b=this._listener.apply(this.context,c),this._isOnce&&this.detach()),b},detach:function(){return this.isBound()?this._signal.remove(this._listener,this.context):null},isBound:function(){return!!this._signal&&!!this._listener},isOnce:function(){return this._isOnce},getListener:function(){return this._listener},getSignal:function(){return this._signal},_destroy:function(){delete this._signal,delete this._listener,delete this.context},toString:function(){return"[SignalBinding isOnce:"+this._isOnce+", isBound:"+this.isBound()+", active:"+this.active+"]"}},d.prototype={VERSION:"1.0.0",memorize:!1,_shouldPropagate:!0,active:!0,_registerListener:function(a,c,d,e){var f,g=this._indexOfListener(a,d);if(-1!==g){if(f=this._bindings[g],f.isOnce()!==c)throw new Error("You cannot add"+(c?"":"Once")+"() then add"+(c?"Once":"")+"() the same listener without removing the relationship first.")}else f=new b(this,a,c,d,e),this._addBinding(f);return this.memorize&&this._prevParams&&f.execute(this._prevParams),f},_addBinding:function(a){var b=this._bindings.length;do--b;while(this._bindings[b]&&a._priority<=this._bindings[b]._priority);this._bindings.splice(b+1,0,a)},_indexOfListener:function(a,b){for(var c,d=this._bindings.length;d--;)if(c=this._bindings[d],c._listener===a&&c.context===b)return d;return-1},has:function(a,b){return-1!==this._indexOfListener(a,b)},add:function(a,b,d){return c(a,"add"),this._registerListener(a,!1,b,d)},addOnce:function(a,b,d){return c(a,"addOnce"),this._registerListener(a,!0,b,d)},remove:function(a,b){c(a,"remove");var d=this._indexOfListener(a,b);return-1!==d&&(this._bindings[d]._destroy(),this._bindings.splice(d,1)),a},removeAll:function(){for(var a=this._bindings.length;a--;)this._bindings[a]._destroy();this._bindings.length=0},getNumListeners:function(){return this._bindings.length},halt:function(){this._shouldPropagate=!1},dispatch:function(a){if(this.active){var b,c=Array.prototype.slice.call(arguments),d=this._bindings.length;if(this.memorize&&(this._prevParams=c),d){b=this._bindings.slice(),this._shouldPropagate=!0;do d--;while(b[d]&&this._shouldPropagate&&b[d].execute(c)!==!1)}}},forget:function(){this._prevParams=null},dispose:function(){this.removeAll(),delete this._bindings,delete this._prevParams},toString:function(){return"[Signal active:"+this.active+" numListeners:"+this.getNumListeners()+"]"}};var e=d;e.Signal=d,"function"==typeof define&&define.amd?define(function(){return e}):"undefined"!=typeof module&&module.exports?module.exports=e:a.signals=e}(this),/** @license
+function(a){
+// SignalBinding -------------------------------------------------
+//================================================================
+/**
+     * Object that represents a binding between a Signal and a listener function.
+     * <br />- <strong>This is an internal constructor and shouldn't be called by regular users.</strong>
+     * <br />- inspired by Joa Ebert AS3 SignalBinding and Robert Penner's Slot classes.
+     * @author Miller Medeiros
+     * @constructor
+     * @internal
+     * @name SignalBinding
+     * @param {Signal} signal Reference to Signal object that listener is currently bound to.
+     * @param {Function} listener Handler function bound to the signal.
+     * @param {boolean} isOnce If binding should be executed just once.
+     * @param {Object} [listenerContext] Context on which listener will be executed (object that should represent the `this` variable inside listener function).
+     * @param {Number} [priority] The priority level of the event listener. (default = 0).
+     */
+function b(a,b,c,d,e){/**
+         * Handler function bound to the signal.
+         * @type Function
+         * @private
+         */
+this._listener=b,/**
+         * If binding should be executed just once.
+         * @type boolean
+         * @private
+         */
+this._isOnce=c,/**
+         * Context on which listener will be executed (object that should represent the `this` variable inside listener function).
+         * @memberOf SignalBinding.prototype
+         * @name context
+         * @type Object|undefined|null
+         */
+this.context=d,/**
+         * Reference to Signal object that listener is currently bound to.
+         * @type Signal
+         * @private
+         */
+this._signal=a,/**
+         * Listener priority
+         * @type Number
+         * @private
+         */
+this._priority=e||0}/*global SignalBinding:false*/
+// Signal --------------------------------------------------------
+//================================================================
+function c(a,b){if("function"!=typeof a)throw new Error("listener is a required param of {fn}() and should be a Function.".replace("{fn}",b))}/**
+     * Custom event broadcaster
+     * <br />- inspired by Robert Penner's AS3 Signals.
+     * @name Signal
+     * @author Miller Medeiros
+     * @constructor
+     */
+function d(){/**
+         * @type Array.<SignalBinding>
+         * @private
+         */
+this._bindings=[],this._prevParams=null;
+// enforce dispatch to aways work on same context (#47)
+var a=this;this.dispatch=function(){d.prototype.dispatch.apply(a,arguments)}}b.prototype={/**
+         * If binding is active and should be executed.
+         * @type boolean
+         */
+active:!0,/**
+         * Default parameters passed to listener during `Signal.dispatch` and `SignalBinding.execute`. (curried parameters)
+         * @type Array|null
+         */
+params:null,/**
+         * Call listener passing arbitrary parameters.
+         * <p>If binding was added using `Signal.addOnce()` it will be automatically removed from signal dispatch queue, this method is used internally for the signal dispatch.</p>
+         * @param {Array} [paramsArr] Array of parameters that should be passed to the listener
+         * @return {*} Value returned by the listener.
+         */
+execute:function(a){var b,c;return this.active&&this._listener&&(c=this.params?this.params.concat(a):a,b=this._listener.apply(this.context,c),this._isOnce&&this.detach()),b},/**
+         * Detach binding from signal.
+         * - alias to: mySignal.remove(myBinding.getListener());
+         * @return {Function|null} Handler function bound to the signal or `null` if binding was previously detached.
+         */
+detach:function(){return this.isBound()?this._signal.remove(this._listener,this.context):null},/**
+         * @return {Boolean} `true` if binding is still bound to the signal and have a listener.
+         */
+isBound:function(){return!!this._signal&&!!this._listener},/**
+         * @return {boolean} If SignalBinding will only be executed once.
+         */
+isOnce:function(){return this._isOnce},/**
+         * @return {Function} Handler function bound to the signal.
+         */
+getListener:function(){return this._listener},/**
+         * @return {Signal} Signal that listener is currently bound to.
+         */
+getSignal:function(){return this._signal},/**
+         * Delete instance properties
+         * @private
+         */
+_destroy:function(){delete this._signal,delete this._listener,delete this.context},/**
+         * @return {string} String representation of the object.
+         */
+toString:function(){return"[SignalBinding isOnce:"+this._isOnce+", isBound:"+this.isBound()+", active:"+this.active+"]"}},d.prototype={/**
+         * Signals Version Number
+         * @type String
+         * @const
+         */
+VERSION:"1.0.0",/**
+         * If Signal should keep record of previously dispatched parameters and
+         * automatically execute listener during `add()`/`addOnce()` if Signal was
+         * already dispatched before.
+         * @type boolean
+         */
+memorize:!1,/**
+         * @type boolean
+         * @private
+         */
+_shouldPropagate:!0,/**
+         * If Signal is active and should broadcast events.
+         * <p><strong>IMPORTANT:</strong> Setting this property during a dispatch will only affect the next dispatch, if you want to stop the propagation of a signal use `halt()` instead.</p>
+         * @type boolean
+         */
+active:!0,/**
+         * @param {Function} listener
+         * @param {boolean} isOnce
+         * @param {Object} [listenerContext]
+         * @param {Number} [priority]
+         * @return {SignalBinding}
+         * @private
+         */
+_registerListener:function(a,c,d,e){var f,g=this._indexOfListener(a,d);if(-1!==g){if(f=this._bindings[g],f.isOnce()!==c)throw new Error("You cannot add"+(c?"":"Once")+"() then add"+(c?"Once":"")+"() the same listener without removing the relationship first.")}else f=new b(this,a,c,d,e),this._addBinding(f);return this.memorize&&this._prevParams&&f.execute(this._prevParams),f},/**
+         * @param {SignalBinding} binding
+         * @private
+         */
+_addBinding:function(a){
+//simplified insertion sort
+var b=this._bindings.length;do--b;while(this._bindings[b]&&a._priority<=this._bindings[b]._priority);this._bindings.splice(b+1,0,a)},/**
+         * @param {Function} listener
+         * @return {number}
+         * @private
+         */
+_indexOfListener:function(a,b){for(var c,d=this._bindings.length;d--;)if(c=this._bindings[d],c._listener===a&&c.context===b)return d;return-1},/**
+         * Check if listener was attached to Signal.
+         * @param {Function} listener
+         * @param {Object} [context]
+         * @return {boolean} if Signal has the specified listener.
+         */
+has:function(a,b){return-1!==this._indexOfListener(a,b)},/**
+         * Add a listener to the signal.
+         * @param {Function} listener Signal handler function.
+         * @param {Object} [listenerContext] Context on which listener will be executed (object that should represent the `this` variable inside listener function).
+         * @param {Number} [priority] The priority level of the event listener. Listeners with higher priority will be executed before listeners with lower priority. Listeners with same priority level will be executed at the same order as they were added. (default = 0)
+         * @return {SignalBinding} An Object representing the binding between the Signal and listener.
+         */
+add:function(a,b,d){return c(a,"add"),this._registerListener(a,!1,b,d)},/**
+         * Add listener to the signal that should be removed after first execution (will be executed only once).
+         * @param {Function} listener Signal handler function.
+         * @param {Object} [listenerContext] Context on which listener will be executed (object that should represent the `this` variable inside listener function).
+         * @param {Number} [priority] The priority level of the event listener. Listeners with higher priority will be executed before listeners with lower priority. Listeners with same priority level will be executed at the same order as they were added. (default = 0)
+         * @return {SignalBinding} An Object representing the binding between the Signal and listener.
+         */
+addOnce:function(a,b,d){return c(a,"addOnce"),this._registerListener(a,!0,b,d)},/**
+         * Remove a single listener from the dispatch queue.
+         * @param {Function} listener Handler function that should be removed.
+         * @param {Object} [context] Execution context (since you can add the same handler multiple times if executing in a different context).
+         * @return {Function} Listener handler function.
+         */
+remove:function(a,b){c(a,"remove");var d=this._indexOfListener(a,b);//no reason to a SignalBinding exist if it isn't attached to a signal
+return-1!==d&&(this._bindings[d]._destroy(),this._bindings.splice(d,1)),a},/**
+         * Remove all listeners from the Signal.
+         */
+removeAll:function(){for(var a=this._bindings.length;a--;)this._bindings[a]._destroy();this._bindings.length=0},/**
+         * @return {number} Number of listeners attached to the Signal.
+         */
+getNumListeners:function(){return this._bindings.length},/**
+         * Stop propagation of the event, blocking the dispatch to next listeners on the queue.
+         * <p><strong>IMPORTANT:</strong> should be called only during signal dispatch, calling it before/after dispatch won't affect signal broadcast.</p>
+         * @see Signal.prototype.disable
+         */
+halt:function(){this._shouldPropagate=!1},/**
+         * Dispatch/Broadcast Signal to all listeners added to the queue.
+         * @param {...*} [params] Parameters that should be passed to each handler.
+         */
+dispatch:function(a){if(this.active){var b,c=Array.prototype.slice.call(arguments),d=this._bindings.length;if(this.memorize&&(this._prevParams=c),d){b=this._bindings.slice(),//clone array in case add/remove items during dispatch
+this._shouldPropagate=!0;//in case `halt` was called before dispatch or during the previous dispatch.
+//execute all callbacks until end of the list or until a callback returns `false` or stops propagation
+//reverse loop since listeners with higher priority will be added at the end of the list
+do d--;while(b[d]&&this._shouldPropagate&&b[d].execute(c)!==!1)}}},/**
+         * Forget memorized arguments.
+         * @see Signal.memorize
+         */
+forget:function(){this._prevParams=null},/**
+         * Remove all bindings from signal and destroy any reference to external objects (destroy Signal object).
+         * <p><strong>IMPORTANT:</strong> calling any method on the signal instance after calling dispose will throw errors.</p>
+         */
+dispose:function(){this.removeAll(),delete this._bindings,delete this._prevParams},/**
+         * @return {string} String representation of the object.
+         */
+toString:function(){return"[Signal active:"+this.active+" numListeners:"+this.getNumListeners()+"]"}};
+// Namespace -----------------------------------------------------
+//================================================================
+/**
+     * Signals namespace
+     * @namespace
+     * @name signals
+     */
+var e=d;/**
+     * Custom event broadcaster
+     * @see Signal
+     */
+// alias for backwards compatibility (see #gh-44)
+e.Signal=d,
+//exports to multiple environments
+"function"==typeof define&&define.amd?//AMD
+define(function(){return e}):"undefined"!=typeof module&&module.exports?module.exports=e:a.signals=e}(this),/** @license
  * crossroads <http://millermedeiros.github.com/crossroads.js/>
  * Author: Miller Medeiros | MIT License
  * v0.12.0 (2013/01/21 13:47)
  */
-function(){var a=function(a){function b(a,b){if(a.indexOf)return a.indexOf(b);for(var c=a.length;c--;)if(a[c]===b)return c;return-1}function c(a,c){var d=b(a,c);-1!==d&&a.splice(d,1)}function d(a,b){return"[object "+b+"]"===Object.prototype.toString.call(a)}function e(a){return d(a,"RegExp")}function f(a){return d(a,"Array")}function g(a){return"function"==typeof a}function h(a){var b;return b=null===a||"null"===a?null:"true"===a?!0:"false"===a?!1:a===o||"undefined"===a?o:""===a||isNaN(a)?a:parseFloat(a)}function i(a){for(var b=a.length,c=[];b--;)c[b]=h(a[b]);return c}function j(a,b){for(var c,d,e=(a||"").replace("?","").split("&"),f=e.length,g={};f--;)c=e[f].split("="),d=b?h(c[1]):c[1],g[c[0]]="string"==typeof d?decodeURIComponent(d):d;return g}function k(){this.bypassed=new a.Signal,this.routed=new a.Signal,this._routes=[],this._prevRoutes=[],this._piped=[],this.resetState()}function l(b,c,d,f){var g=e(b),h=f.patternLexer;this._router=f,this._pattern=b,this._paramsIds=g?null:h.getParamIds(b),this._optionalParamsIds=g?null:h.getOptionalParamsIds(b),this._matchRegexp=g?b:h.compilePattern(b,f.ignoreCase),this.matched=new a.Signal,this.switched=new a.Signal,c&&this.matched.add(c),this._priority=d||0}var m,n,o;return n=""===/t(.+)?/.exec("t")[1],k.prototype={greedy:!1,greedyEnabled:!0,ignoreCase:!0,ignoreState:!1,shouldTypecast:!1,normalizeFn:null,resetState:function(){this._prevRoutes.length=0,this._prevMatchedRequest=null,this._prevBypassedRequest=null},create:function(){return new k},addRoute:function(a,b,c){var d=new l(a,b,c,this);return this._sortedInsert(d),d},removeRoute:function(a){c(this._routes,a),a._destroy()},removeAllRoutes:function(){for(var a=this.getNumRoutes();a--;)this._routes[a]._destroy();this._routes.length=0},parse:function(a,b){if(a=a||"",b=b||[],this.ignoreState||a!==this._prevMatchedRequest&&a!==this._prevBypassedRequest){var c,d=this._getMatchedRoutes(a),e=0,f=d.length;if(f)for(this._prevMatchedRequest=a,this._notifyPrevRoutes(d,a),this._prevRoutes=d;f>e;)c=d[e],c.route.matched.dispatch.apply(c.route.matched,b.concat(c.params)),c.isFirst=!e,this.routed.dispatch.apply(this.routed,b.concat([a,c])),e+=1;else this._prevBypassedRequest=a,this.bypassed.dispatch.apply(this.bypassed,b.concat([a]));this._pipeParse(a,b)}},_notifyPrevRoutes:function(a,b){for(var c,d=0;c=this._prevRoutes[d++];)c.route.switched&&this._didSwitch(c.route,a)&&c.route.switched.dispatch(b)},_didSwitch:function(a,b){for(var c,d=0;c=b[d++];)if(c.route===a)return!1;return!0},_pipeParse:function(a,b){for(var c,d=0;c=this._piped[d++];)c.parse(a,b)},getNumRoutes:function(){return this._routes.length},_sortedInsert:function(a){var b=this._routes,c=b.length;do--c;while(b[c]&&a._priority<=b[c]._priority);b.splice(c+1,0,a)},_getMatchedRoutes:function(a){for(var b,c=[],d=this._routes,e=d.length;(b=d[--e])&&((!c.length||this.greedy||b.greedy)&&b.match(a)&&c.push({route:b,params:b._getParamsArray(a)}),this.greedyEnabled||!c.length););return c},pipe:function(a){this._piped.push(a)},unpipe:function(a){c(this._piped,a)},toString:function(){return"[crossroads numRoutes:"+this.getNumRoutes()+"]"}},m=new k,m.VERSION="0.12.0",m.NORM_AS_ARRAY=function(a,b){return[b.vals_]},m.NORM_AS_OBJECT=function(a,b){return[b]},l.prototype={greedy:!1,rules:void 0,match:function(a){return a=a||"",this._matchRegexp.test(a)&&this._validateParams(a)},_validateParams:function(a){var b,c=this.rules,d=this._getParamsObject(a);for(b in c)if("normalize_"!==b&&c.hasOwnProperty(b)&&!this._isValidParam(a,b,d))return!1;return!0},_isValidParam:function(a,c,d){var h=this.rules[c],i=d[c],j=!1,k=0===c.indexOf("?");return null==i&&this._optionalParamsIds&&-1!==b(this._optionalParamsIds,c)?j=!0:e(h)?(k&&(i=d[c+"_"]),j=h.test(i)):f(h)?(k&&(i=d[c+"_"]),j=this._isValidArrayRule(h,i)):g(h)&&(j=h(i,a,d)),j},_isValidArrayRule:function(a,c){if(!this._router.ignoreCase)return-1!==b(a,c);"string"==typeof c&&(c=c.toLowerCase());for(var d,e,f=a.length;f--;)if(d=a[f],e="string"==typeof d?d.toLowerCase():d,e===c)return!0;return!1},_getParamsObject:function(a){for(var c,d,e=this._router.shouldTypecast,f=this._router.patternLexer.getParamValues(a,this._matchRegexp,e),g={},i=f.length;i--;)d=f[i],this._paramsIds&&(c=this._paramsIds[i],0===c.indexOf("?")&&d&&(g[c+"_"]=d,d=j(d,e),f[i]=d),n&&""===d&&-1!==b(this._optionalParamsIds,c)&&(d=void 0,f[i]=d),g[c]=d),g[i]=d;return g.request_=e?h(a):a,g.vals_=f,g},_getParamsArray:function(a){var b,c=this.rules?this.rules.normalize_:null;return c=c||this._router.normalizeFn,b=c&&g(c)?c(a,this._getParamsObject(a)):this._getParamsObject(a).vals_},interpolate:function(a){var b=this._router.patternLexer.interpolate(this._pattern,a);if(!this._validateParams(b))throw new Error("Generated string doesn't validate against `Route.rules`.");return b},dispose:function(){this._router.removeRoute(this)},_destroy:function(){this.matched.dispose(),this.switched.dispose(),this.matched=this.switched=this._pattern=this._matchRegexp=null},toString:function(){return'[Route pattern:"'+this._pattern+'", numListeners:'+this.matched.getNumListeners()+"]"}},k.prototype.patternLexer=function(){function a(){var a,b;for(a in n)n.hasOwnProperty(a)&&(b=n[a],b.id="__CR_"+a+"__",b.save="save"in b?b.save.replace("{{id}}",b.id):b.id,b.rRestore=new RegExp(b.id,"g"))}function b(a,b){var c,d=[];for(a.lastIndex=0;c=a.exec(b);)d.push(c[1]);return d}function c(a){return b(m,a)}function d(a){return b(n.OP.rgx,a)}function e(a,b){return a=a||"",a&&(r===o?a=a.replace(k,""):r===q&&(a=a.replace(l,"")),a=f(a,"rgx","save"),a=a.replace(j,"\\$&"),a=f(a,"rRestore","res"),r===o&&(a="\\/?"+a)),r!==p&&(a+="\\/?"),new RegExp("^"+a+"$",b?"i":"")}function f(a,b,c){var d,e;for(e in n)n.hasOwnProperty(e)&&(d=n[e],a=a.replace(d[b],d[c]));return a}function g(a,b,c){var d=b.exec(a);return d&&(d.shift(),c&&(d=i(d))),d}function h(a,b){if("string"!=typeof a)throw new Error("Route pattern should be a string.");var c=function(a,c){var d;if(c="?"===c.substr(0,1)?c.substr(1):c,null!=b[c]){if("object"==typeof b[c]){var e=[];for(var f in b[c])e.push(encodeURI(f+"="+b[c][f]));d="?"+e.join("&")}else d=String(b[c]);if(-1===a.indexOf("*")&&-1!==d.indexOf("/"))throw new Error('Invalid value "'+d+'" for segment "'+a+'".')}else{if(-1!==a.indexOf("{"))throw new Error("The segment "+a+" is required.");d=""}return d};return n.OS.trail||(n.OS.trail=new RegExp("(?:"+n.OS.id+")+$")),a.replace(n.OS.rgx,n.OS.save).replace(m,c).replace(n.OS.trail,"").replace(n.OS.rRestore,"/")}var j=/[\\.+*?\^$\[\](){}\/'#]/g,k=/^\/|\/$/g,l=/\/$/g,m=/(?:\{|:)([^}:]+)(?:\}|:)/g,n={OS:{rgx:/([:}]|\w(?=\/))\/?(:|(?:\{\?))/g,save:"$1{{id}}$2",res:"\\/?"},RS:{rgx:/([:}])\/?(\{)/g,save:"$1{{id}}$2",res:"\\/"},RQ:{rgx:/\{\?([^}]+)\}/g,res:"\\?([^#]+)"},OQ:{rgx:/:\?([^:]+):/g,res:"(?:\\?([^#]*))?"},OR:{rgx:/:([^:]+)\*:/g,res:"(.*)?"},RR:{rgx:/\{([^}]+)\*\}/g,res:"(.+)"},RP:{rgx:/\{([^}]+)\}/g,res:"([^\\/?]+)"},OP:{rgx:/:([^:]+):/g,res:"([^\\/?]+)?/?"}},o=1,p=2,q=3,r=o;return a(),{strict:function(){r=p},loose:function(){r=o},legacy:function(){r=q},getParamIds:c,getOptionalParamsIds:d,getParamValues:g,compilePattern:e,interpolate:h}}(),m};"function"==typeof define&&define.amd?define(["signals"],a):"undefined"!=typeof module&&module.exports?module.exports=a(require("signals")):window.crossroads=a(window.signals)}(),/*!
+function(){var a=function(a){function b(a,b){if(a.indexOf)return a.indexOf(b);for(
+//Array.indexOf doesn't work on IE 6-7
+var c=a.length;c--;)if(a[c]===b)return c;return-1}function c(a,c){var d=b(a,c);-1!==d&&a.splice(d,1)}function d(a,b){return"[object "+b+"]"===Object.prototype.toString.call(a)}function e(a){return d(a,"RegExp")}function f(a){return d(a,"Array")}function g(a){return"function"==typeof a}
+//borrowed from AMD-utils
+function h(a){var b;return b=null===a||"null"===a?null:"true"===a?!0:"false"===a?!1:a===o||"undefined"===a?o:""===a||isNaN(a)?a:parseFloat(a)}function i(a){for(var b=a.length,c=[];b--;)c[b]=h(a[b]);return c}
+//borrowed from AMD-Utils
+function j(a,b){for(var c,d,e=(a||"").replace("?","").split("&"),f=e.length,g={};f--;)c=e[f].split("="),d=b?h(c[1]):c[1],g[c[0]]="string"==typeof d?decodeURIComponent(d):d;return g}
+// Crossroads --------
+//====================
+/**
+     * @constructor
+     */
+function k(){this.bypassed=new a.Signal,this.routed=new a.Signal,this._routes=[],this._prevRoutes=[],this._piped=[],this.resetState()}
+// Route --------------
+//=====================
+/**
+     * @constructor
+     */
+function l(b,c,d,f){var g=e(b),h=f.patternLexer;this._router=f,this._pattern=b,this._paramsIds=g?null:h.getParamIds(b),this._optionalParamsIds=g?null:h.getOptionalParamsIds(b),this._matchRegexp=g?b:h.compilePattern(b,f.ignoreCase),this.matched=new a.Signal,this.switched=new a.Signal,c&&this.matched.add(c),this._priority=d||0}var m,n,o;
+// Helpers -----------
+//====================
+// IE 7-8 capture optional groups as empty strings while other browsers
+// capture as `undefined`
+//"static" instance
+// Pattern Lexer ------
+//=====================
+return n=""===/t(.+)?/.exec("t")[1],k.prototype={greedy:!1,greedyEnabled:!0,ignoreCase:!0,ignoreState:!1,shouldTypecast:!1,normalizeFn:null,resetState:function(){this._prevRoutes.length=0,this._prevMatchedRequest=null,this._prevBypassedRequest=null},create:function(){return new k},addRoute:function(a,b,c){var d=new l(a,b,c,this);return this._sortedInsert(d),d},removeRoute:function(a){c(this._routes,a),a._destroy()},removeAllRoutes:function(){for(var a=this.getNumRoutes();a--;)this._routes[a]._destroy();this._routes.length=0},parse:function(a,b){if(a=a||"",b=b||[],this.ignoreState||a!==this._prevMatchedRequest&&a!==this._prevBypassedRequest){var c,d=this._getMatchedRoutes(a),e=0,f=d.length;if(f)for(this._prevMatchedRequest=a,this._notifyPrevRoutes(d,a),this._prevRoutes=d;f>e;)c=d[e],c.route.matched.dispatch.apply(c.route.matched,b.concat(c.params)),c.isFirst=!e,this.routed.dispatch.apply(this.routed,b.concat([a,c])),e+=1;else this._prevBypassedRequest=a,this.bypassed.dispatch.apply(this.bypassed,b.concat([a]));this._pipeParse(a,b)}},_notifyPrevRoutes:function(a,b){for(var c,d=0;c=this._prevRoutes[d++];)c.route.switched&&this._didSwitch(c.route,a)&&c.route.switched.dispatch(b)},_didSwitch:function(a,b){for(var c,d=0;c=b[d++];)if(c.route===a)return!1;return!0},_pipeParse:function(a,b){for(var c,d=0;c=this._piped[d++];)c.parse(a,b)},getNumRoutes:function(){return this._routes.length},_sortedInsert:function(a){var b=this._routes,c=b.length;do--c;while(b[c]&&a._priority<=b[c]._priority);b.splice(c+1,0,a)},_getMatchedRoutes:function(a){for(var b,c=[],d=this._routes,e=d.length;(b=d[--e])&&((!c.length||this.greedy||b.greedy)&&b.match(a)&&c.push({route:b,params:b._getParamsArray(a)}),this.greedyEnabled||!c.length););return c},pipe:function(a){this._piped.push(a)},unpipe:function(a){c(this._piped,a)},toString:function(){return"[crossroads numRoutes:"+this.getNumRoutes()+"]"}},m=new k,m.VERSION="0.12.0",m.NORM_AS_ARRAY=function(a,b){return[b.vals_]},m.NORM_AS_OBJECT=function(a,b){return[b]},l.prototype={greedy:!1,rules:void 0,match:function(a){return a=a||"",this._matchRegexp.test(a)&&this._validateParams(a)},_validateParams:function(a){var b,c=this.rules,d=this._getParamsObject(a);for(b in c)if("normalize_"!==b&&c.hasOwnProperty(b)&&!this._isValidParam(a,b,d))return!1;return!0},_isValidParam:function(a,c,d){var h=this.rules[c],i=d[c],j=!1,k=0===c.indexOf("?");return null==i&&this._optionalParamsIds&&-1!==b(this._optionalParamsIds,c)?j=!0:e(h)?(k&&(i=d[c+"_"]),j=h.test(i)):f(h)?(k&&(i=d[c+"_"]),j=this._isValidArrayRule(h,i)):g(h)&&(j=h(i,a,d)),j},_isValidArrayRule:function(a,c){if(!this._router.ignoreCase)return-1!==b(a,c);"string"==typeof c&&(c=c.toLowerCase());for(var d,e,f=a.length;f--;)if(d=a[f],e="string"==typeof d?d.toLowerCase():d,e===c)return!0;return!1},_getParamsObject:function(a){for(var c,d,e=this._router.shouldTypecast,f=this._router.patternLexer.getParamValues(a,this._matchRegexp,e),g={},i=f.length;i--;)d=f[i],this._paramsIds&&(c=this._paramsIds[i],0===c.indexOf("?")&&d&&(g[c+"_"]=d,d=j(d,e),f[i]=d),n&&""===d&&-1!==b(this._optionalParamsIds,c)&&(d=void 0,f[i]=d),g[c]=d),g[i]=d;return g.request_=e?h(a):a,g.vals_=f,g},_getParamsArray:function(a){var b,c=this.rules?this.rules.normalize_:null;return c=c||this._router.normalizeFn,b=c&&g(c)?c(a,this._getParamsObject(a)):this._getParamsObject(a).vals_},interpolate:function(a){var b=this._router.patternLexer.interpolate(this._pattern,a);if(!this._validateParams(b))throw new Error("Generated string doesn't validate against `Route.rules`.");return b},dispose:function(){this._router.removeRoute(this)},_destroy:function(){this.matched.dispose(),this.switched.dispose(),this.matched=this.switched=this._pattern=this._matchRegexp=null},toString:function(){return'[Route pattern:"'+this._pattern+'", numListeners:'+this.matched.getNumListeners()+"]"}},k.prototype.patternLexer=function(){function a(){var a,b;for(a in n)n.hasOwnProperty(a)&&(b=n[a],b.id="__CR_"+a+"__",b.save="save"in b?b.save.replace("{{id}}",b.id):b.id,b.rRestore=new RegExp(b.id,"g"))}function b(a,b){var c,d=[];for(a.lastIndex=0;c=a.exec(b);)d.push(c[1]);return d}function c(a){return b(m,a)}function d(a){return b(n.OP.rgx,a)}function e(a,b){return a=a||"",a&&(r===o?a=a.replace(k,""):r===q&&(a=a.replace(l,"")),a=f(a,"rgx","save"),a=a.replace(j,"\\$&"),a=f(a,"rRestore","res"),r===o&&(a="\\/?"+a)),r!==p&&(a+="\\/?"),new RegExp("^"+a+"$",b?"i":"")}function f(a,b,c){var d,e;for(e in n)n.hasOwnProperty(e)&&(d=n[e],a=a.replace(d[b],d[c]));return a}function g(a,b,c){var d=b.exec(a);return d&&(d.shift(),c&&(d=i(d))),d}function h(a,b){if("string"!=typeof a)throw new Error("Route pattern should be a string.");var c=function(a,c){var d;if(c="?"===c.substr(0,1)?c.substr(1):c,null!=b[c]){if("object"==typeof b[c]){var e=[];for(var f in b[c])e.push(encodeURI(f+"="+b[c][f]));d="?"+e.join("&")}else d=String(b[c]);if(-1===a.indexOf("*")&&-1!==d.indexOf("/"))throw new Error('Invalid value "'+d+'" for segment "'+a+'".')}else{if(-1!==a.indexOf("{"))throw new Error("The segment "+a+" is required.");d=""}return d};return n.OS.trail||(n.OS.trail=new RegExp("(?:"+n.OS.id+")+$")),a.replace(n.OS.rgx,n.OS.save).replace(m,c).replace(n.OS.trail,"").replace(n.OS.rRestore,"/")}var j=/[\\.+*?\^$\[\](){}\/'#]/g,k=/^\/|\/$/g,l=/\/$/g,m=/(?:\{|:)([^}:]+)(?:\}|:)/g,n={OS:{rgx:/([:}]|\w(?=\/))\/?(:|(?:\{\?))/g,save:"$1{{id}}$2",res:"\\/?"},RS:{rgx:/([:}])\/?(\{)/g,save:"$1{{id}}$2",res:"\\/"},RQ:{rgx:/\{\?([^}]+)\}/g,res:"\\?([^#]+)"},OQ:{rgx:/:\?([^:]+):/g,res:"(?:\\?([^#]*))?"},OR:{rgx:/:([^:]+)\*:/g,res:"(.*)?"},RR:{rgx:/\{([^}]+)\*\}/g,res:"(.+)"},RP:{rgx:/\{([^}]+)\}/g,res:"([^\\/?]+)"},OP:{rgx:/:([^:]+):/g,res:"([^\\/?]+)?/?"}},o=1,p=2,q=3,r=o;return a(),{strict:function(){r=p},loose:function(){r=o},legacy:function(){r=q},getParamIds:c,getOptionalParamsIds:d,getParamValues:g,compilePattern:e,interpolate:h}}(),m};"function"==typeof define&&define.amd?define(["signals"],a):"undefined"!=typeof module&&module.exports?module.exports=a(require("signals")):window.crossroads=a(window.signals)}(),/*!
  * sifter.js
  * Copyright (c) 2013 Brian Reavis & contributors
  *
@@ -50,7 +1876,106 @@ function(){var a=function(a){function b(a,b){if(a.indexOf)return a.indexOf(b);fo
  *
  * @author Brian Reavis <brian@thirdroute.com>
  */
-function(a,b){"function"==typeof define&&define.amd?define("sifter",b):"object"==typeof exports?module.exports=b():a.Sifter=b()}(this,function(){var a=function(a,b){this.items=a,this.settings=b||{diacritics:!0}};a.prototype.tokenize=function(a){if(a=d(String(a||"").toLowerCase()),!a||!a.length)return[];var b,c,f,h,i=[],j=a.split(/ +/);for(b=0,c=j.length;c>b;b++){if(f=e(j[b]),this.settings.diacritics)for(h in g)g.hasOwnProperty(h)&&(f=f.replace(new RegExp(h,"g"),g[h]));i.push({string:j[b],regex:new RegExp(f,"i")})}return i},a.prototype.iterator=function(a,b){var c;c=f(a)?Array.prototype.forEach||function(a){for(var b=0,c=this.length;c>b;b++)a(this[b],b,this)}:function(a){for(var b in this)this.hasOwnProperty(b)&&a(this[b],b,this)},c.apply(a,[b])},a.prototype.getScoreFunction=function(a,b){var c,d,e,f;c=this,a=c.prepareSearch(a,b),e=a.tokens,d=a.options.fields,f=e.length;var g=function(a,b){var c,d;return a?(a=String(a||""),d=a.search(b.regex),-1===d?0:(c=b.string.length/a.length,0===d&&(c+=.5),c)):0},h=function(){var a=d.length;return a?1===a?function(a,b){return g(b[d[0]],a)}:function(b,c){for(var e=0,f=0;a>e;e++)f+=g(c[d[e]],b);return f/a}:function(){return 0}}();return f?1===f?function(a){return h(e[0],a)}:"and"===a.options.conjunction?function(a){for(var b,c=0,d=0;f>c;c++){if(b=h(e[c],a),0>=b)return 0;d+=b}return d/f}:function(a){for(var b=0,c=0;f>b;b++)c+=h(e[b],a);return c/f}:function(){return 0}},a.prototype.getSortFunction=function(a,c){var d,e,f,g,h,i,j,k,l,m,n;if(f=this,a=f.prepareSearch(a,c),n=!a.query&&c.sort_empty||c.sort,l=function(a,b){return"$score"===a?b.score:f.items[b.id][a]},h=[],n)for(d=0,e=n.length;e>d;d++)(a.query||"$score"!==n[d].field)&&h.push(n[d]);if(a.query){for(m=!0,d=0,e=h.length;e>d;d++)if("$score"===h[d].field){m=!1;break}m&&h.unshift({field:"$score",direction:"desc"})}else for(d=0,e=h.length;e>d;d++)if("$score"===h[d].field){h.splice(d,1);break}for(k=[],d=0,e=h.length;e>d;d++)k.push("desc"===h[d].direction?-1:1);return i=h.length,i?1===i?(g=h[0].field,j=k[0],function(a,c){return j*b(l(g,a),l(g,c))}):function(a,c){var d,e,f;for(d=0;i>d;d++)if(f=h[d].field,e=k[d]*b(l(f,a),l(f,c)))return e;return 0}:null},a.prototype.prepareSearch=function(a,b){if("object"==typeof a)return a;b=c({},b);var d=b.fields,e=b.sort,g=b.sort_empty;return d&&!f(d)&&(b.fields=[d]),e&&!f(e)&&(b.sort=[e]),g&&!f(g)&&(b.sort_empty=[g]),{options:b,query:String(a||"").toLowerCase(),tokens:this.tokenize(a),total:0,items:[]}},a.prototype.search=function(a,b){var c,d,e,f,g=this;return d=this.prepareSearch(a,b),b=d.options,a=d.query,f=b.score||g.getScoreFunction(d),a.length?g.iterator(g.items,function(a,e){c=f(a),(b.filter===!1||c>0)&&d.items.push({score:c,id:e})}):g.iterator(g.items,function(a,b){d.items.push({score:1,id:b})}),e=g.getSortFunction(d,b),e&&d.items.sort(e),d.total=d.items.length,"number"==typeof b.limit&&(d.items=d.items.slice(0,b.limit)),d};var b=function(a,b){return"number"==typeof a&&"number"==typeof b?a>b?1:b>a?-1:0:(a=String(a||"").toLowerCase(),b=String(b||"").toLowerCase(),a>b?1:b>a?-1:0)},c=function(a,b){var c,d,e,f;for(c=1,d=arguments.length;d>c;c++)if(f=arguments[c])for(e in f)f.hasOwnProperty(e)&&(a[e]=f[e]);return a},d=function(a){return(a+"").replace(/^\s+|\s+$|/g,"")},e=function(a){return(a+"").replace(/([.?*+^$[\]\\(){}|-])/g,"\\$1")},f=Array.isArray||$&&$.isArray||function(a){return"[object Array]"===Object.prototype.toString.call(a)},g={a:"[aÀÁÂÃÄÅàáâãäå]",c:"[cÇçćĆčČ]",d:"[dđĐďĎ]",e:"[eÈÉÊËèéêëěĚ]",i:"[iÌÍÎÏìíîï]",n:"[nÑñňŇ]",o:"[oÒÓÔÕÕÖØòóôõöø]",r:"[rřŘ]",s:"[sŠš]",t:"[tťŤ]",u:"[uÙÚÛÜùúûüůŮ]",y:"[yŸÿýÝ]",z:"[zŽž]"};return a}),/*!
+function(a,b){"function"==typeof define&&define.amd?define("sifter",b):"object"==typeof exports?module.exports=b():a.Sifter=b()}(this,function(){/**
+	 * Textually searches arrays and hashes of objects
+	 * by property (or multiple properties). Designed
+	 * specifically for autocomplete.
+	 *
+	 * @constructor
+	 * @param {array|object} items
+	 * @param {object} items
+	 */
+var a=function(a,b){this.items=a,this.settings=b||{diacritics:!0}};/**
+	 * Splits a search string into an array of individual
+	 * regexps to be used to match results.
+	 *
+	 * @param {string} query
+	 * @returns {array}
+	 */
+a.prototype.tokenize=function(a){if(a=d(String(a||"").toLowerCase()),!a||!a.length)return[];var b,c,f,h,i=[],j=a.split(/ +/);for(b=0,c=j.length;c>b;b++){if(f=e(j[b]),this.settings.diacritics)for(h in g)g.hasOwnProperty(h)&&(f=f.replace(new RegExp(h,"g"),g[h]));i.push({string:j[b],regex:new RegExp(f,"i")})}return i},/**
+	 * Iterates over arrays and hashes.
+	 *
+	 * ```
+	 * this.iterator(this.items, function(item, id) {
+	 *    // invoked for each item
+	 * });
+	 * ```
+	 *
+	 * @param {array|object} object
+	 */
+a.prototype.iterator=function(a,b){var c;c=f(a)?Array.prototype.forEach||function(a){for(var b=0,c=this.length;c>b;b++)a(this[b],b,this)}:function(a){for(var b in this)this.hasOwnProperty(b)&&a(this[b],b,this)},c.apply(a,[b])},/**
+	 * Returns a function to be used to score individual results.
+	 *
+	 * Good matches will have a higher score than poor matches.
+	 * If an item is not a match, 0 will be returned by the function.
+	 *
+	 * @param {object|string} search
+	 * @param {object} options (optional)
+	 * @returns {function}
+	 */
+a.prototype.getScoreFunction=function(a,b){var c,d,e,f;c=this,a=c.prepareSearch(a,b),e=a.tokens,d=a.options.fields,f=e.length;/**
+		 * Calculates how close of a match the
+		 * given value is against a search token.
+		 *
+		 * @param {mixed} value
+		 * @param {object} token
+		 * @return {number}
+		 */
+var g=function(a,b){var c,d;return a?(a=String(a||""),d=a.search(b.regex),-1===d?0:(c=b.string.length/a.length,0===d&&(c+=.5),c)):0},h=function(){var a=d.length;return a?1===a?function(a,b){return g(b[d[0]],a)}:function(b,c){for(var e=0,f=0;a>e;e++)f+=g(c[d[e]],b);return f/a}:function(){return 0}}();return f?1===f?function(a){return h(e[0],a)}:"and"===a.options.conjunction?function(a){for(var b,c=0,d=0;f>c;c++){if(b=h(e[c],a),0>=b)return 0;d+=b}return d/f}:function(a){for(var b=0,c=0;f>b;b++)c+=h(e[b],a);return c/f}:function(){return 0}},/**
+	 * Returns a function that can be used to compare two
+	 * results, for sorting purposes. If no sorting should
+	 * be performed, `null` will be returned.
+	 *
+	 * @param {string|object} search
+	 * @param {object} options
+	 * @return function(a,b)
+	 */
+a.prototype.getSortFunction=function(a,c){var d,e,f,g,h,i,j,k,l,m,n;if(f=this,a=f.prepareSearch(a,c),n=!a.query&&c.sort_empty||c.sort,l=function(a,b){return"$score"===a?b.score:f.items[b.id][a]},h=[],n)for(d=0,e=n.length;e>d;d++)(a.query||"$score"!==n[d].field)&&h.push(n[d]);
+// the "$score" field is implied to be the primary
+// sort field, unless it's manually specified
+if(a.query){for(m=!0,d=0,e=h.length;e>d;d++)if("$score"===h[d].field){m=!1;break}m&&h.unshift({field:"$score",direction:"desc"})}else for(d=0,e=h.length;e>d;d++)if("$score"===h[d].field){h.splice(d,1);break}for(k=[],d=0,e=h.length;e>d;d++)k.push("desc"===h[d].direction?-1:1);return i=h.length,i?1===i?(g=h[0].field,j=k[0],function(a,c){return j*b(l(g,a),l(g,c))}):function(a,c){var d,e,f;for(d=0;i>d;d++)if(f=h[d].field,e=k[d]*b(l(f,a),l(f,c)))return e;return 0}:null},/**
+	 * Parses a search query and returns an object
+	 * with tokens and fields ready to be populated
+	 * with results.
+	 *
+	 * @param {string} query
+	 * @param {object} options
+	 * @returns {object}
+	 */
+a.prototype.prepareSearch=function(a,b){if("object"==typeof a)return a;b=c({},b);var d=b.fields,e=b.sort,g=b.sort_empty;return d&&!f(d)&&(b.fields=[d]),e&&!f(e)&&(b.sort=[e]),g&&!f(g)&&(b.sort_empty=[g]),{options:b,query:String(a||"").toLowerCase(),tokens:this.tokenize(a),total:0,items:[]}},/**
+	 * Searches through all items and returns a sorted array of matches.
+	 *
+	 * The `options` parameter can contain:
+	 *
+	 *   - fields {string|array}
+	 *   - sort {array}
+	 *   - score {function}
+	 *   - filter {bool}
+	 *   - limit {integer}
+	 *
+	 * Returns an object containing:
+	 *
+	 *   - options {object}
+	 *   - query {string}
+	 *   - tokens {array}
+	 *   - total {int}
+	 *   - items {array}
+	 *
+	 * @param {string} query
+	 * @param {object} options
+	 * @returns {object}
+	 */
+a.prototype.search=function(a,b){var c,d,e,f,g=this;
+// generate result scoring function
+// perform search and sort
+// apply limits
+return d=this.prepareSearch(a,b),b=d.options,a=d.query,f=b.score||g.getScoreFunction(d),a.length?g.iterator(g.items,function(a,e){c=f(a),(b.filter===!1||c>0)&&d.items.push({score:c,id:e})}):g.iterator(g.items,function(a,b){d.items.push({score:1,id:b})}),e=g.getSortFunction(d,b),e&&d.items.sort(e),d.total=d.items.length,"number"==typeof b.limit&&(d.items=d.items.slice(0,b.limit)),d};
+// utilities
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+var b=function(a,b){return"number"==typeof a&&"number"==typeof b?a>b?1:b>a?-1:0:(a=String(a||"").toLowerCase(),b=String(b||"").toLowerCase(),a>b?1:b>a?-1:0)},c=function(a,b){var c,d,e,f;for(c=1,d=arguments.length;d>c;c++)if(f=arguments[c])for(e in f)f.hasOwnProperty(e)&&(a[e]=f[e]);return a},d=function(a){return(a+"").replace(/^\s+|\s+$|/g,"")},e=function(a){return(a+"").replace(/([.?*+^$[\]\\(){}|-])/g,"\\$1")},f=Array.isArray||$&&$.isArray||function(a){return"[object Array]"===Object.prototype.toString.call(a)},g={a:"[aÀÁÂÃÄÅàáâãäå]",c:"[cÇçćĆčČ]",d:"[dđĐďĎ]",e:"[eÈÉÊËèéêëěĚ]",i:"[iÌÍÎÏìíîï]",n:"[nÑñňŇ]",o:"[oÒÓÔÕÕÖØòóôõöø]",r:"[rřŘ]",s:"[sŠš]",t:"[tťŤ]",u:"[uÙÚÛÜùúûüůŮ]",y:"[yŸÿýÝ]",z:"[zŽž]"};
+// export
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+return a}),/*!
  * microplugin.js
  * Copyright (c) 2013 Brian Reavis & contributors
  *
@@ -65,7 +1990,33 @@ function(a,b){"function"==typeof define&&define.amd?define("sifter",b):"object"=
  *
  * @author Brian Reavis <brian@thirdroute.com>
  */
-function(a,b){"function"==typeof define&&define.amd?define("microplugin",b):"object"==typeof exports?module.exports=b():a.MicroPlugin=b()}(this,function(){var a={};a.mixin=function(a){a.plugins={},a.prototype.initializePlugins=function(a){var c,d,e,f=this,g=[];if(f.plugins={names:[],settings:{},requested:{},loaded:{}},b.isArray(a))for(c=0,d=a.length;d>c;c++)"string"==typeof a[c]?g.push(a[c]):(f.plugins.settings[a[c].name]=a[c].options,g.push(a[c].name));else if(a)for(e in a)a.hasOwnProperty(e)&&(f.plugins.settings[e]=a[e],g.push(e));for(;g.length;)f.require(g.shift())},a.prototype.loadPlugin=function(b){var c=this,d=c.plugins,e=a.plugins[b];if(!a.plugins.hasOwnProperty(b))throw new Error('Unable to find "'+b+'" plugin');d.requested[b]=!0,d.loaded[b]=e.fn.apply(c,[c.plugins.settings[b]||{}]),d.names.push(b)},a.prototype.require=function(a){var b=this,c=b.plugins;if(!b.plugins.loaded.hasOwnProperty(a)){if(c.requested[a])throw new Error('Plugin has circular dependency ("'+a+'")');b.loadPlugin(a)}return c.loaded[a]},a.define=function(b,c){a.plugins[b]={name:b,fn:c}}};var b={isArray:Array.isArray||function(a){return"[object Array]"===Object.prototype.toString.call(a)}};return a}),/*!
+function(a,b){"function"==typeof define&&define.amd?define("microplugin",b):"object"==typeof exports?module.exports=b():a.MicroPlugin=b()}(this,function(){var a={};a.mixin=function(a){a.plugins={},/**
+		 * Initializes the listed plugins (with options).
+		 * Acceptable formats:
+		 *
+		 * List (without options):
+		 *   ['a', 'b', 'c']
+		 *
+		 * List (with options):
+		 *   [{'name': 'a', options: {}}, {'name': 'b', options: {}}]
+		 *
+		 * Hash (with options):
+		 *   {'a': { ... }, 'b': { ... }, 'c': { ... }}
+		 *
+		 * @param {mixed} plugins
+		 */
+a.prototype.initializePlugins=function(a){var c,d,e,f=this,g=[];if(f.plugins={names:[],settings:{},requested:{},loaded:{}},b.isArray(a))for(c=0,d=a.length;d>c;c++)"string"==typeof a[c]?g.push(a[c]):(f.plugins.settings[a[c].name]=a[c].options,g.push(a[c].name));else if(a)for(e in a)a.hasOwnProperty(e)&&(f.plugins.settings[e]=a[e],g.push(e));for(;g.length;)f.require(g.shift())},a.prototype.loadPlugin=function(b){var c=this,d=c.plugins,e=a.plugins[b];if(!a.plugins.hasOwnProperty(b))throw new Error('Unable to find "'+b+'" plugin');d.requested[b]=!0,d.loaded[b]=e.fn.apply(c,[c.plugins.settings[b]||{}]),d.names.push(b)},/**
+		 * Initializes a plugin.
+		 *
+		 * @param {string} name
+		 */
+a.prototype.require=function(a){var b=this,c=b.plugins;if(!b.plugins.loaded.hasOwnProperty(a)){if(c.requested[a])throw new Error('Plugin has circular dependency ("'+a+'")');b.loadPlugin(a)}return c.loaded[a]},/**
+		 * Registers a plugin.
+		 *
+		 * @param {string} name
+		 * @param {function} fn
+		 */
+a.define=function(b,c){a.plugins[b]={name:b,fn:c}}};var b={isArray:Array.isArray||function(a){return"[object Array]"===Object.prototype.toString.call(a)}};return a}),/*!
  * selectize.js (v0.9.0)
  * Copyright (c) 2013 Brian Reavis & contributors
  *
@@ -80,21 +2031,1441 @@ function(a,b){"function"==typeof define&&define.amd?define("microplugin",b):"obj
  *
  * @author Brian Reavis <brian@thirdroute.com>
  */
-function(a,b){"function"==typeof define&&define.amd?define("selectize",["jquery","sifter","microplugin"],b):"object"==typeof exports?module.exports=b(require("jquery"),require("sifter"),require("microplugin")):a.Selectize=b(a.jQuery,a.Sifter,a.MicroPlugin)}(this,function(a,b,c){"use strict";var d=function(a,b){if("string"!=typeof b||b.length){var c="string"==typeof b?new RegExp(b,"i"):b,d=function(a){var b=0;if(3===a.nodeType){var e=a.data.search(c);if(e>=0&&a.data.length>0){var f=a.data.match(c),g=document.createElement("span");g.className="highlight";var h=a.splitText(e),i=(h.splitText(f[0].length),h.cloneNode(!0));g.appendChild(i),h.parentNode.replaceChild(g,h),b=1}}else if(1===a.nodeType&&a.childNodes&&!/(script|style)/i.test(a.tagName))for(var j=0;j<a.childNodes.length;++j)j+=d(a.childNodes[j]);return b};return a.each(function(){d(this)})}},e=function(){};e.prototype={on:function(a,b){this._events=this._events||{},this._events[a]=this._events[a]||[],this._events[a].push(b)},off:function(a,b){var c=arguments.length;return 0===c?delete this._events:1===c?delete this._events[a]:(this._events=this._events||{},void(a in this._events!=!1&&this._events[a].splice(this._events[a].indexOf(b),1)))},trigger:function(a){if(this._events=this._events||{},a in this._events!=!1)for(var b=0;b<this._events[a].length;b++)this._events[a][b].apply(this,Array.prototype.slice.call(arguments,1))}},e.mixin=function(a){for(var b=["on","off","trigger"],c=0;c<b.length;c++)a.prototype[b[c]]=e.prototype[b[c]]};var f=/Mac/.test(navigator.userAgent),g=65,h=13,i=27,j=37,k=38,l=80,m=39,n=40,o=78,p=8,q=46,r=16,s=f?91:17,t=f?18:17,u=9,v=1,w=2,x=function(a){return"undefined"!=typeof a},y=function(a){return"undefined"==typeof a||null===a?"":"boolean"==typeof a?a?"1":"0":a+""},z=function(a){return(a+"").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;")},A=function(a){return(a+"").replace(/\$/g,"$$$$")},B={};B.before=function(a,b,c){var d=a[b];a[b]=function(){return c.apply(a,arguments),d.apply(a,arguments)}},B.after=function(a,b,c){var d=a[b];a[b]=function(){var b=d.apply(a,arguments);return c.apply(a,arguments),b}};var C=function(b,c){if(!a.isArray(c))return c;var d,e,f={};for(d=0,e=c.length;e>d;d++)c[d].hasOwnProperty(b)&&(f[c[d][b]]=c[d]);return f},D=function(a){var b=!1;return function(){b||(b=!0,a.apply(this,arguments))}},E=function(a,b){var c;return function(){var d=this,e=arguments;window.clearTimeout(c),c=window.setTimeout(function(){a.apply(d,e)},b)}},F=function(a,b,c){var d,e=a.trigger,f={};a.trigger=function(){var c=arguments[0];return-1===b.indexOf(c)?e.apply(a,arguments):void(f[c]=arguments)},c.apply(a,[]),a.trigger=e;for(d in f)f.hasOwnProperty(d)&&e.apply(a,f[d])},G=function(a,b,c,d){a.on(b,c,function(b){for(var c=b.target;c&&c.parentNode!==a[0];)c=c.parentNode;return b.currentTarget=c,d.apply(this,[b])})},H=function(a){var b={};if("selectionStart"in a)b.start=a.selectionStart,b.length=a.selectionEnd-b.start;else if(document.selection){a.focus();var c=document.selection.createRange(),d=document.selection.createRange().text.length;c.moveStart("character",-a.value.length),b.start=c.text.length-d,b.length=d}return b},I=function(a,b,c){var d,e,f={};if(c)for(d=0,e=c.length;e>d;d++)f[c[d]]=a.css(c[d]);else f=a.css();b.css(f)},J=function(b,c){if(!b)return 0;var d=a("<test>").css({position:"absolute",top:-99999,left:-99999,width:"auto",padding:0,whiteSpace:"pre"}).text(b).appendTo("body");I(c,d,["letterSpacing","fontSize","fontFamily","fontWeight","textTransform"]);var e=d.width();return d.remove(),e},K=function(a){var b=null,c=function(c){var d,e,f,g,h,i,j,k;c=c||window.event||{},c.metaKey||c.altKey||a.data("grow")!==!1&&(d=a.val(),c.type&&"keydown"===c.type.toLowerCase()&&(e=c.keyCode,f=e>=97&&122>=e||e>=65&&90>=e||e>=48&&57>=e||32===e,e===q||e===p?(k=H(a[0]),k.length?d=d.substring(0,k.start)+d.substring(k.start+k.length):e===p&&k.start?d=d.substring(0,k.start-1)+d.substring(k.start+1):e===q&&"undefined"!=typeof k.start&&(d=d.substring(0,k.start)+d.substring(k.start+1))):f&&(i=c.shiftKey,j=String.fromCharCode(c.keyCode),j=i?j.toUpperCase():j.toLowerCase(),d+=j)),g=a.attr("placeholder")||"",!d.length&&g.length&&(d=g),h=J(d,a)+4,h!==b&&(b=h,a.width(h),a.triggerHandler("resize")))};a.on("keydown keyup update blur",c),c()},L=function(c,d){var e,f,g=this;f=c[0],f.selectize=g,e=window.getComputedStyle?window.getComputedStyle(f,null).getPropertyValue("direction"):f.currentStyle&&f.currentStyle.direction,e=e||c.parents("[dir]:first").attr("dir")||"",a.extend(g,{settings:d,$input:c,tagType:"select"===f.tagName.toLowerCase()?v:w,rtl:/rtl/i.test(e),eventNS:".selectize"+ ++L.count,highlightedValue:null,isOpen:!1,isDisabled:!1,isRequired:c.is("[required]"),isInvalid:!1,isLocked:!1,isFocused:!1,isInputHidden:!1,isSetup:!1,isShiftDown:!1,isCmdDown:!1,isCtrlDown:!1,ignoreFocus:!1,ignoreHover:!1,hasOptions:!1,currentResults:null,lastValue:"",caretPos:0,loading:0,loadedSearches:{},$activeOption:null,$activeItems:[],optgroups:{},options:{},userOptions:{},items:[],renderCache:{},onSearchChange:E(g.onSearchChange,d.loadThrottle)}),g.sifter=new b(this.options,{diacritics:d.diacritics}),a.extend(g.options,C(d.valueField,d.options)),delete g.settings.options,a.extend(g.optgroups,C(d.optgroupValueField,d.optgroups)),delete g.settings.optgroups,g.settings.mode=g.settings.mode||(1===g.settings.maxItems?"single":"multi"),"boolean"!=typeof g.settings.hideSelected&&(g.settings.hideSelected="multi"===g.settings.mode),g.initializePlugins(g.settings.plugins),g.setupCallbacks(),g.setupTemplates(),g.setup()};return e.mixin(L),c.mixin(L),a.extend(L.prototype,{setup:function(){var b,c,d,e,g,h,i,j,k,l,m=this,n=m.settings,o=m.eventNS,p=a(window),q=a(document);i=m.settings.mode,j=m.$input.attr("tabindex")||"",k=m.$input.attr("class")||"",b=a("<div>").addClass(n.wrapperClass).addClass(k).addClass(i),c=a("<div>").addClass(n.inputClass).addClass("items").appendTo(b),d=a('<input type="text" autocomplete="off" />').appendTo(c).attr("tabindex",j),h=a(n.dropdownParent||b),e=a("<div>").addClass(n.dropdownClass).addClass(k).addClass(i).hide().appendTo(h),g=a("<div>").addClass(n.dropdownContentClass).appendTo(e),b.css({width:m.$input[0].style.width}),m.plugins.names.length&&(l="plugin-"+m.plugins.names.join(" plugin-"),b.addClass(l),e.addClass(l)),(null===n.maxItems||n.maxItems>1)&&m.tagType===v&&m.$input.attr("multiple","multiple"),m.settings.placeholder&&d.attr("placeholder",n.placeholder),m.$wrapper=b,m.$control=c,m.$control_input=d,m.$dropdown=e,m.$dropdown_content=g,e.on("mouseenter","[data-selectable]",function(){return m.onOptionHover.apply(m,arguments)}),e.on("mousedown","[data-selectable]",function(){return m.onOptionSelect.apply(m,arguments)}),G(c,"mousedown","*:not(input)",function(){return m.onItemSelect.apply(m,arguments)}),K(d),c.on({mousedown:function(){return m.onMouseDown.apply(m,arguments)},click:function(){return m.onClick.apply(m,arguments)}}),d.on({mousedown:function(a){a.stopPropagation()},keydown:function(){return m.onKeyDown.apply(m,arguments)},keyup:function(){return m.onKeyUp.apply(m,arguments)},keypress:function(){return m.onKeyPress.apply(m,arguments)},resize:function(){m.positionDropdown.apply(m,[])},blur:function(){return m.onBlur.apply(m,arguments)},focus:function(){return m.onFocus.apply(m,arguments)}}),q.on("keydown"+o,function(a){m.isCmdDown=a[f?"metaKey":"ctrlKey"],m.isCtrlDown=a[f?"altKey":"ctrlKey"],m.isShiftDown=a.shiftKey}),q.on("keyup"+o,function(a){a.keyCode===t&&(m.isCtrlDown=!1),a.keyCode===r&&(m.isShiftDown=!1),a.keyCode===s&&(m.isCmdDown=!1)}),q.on("mousedown"+o,function(a){if(m.isFocused){if(a.target===m.$dropdown[0]||a.target.parentNode===m.$dropdown[0])return!1;m.$control.has(a.target).length||a.target===m.$control[0]||m.blur()}}),p.on(["scroll"+o,"resize"+o].join(" "),function(){m.isOpen&&m.positionDropdown.apply(m,arguments)}),p.on("mousemove"+o,function(){m.ignoreHover=!1}),this.revertSettings={$children:m.$input.children().detach(),tabindex:m.$input.attr("tabindex")},m.$input.attr("tabindex",-1).hide().after(m.$wrapper),a.isArray(n.items)&&(m.setValue(n.items),delete n.items),m.$input[0].validity&&m.$input.on("invalid"+o,function(a){a.preventDefault(),m.isInvalid=!0,m.refreshState()}),m.updateOriginalInput(),m.refreshItems(),m.refreshState(),m.updatePlaceholder(),m.isSetup=!0,m.$input.is(":disabled")&&m.disable(),m.on("change",this.onChange),m.trigger("initialize"),n.preload===!0&&m.onSearchChange("")},setupTemplates:function(){var b=this,c=b.settings.labelField,d=b.settings.optgroupLabelField,e={optgroup:function(a){return'<div class="optgroup">'+a.html+"</div>"},optgroup_header:function(a,b){return'<div class="optgroup-header">'+b(a[d])+"</div>"},option:function(a,b){return'<div class="option">'+b(a[c])+"</div>"},item:function(a,b){return'<div class="item">'+b(a[c])+"</div>"},option_create:function(a,b){return'<div class="create">Add <strong>'+b(a.input)+"</strong>&hellip;</div>"}};b.settings.render=a.extend({},e,b.settings.render)},setupCallbacks:function(){var a,b,c={initialize:"onInitialize",change:"onChange",item_add:"onItemAdd",item_remove:"onItemRemove",clear:"onClear",option_add:"onOptionAdd",option_remove:"onOptionRemove",option_clear:"onOptionClear",dropdown_open:"onDropdownOpen",dropdown_close:"onDropdownClose",type:"onType"};for(a in c)c.hasOwnProperty(a)&&(b=this.settings[c[a]],b&&this.on(a,b))},onClick:function(a){var b=this;b.isFocused||(b.focus(),a.preventDefault())},onMouseDown:function(b){{var c=this,d=b.isDefaultPrevented();a(b.target)}if(c.isFocused){if(b.target!==c.$control_input[0])return"single"===c.settings.mode?c.isOpen?c.close():c.open():d||c.setActiveItem(null),!1}else d||window.setTimeout(function(){c.focus()},0)},onChange:function(){this.$input.trigger("change")},onKeyPress:function(a){if(this.isLocked)return a&&a.preventDefault();var b=String.fromCharCode(a.keyCode||a.which);return this.settings.create&&b===this.settings.delimiter?(this.createItem(),a.preventDefault(),!1):void 0},onKeyDown:function(a){var b=(a.target===this.$control_input[0],this);if(b.isLocked)return void(a.keyCode!==u&&a.preventDefault());switch(a.keyCode){case g:if(b.isCmdDown)return void b.selectAll();break;case i:return void b.close();case o:if(!a.ctrlKey)break;case n:if(!b.isOpen&&b.hasOptions)b.open();else if(b.$activeOption){b.ignoreHover=!0;var c=b.getAdjacentOption(b.$activeOption,1);c.length&&b.setActiveOption(c,!0,!0)}return void a.preventDefault();case l:if(!a.ctrlKey)break;case k:if(b.$activeOption){b.ignoreHover=!0;var d=b.getAdjacentOption(b.$activeOption,-1);d.length&&b.setActiveOption(d,!0,!0)}return void a.preventDefault();case h:return b.isOpen&&b.$activeOption&&b.onOptionSelect({currentTarget:b.$activeOption}),void a.preventDefault();case j:return void b.advanceSelection(-1,a);case m:return void b.advanceSelection(1,a);case u:return b.isOpen&&b.$activeOption&&b.onOptionSelect({currentTarget:b.$activeOption}),void(b.settings.create&&b.createItem()&&a.preventDefault());case p:case q:return void b.deleteSelection(a)}return b.isFull()||b.isInputHidden?void a.preventDefault():void 0},onKeyUp:function(a){var b=this;if(b.isLocked)return a&&a.preventDefault();var c=b.$control_input.val()||"";b.lastValue!==c&&(b.lastValue=c,b.onSearchChange(c),b.refreshOptions(),b.trigger("type",c))},onSearchChange:function(a){var b=this,c=b.settings.load;c&&(b.loadedSearches.hasOwnProperty(a)||(b.loadedSearches[a]=!0,b.load(function(d){c.apply(b,[a,d])})))},onFocus:function(a){var b=this;return b.isFocused=!0,b.isDisabled?(b.blur(),a&&a.preventDefault(),!1):void(b.ignoreFocus||("focus"===b.settings.preload&&b.onSearchChange(""),b.$activeItems.length||(b.showInput(),b.setActiveItem(null),b.refreshOptions(!!b.settings.openOnFocus)),b.refreshState()))},onBlur:function(a){var b=this;b.isFocused=!1,b.ignoreFocus||(b.settings.create&&b.settings.createOnBlur&&b.createItem(!1),b.close(),b.setTextboxValue(""),b.setActiveItem(null),b.setActiveOption(null),b.setCaret(b.items.length),b.refreshState())},onOptionHover:function(a){this.ignoreHover||this.setActiveOption(a.currentTarget,!1)},onOptionSelect:function(b){var c,d,e=this;b.preventDefault&&(b.preventDefault(),b.stopPropagation()),d=a(b.currentTarget),d.hasClass("create")?e.createItem():(c=d.attr("data-value"),c&&(e.lastQuery=null,e.setTextboxValue(""),e.addItem(c),!e.settings.hideSelected&&b.type&&/mouse/.test(b.type)&&e.setActiveOption(e.getOption(c))))},onItemSelect:function(a){var b=this;b.isLocked||"multi"===b.settings.mode&&(a.preventDefault(),b.setActiveItem(a.currentTarget,a))},load:function(a){var b=this,c=b.$wrapper.addClass("loading");b.loading++,a.apply(b,[function(a){b.loading=Math.max(b.loading-1,0),a&&a.length&&(b.addOption(a),b.refreshOptions(b.isFocused&&!b.isInputHidden)),b.loading||c.removeClass("loading"),b.trigger("load",a)}])},setTextboxValue:function(a){this.$control_input.val(a).triggerHandler("update"),this.lastValue=a},getValue:function(){return this.tagType===v&&this.$input.attr("multiple")?this.items:this.items.join(this.settings.delimiter)},setValue:function(a){F(this,["change"],function(){this.clear(),this.addItems(a)})},setActiveItem:function(b,c){var d,e,f,g,h,i,j,k,l=this;if("single"!==l.settings.mode){if(b=a(b),!b.length)return a(l.$activeItems).removeClass("active"),l.$activeItems=[],void(l.isFocused&&l.showInput());if(d=c&&c.type.toLowerCase(),"mousedown"===d&&l.isShiftDown&&l.$activeItems.length){for(k=l.$control.children(".active:last"),g=Array.prototype.indexOf.apply(l.$control[0].childNodes,[k[0]]),h=Array.prototype.indexOf.apply(l.$control[0].childNodes,[b[0]]),g>h&&(j=g,g=h,h=j),e=g;h>=e;e++)i=l.$control[0].childNodes[e],-1===l.$activeItems.indexOf(i)&&(a(i).addClass("active"),l.$activeItems.push(i));c.preventDefault()}else"mousedown"===d&&l.isCtrlDown||"keydown"===d&&this.isShiftDown?b.hasClass("active")?(f=l.$activeItems.indexOf(b[0]),l.$activeItems.splice(f,1),b.removeClass("active")):l.$activeItems.push(b.addClass("active")[0]):(a(l.$activeItems).removeClass("active"),l.$activeItems=[b.addClass("active")[0]]);l.hideInput(),this.isFocused||l.focus()}},setActiveOption:function(b,c,d){var e,f,g,h,i,j=this;j.$activeOption&&j.$activeOption.removeClass("active"),j.$activeOption=null,b=a(b),b.length&&(j.$activeOption=b.addClass("active"),(c||!x(c))&&(e=j.$dropdown_content.height(),f=j.$activeOption.outerHeight(!0),c=j.$dropdown_content.scrollTop()||0,g=j.$activeOption.offset().top-j.$dropdown_content.offset().top+c,h=g,i=g-e+f,g+f>e+c?j.$dropdown_content.stop().animate({scrollTop:i},d?j.settings.scrollDuration:0):c>g&&j.$dropdown_content.stop().animate({scrollTop:h},d?j.settings.scrollDuration:0)))},selectAll:function(){var a=this;"single"!==a.settings.mode&&(a.$activeItems=Array.prototype.slice.apply(a.$control.children(":not(input)").addClass("active")),a.$activeItems.length&&(a.hideInput(),a.close()),a.focus())},hideInput:function(){var a=this;a.setTextboxValue(""),a.$control_input.css({opacity:0,position:"absolute",left:a.rtl?1e4:-1e4}),a.isInputHidden=!0},showInput:function(){this.$control_input.css({opacity:1,position:"relative",left:0}),this.isInputHidden=!1},focus:function(){var a=this;a.isDisabled||(a.ignoreFocus=!0,a.$control_input[0].focus(),window.setTimeout(function(){a.ignoreFocus=!1,a.onFocus()},0))},blur:function(){this.$control_input.trigger("blur")},getScoreFunction:function(a){return this.sifter.getScoreFunction(a,this.getSearchOptions())},getSearchOptions:function(){var a=this.settings,b=a.sortField;return"string"==typeof b&&(b={field:b}),{fields:a.searchField,conjunction:a.searchConjunction,sort:b}},search:function(b){var c,d,e,f=this,g=f.settings,h=this.getSearchOptions();if(g.score&&(e=f.settings.score.apply(this,[b]),"function"!=typeof e))throw new Error('Selectize "score" setting must be a function that returns a function');if(b!==f.lastQuery?(f.lastQuery=b,d=f.sifter.search(b,a.extend(h,{score:e})),f.currentResults=d):d=a.extend(!0,{},f.currentResults),g.hideSelected)for(c=d.items.length-1;c>=0;c--)-1!==f.items.indexOf(y(d.items[c].id))&&d.items.splice(c,1);return d},refreshOptions:function(b){var c,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s;"undefined"==typeof b&&(b=!0);var t=this,u=t.$control_input.val(),v=t.search(u),w=t.$dropdown_content,x=t.$activeOption&&y(t.$activeOption.attr("data-value"));if(g=v.items.length,"number"==typeof t.settings.maxOptions&&(g=Math.min(g,t.settings.maxOptions)),h={},t.settings.optgroupOrder)for(i=t.settings.optgroupOrder,c=0;c<i.length;c++)h[i[c]]=[];else i=[];for(c=0;g>c;c++)for(j=t.options[v.items[c].id],k=t.render("option",j),l=j[t.settings.optgroupField]||"",m=a.isArray(l)?l:[l],e=0,f=m&&m.length;f>e;e++)l=m[e],t.optgroups.hasOwnProperty(l)||(l=""),h.hasOwnProperty(l)||(h[l]=[],i.push(l)),h[l].push(k);for(n=[],c=0,g=i.length;g>c;c++)l=i[c],t.optgroups.hasOwnProperty(l)&&h[l].length?(o=t.render("optgroup_header",t.optgroups[l])||"",o+=h[l].join(""),n.push(t.render("optgroup",a.extend({},t.optgroups[l],{html:o})))):n.push(h[l].join(""));if(w.html(n.join("")),t.settings.highlight&&v.query.length&&v.tokens.length)for(c=0,g=v.tokens.length;g>c;c++)d(w,v.tokens[c].regex);if(!t.settings.hideSelected)for(c=0,g=t.items.length;g>c;c++)t.getOption(t.items[c]).addClass("selected");p=t.settings.create&&v.query.length,p&&(w.prepend(t.render("option_create",{input:u})),s=a(w[0].childNodes[0])),t.hasOptions=v.items.length>0||p,t.hasOptions?(v.items.length>0?(r=x&&t.getOption(x),r&&r.length?q=r:"single"===t.settings.mode&&t.items.length&&(q=t.getOption(t.items[0])),q&&q.length||(q=s&&!t.settings.addPrecedence?t.getAdjacentOption(s,1):w.find("[data-selectable]:first"))):q=s,t.setActiveOption(q),b&&!t.isOpen&&t.open()):(t.setActiveOption(null),b&&t.isOpen&&t.close())},addOption:function(b){var c,d,e,f=this;if(a.isArray(b))for(c=0,d=b.length;d>c;c++)f.addOption(b[c]);else e=y(b[f.settings.valueField]),e&&!f.options.hasOwnProperty(e)&&(f.userOptions[e]=!0,f.options[e]=b,f.lastQuery=null,f.trigger("option_add",e,b))},addOptionGroup:function(a,b){this.optgroups[a]=b,this.trigger("optgroup_add",a,b)},updateOption:function(b,c){var d,e,f,g,h,i,j=this;if(b=y(b),f=y(c[j.settings.valueField]),j.options.hasOwnProperty(b)){if(!f)throw new Error("Value must be set in option data");f!==b&&(delete j.options[b],g=j.items.indexOf(b),-1!==g&&j.items.splice(g,1,f)),j.options[f]=c,h=j.renderCache.item,i=j.renderCache.option,x(h)&&(delete h[b],delete h[f]),x(i)&&(delete i[b],delete i[f]),-1!==j.items.indexOf(f)&&(d=j.getItem(b),e=a(j.render("item",c)),d.hasClass("active")&&e.addClass("active"),d.replaceWith(e)),j.isOpen&&j.refreshOptions(!1)}},removeOption:function(a){var b=this;a=y(a),delete b.userOptions[a],delete b.options[a],b.lastQuery=null,b.trigger("option_remove",a),b.removeItem(a)},clearOptions:function(){var a=this;a.loadedSearches={},a.userOptions={},a.options=a.sifter.items={},a.lastQuery=null,a.trigger("option_clear"),a.clear()},getOption:function(a){return this.getElementWithValue(a,this.$dropdown_content.find("[data-selectable]"))},getAdjacentOption:function(b,c){var d=this.$dropdown.find("[data-selectable]"),e=d.index(b)+c;return e>=0&&e<d.length?d.eq(e):a()},getElementWithValue:function(b,c){if(b=y(b))for(var d=0,e=c.length;e>d;d++)if(c[d].getAttribute("data-value")===b)return a(c[d]);return a()},getItem:function(a){return this.getElementWithValue(a,this.$control.children())},addItems:function(b){for(var c=a.isArray(b)?b:[b],d=0,e=c.length;e>d;d++)this.isPending=e-1>d,this.addItem(c[d])},addItem:function(b){F(this,["change"],function(){var c,d,e,f,g=this,h=g.settings.mode;return b=y(b),-1!==g.items.indexOf(b)?void("single"===h&&g.close()):void(g.options.hasOwnProperty(b)&&("single"===h&&g.clear(),"multi"===h&&g.isFull()||(c=a(g.render("item",g.options[b])),g.items.splice(g.caretPos,0,b),g.insertAtCaret(c),g.refreshState(),g.isSetup&&(e=g.$dropdown_content.find("[data-selectable]"),this.isPending||(d=g.getOption(b),f=g.getAdjacentOption(d,1).attr("data-value"),g.refreshOptions(g.isFocused&&"single"!==h),f&&g.setActiveOption(g.getOption(f))),!e.length||null!==g.settings.maxItems&&g.items.length>=g.settings.maxItems?g.close():g.positionDropdown(),g.updatePlaceholder(),g.trigger("item_add",b,c),g.updateOriginalInput()))))})},removeItem:function(a){var b,c,d,e=this;b="object"==typeof a?a:e.getItem(a),a=y(b.attr("data-value")),c=e.items.indexOf(a),-1!==c&&(b.remove(),b.hasClass("active")&&(d=e.$activeItems.indexOf(b[0]),e.$activeItems.splice(d,1)),e.items.splice(c,1),e.lastQuery=null,!e.settings.persist&&e.userOptions.hasOwnProperty(a)&&e.removeOption(a),c<e.caretPos&&e.setCaret(e.caretPos-1),e.refreshState(),e.updatePlaceholder(),e.updateOriginalInput(),e.positionDropdown(),e.trigger("item_remove",a))},createItem:function(b){var c=this,d=a.trim(c.$control_input.val()||""),e=c.caretPos;if(!d.length)return!1;c.lock(),"undefined"==typeof b&&(b=!0);var f="function"==typeof c.settings.create?this.settings.create:function(a){var b={};return b[c.settings.labelField]=a,b[c.settings.valueField]=a,b},g=D(function(a){if(c.unlock(),a&&"object"==typeof a){var d=y(a[c.settings.valueField]);d&&(c.setTextboxValue(""),c.addOption(a),c.setCaret(e),c.addItem(d),c.refreshOptions(b&&"single"!==c.settings.mode))}}),h=f.apply(this,[d,g]);return"undefined"!=typeof h&&g(h),!0},refreshItems:function(){if(this.lastQuery=null,this.isSetup)for(var a=0;a<this.items.length;a++)this.addItem(this.items);this.refreshState(),this.updateOriginalInput()},refreshState:function(){var a=this,b=a.isRequired&&!a.items.length;b||(a.isInvalid=!1),a.$control_input.prop("required",b),a.refreshClasses()},refreshClasses:function(){var b=this,c=b.isFull(),d=b.isLocked;b.$wrapper.toggleClass("rtl",b.rtl),b.$control.toggleClass("focus",b.isFocused).toggleClass("disabled",b.isDisabled).toggleClass("required",b.isRequired).toggleClass("invalid",b.isInvalid).toggleClass("locked",d).toggleClass("full",c).toggleClass("not-full",!c).toggleClass("input-active",b.isFocused&&!b.isInputHidden).toggleClass("dropdown-active",b.isOpen).toggleClass("has-options",!a.isEmptyObject(b.options)).toggleClass("has-items",b.items.length>0),b.$control_input.data("grow",!c&&!d)},isFull:function(){return null!==this.settings.maxItems&&this.items.length>=this.settings.maxItems},updateOriginalInput:function(){var a,b,c,d=this;if("select"===d.$input[0].tagName.toLowerCase()){for(c=[],a=0,b=d.items.length;b>a;a++)c.push('<option value="'+z(d.items[a])+'" selected="selected"></option>');c.length||this.$input.attr("multiple")||c.push('<option value="" selected="selected"></option>'),d.$input.html(c.join(""))}else d.$input.val(d.getValue());d.isSetup&&d.trigger("change",d.$input.val())},updatePlaceholder:function(){if(this.settings.placeholder){var a=this.$control_input;this.items.length?a.removeAttr("placeholder"):a.attr("placeholder",this.settings.placeholder),a.triggerHandler("update")}},open:function(){var a=this;a.isLocked||a.isOpen||"multi"===a.settings.mode&&a.isFull()||(a.focus(),a.isOpen=!0,a.refreshState(),a.$dropdown.css({visibility:"hidden",display:"block"}),a.positionDropdown(),a.$dropdown.css({visibility:"visible"}),a.trigger("dropdown_open",a.$dropdown))},close:function(){var a=this,b=a.isOpen;"single"===a.settings.mode&&a.items.length&&a.hideInput(),a.isOpen=!1,a.$dropdown.hide(),a.setActiveOption(null),a.refreshState(),b&&a.trigger("dropdown_close",a.$dropdown)},positionDropdown:function(){var a=this.$control,b="body"===this.settings.dropdownParent?a.offset():a.position();b.top+=a.outerHeight(!0),this.$dropdown.css({width:a.outerWidth(),top:b.top,left:b.left})},clear:function(){var a=this;a.items.length&&(a.$control.children(":not(input)").remove(),a.items=[],a.setCaret(0),a.updatePlaceholder(),a.updateOriginalInput(),a.refreshState(),a.showInput(),a.trigger("clear"))},insertAtCaret:function(b){var c=Math.min(this.caretPos,this.items.length);0===c?this.$control.prepend(b):a(this.$control[0].childNodes[c]).before(b),this.setCaret(c+1)},deleteSelection:function(b){var c,d,e,f,g,h,i,j,k,l=this;if(e=b&&b.keyCode===p?-1:1,f=H(l.$control_input[0]),l.$activeOption&&!l.settings.hideSelected&&(i=l.getAdjacentOption(l.$activeOption,-1).attr("data-value")),g=[],l.$activeItems.length){for(k=l.$control.children(".active:"+(e>0?"last":"first")),h=l.$control.children(":not(input)").index(k),e>0&&h++,c=0,d=l.$activeItems.length;d>c;c++)g.push(a(l.$activeItems[c]).attr("data-value"));b&&(b.preventDefault(),b.stopPropagation())}else(l.isFocused||"single"===l.settings.mode)&&l.items.length&&(0>e&&0===f.start&&0===f.length?g.push(l.items[l.caretPos-1]):e>0&&f.start===l.$control_input.val().length&&g.push(l.items[l.caretPos]));if(!g.length||"function"==typeof l.settings.onDelete&&l.settings.onDelete.apply(l,[g])===!1)return!1;for("undefined"!=typeof h&&l.setCaret(h);g.length;)l.removeItem(g.pop());return l.showInput(),l.positionDropdown(),l.refreshOptions(!0),i&&(j=l.getOption(i),j.length&&l.setActiveOption(j)),!0},advanceSelection:function(a,b){var c,d,e,f,g,h,i=this;0!==a&&(i.rtl&&(a*=-1),c=a>0?"last":"first",d=H(i.$control_input[0]),i.isFocused&&!i.isInputHidden?(f=i.$control_input.val().length,g=0>a?0===d.start&&0===d.length:d.start===f,g&&!f&&i.advanceCaret(a,b)):(h=i.$control.children(".active:"+c),h.length&&(e=i.$control.children(":not(input)").index(h),i.setActiveItem(null),i.setCaret(a>0?e+1:e))))},advanceCaret:function(a,b){var c,d,e=this;0!==a&&(c=a>0?"next":"prev",e.isShiftDown?(d=e.$control_input[c](),d.length&&(e.hideInput(),e.setActiveItem(d),b&&b.preventDefault())):e.setCaret(e.caretPos+a))},setCaret:function(b){var c=this;b="single"===c.settings.mode?c.items.length:Math.max(0,Math.min(c.items.length,b));var d,e,f,g;for(f=c.$control.children(":not(input)"),d=0,e=f.length;e>d;d++)g=a(f[d]).detach(),b>d?c.$control_input.before(g):c.$control.append(g);c.caretPos=b},lock:function(){this.close(),this.isLocked=!0,this.refreshState()},unlock:function(){this.isLocked=!1,this.refreshState()},disable:function(){var a=this;a.$input.prop("disabled",!0),a.isDisabled=!0,a.lock()},enable:function(){var a=this;a.$input.prop("disabled",!1),a.isDisabled=!1,a.unlock()},destroy:function(){var b=this,c=b.eventNS,d=b.revertSettings;b.trigger("destroy"),b.off(),b.$wrapper.remove(),b.$dropdown.remove(),b.$input.html("").append(d.$children).removeAttr("tabindex").attr({tabindex:d.tabindex}).show(),a(window).off(c),a(document).off(c),a(document.body).off(c),delete b.$input[0].selectize},render:function(a,b){var c,d,e="",f=!1,g=this,h=/^[\t ]*<([a-z][a-z0-9\-_]*(?:\:[a-z][a-z0-9\-_]*)?)/i;return("option"===a||"item"===a)&&(c=y(b[g.settings.valueField]),f=!!c),f&&(x(g.renderCache[a])||(g.renderCache[a]={}),g.renderCache[a].hasOwnProperty(c))?g.renderCache[a][c]:(e=g.settings.render[a].apply(this,[b,z]),("option"===a||"option_create"===a)&&(e=e.replace(h,"<$1 data-selectable")),"optgroup"===a&&(d=b[g.settings.optgroupValueField]||"",e=e.replace(h,'<$1 data-group="'+A(z(d))+'"')),("option"===a||"item"===a)&&(e=e.replace(h,'<$1 data-value="'+A(z(c||""))+'"')),f&&(g.renderCache[a][c]=e),e)}}),L.count=0,L.defaults={plugins:[],delimiter:",",persist:!0,diacritics:!0,create:!1,createOnBlur:!1,highlight:!0,openOnFocus:!0,maxOptions:1e3,maxItems:null,hideSelected:null,addPrecedence:!1,preload:!1,scrollDuration:60,loadThrottle:300,dataAttr:"data-data",optgroupField:"optgroup",valueField:"value",labelField:"text",optgroupLabelField:"label",optgroupValueField:"value",optgroupOrder:null,sortField:"$order",searchField:["text"],searchConjunction:"and",mode:null,wrapperClass:"selectize-control",inputClass:"selectize-input",dropdownClass:"selectize-dropdown",dropdownContentClass:"selectize-dropdown-content",dropdownParent:null,render:{}},a.fn.selectize=function(b){var c=a.fn.selectize.defaults,d=a.extend({},c,b),e=d.dataAttr,f=d.labelField,g=d.valueField,h=d.optgroupField,i=d.optgroupLabelField,j=d.optgroupValueField,k=function(b,c){var e,h,i,j,k=a.trim(b.val()||"");if(k.length){for(i=k.split(d.delimiter),e=0,h=i.length;h>e;e++)j={},j[f]=i[e],j[g]=i[e],c.options[i[e]]=j;c.items=i}},l=function(b,c){var d,k,l,m,n=0,o=c.options,p=function(a){var b=e&&a.attr(e);return"string"==typeof b&&b.length?JSON.parse(b):null},q=function(b,d){var e,i;if(b=a(b),e=b.attr("value")||"",e.length){if(o.hasOwnProperty(e))return void(d&&(o[e].optgroup?a.isArray(o[e].optgroup)?o[e].optgroup.push(d):o[e].optgroup=[o[e].optgroup,d]:o[e].optgroup=d));i=p(b)||{},i[f]=i[f]||b.text(),i[g]=i[g]||e,i[h]=i[h]||d,i.$order=++n,o[e]=i,b.is(":selected")&&c.items.push(e)}},r=function(b){var d,e,f,g,h;for(b=a(b),f=b.attr("label"),f&&(g=p(b)||{},g[i]=f,g[j]=f,c.optgroups[f]=g),h=a("option",b),d=0,e=h.length;e>d;d++)q(h[d],f)};for(c.maxItems=b.attr("multiple")?null:1,m=b.children(),d=0,k=m.length;k>d;d++)l=m[d].tagName.toLowerCase(),"optgroup"===l?r(m[d]):"option"===l&&q(m[d])};return this.each(function(){if(!this.selectize){var d,e=a(this),f=this.tagName.toLowerCase(),g={placeholder:e.children('option[value=""]').text()||e.attr("placeholder"),options:{},optgroups:{},items:[]};"select"===f?l(e,g):k(e,g),d=new L(e,a.extend(!0,{},c,g,b)),e.data("selectize",d),e.addClass("selectized")}})},a.fn.selectize.defaults=L.defaults,L.define("drag_drop",function(b){if(!a.fn.sortable)throw new Error('The "drag_drop" plugin requires jQuery UI "sortable".');if("multi"===this.settings.mode){var c=this;c.lock=function(){var a=c.lock;return function(){var b=c.$control.data("sortable");return b&&b.disable(),a.apply(c,arguments)}}(),c.unlock=function(){var a=c.unlock;return function(){var b=c.$control.data("sortable");return b&&b.enable(),a.apply(c,arguments)}}(),c.setup=function(){var b=c.setup;return function(){b.apply(this,arguments);var d=c.$control.sortable({items:"[data-value]",forcePlaceholderSize:!0,disabled:c.isLocked,start:function(a,b){b.placeholder.css("width",b.helper.css("width")),d.css({overflow:"visible"})},stop:function(){d.css({overflow:"hidden"});var b=c.$activeItems?c.$activeItems.slice():null,e=[];d.children("[data-value]").each(function(){e.push(a(this).attr("data-value"))}),c.setValue(e),c.setActiveItem(b)}})}}()}}),L.define("dropdown_header",function(b){var c=this;b=a.extend({title:"Untitled",headerClass:"selectize-dropdown-header",titleRowClass:"selectize-dropdown-header-title",labelClass:"selectize-dropdown-header-label",closeClass:"selectize-dropdown-header-close",html:function(a){return'<div class="'+a.headerClass+'"><div class="'+a.titleRowClass+'"><span class="'+a.labelClass+'">'+a.title+'</span><a href="javascript:void(0)" class="'+a.closeClass+'">&times;</a></div></div>'}},b),c.setup=function(){var d=c.setup;return function(){d.apply(c,arguments),c.$dropdown_header=a(b.html(b)),c.$dropdown.prepend(c.$dropdown_header)}}()}),L.define("optgroup_columns",function(b){var c=this;b=a.extend({equalizeWidth:!0,equalizeHeight:!0},b),this.getAdjacentOption=function(b,c){var d=b.closest("[data-group]").find("[data-selectable]"),e=d.index(b)+c;return e>=0&&e<d.length?d.eq(e):a()},this.onKeyDown=function(){var a=c.onKeyDown;return function(b){var d,e,f,g;return!this.isOpen||b.keyCode!==j&&b.keyCode!==m?a.apply(this,arguments):(c.ignoreHover=!0,g=this.$activeOption.closest("[data-group]"),d=g.find("[data-selectable]").index(this.$activeOption),g=b.keyCode===j?g.prev("[data-group]"):g.next("[data-group]"),f=g.find("[data-selectable]"),e=f.eq(Math.min(f.length-1,d)),void(e.length&&this.setActiveOption(e)))}}();var d=function(){var d,e,f,g,h,i,j;if(j=a("[data-group]",c.$dropdown_content),e=j.length,e&&c.$dropdown_content.width()){if(b.equalizeHeight){for(f=0,d=0;e>d;d++)f=Math.max(f,j.eq(d).height());j.css({height:f})}b.equalizeWidth&&(i=c.$dropdown_content.innerWidth(),g=Math.round(i/e),j.css({width:g}),e>1&&(h=i-g*(e-1),j.eq(e-1).css({width:h})))}};(b.equalizeHeight||b.equalizeWidth)&&(B.after(this,"positionDropdown",d),B.after(this,"refreshOptions",d))}),L.define("remove_button",function(b){if("single"!==this.settings.mode){b=a.extend({label:"&times;",title:"Remove",className:"remove",append:!0},b);var c=this,d='<a href="javascript:void(0)" class="'+b.className+'" tabindex="-1" title="'+z(b.title)+'">'+b.label+"</a>",e=function(a,b){
-var c=a.search(/(<\/[^>]+>\s*)$/);return a.substring(0,c)+b+a.substring(c)};this.setup=function(){var f=c.setup;return function(){if(b.append){var g=c.settings.render.item;c.settings.render.item=function(a){return e(g.apply(this,arguments),d)}}f.apply(this,arguments),this.$control.on("click","."+b.className,function(b){if(b.preventDefault(),!c.isLocked){var d=a(b.currentTarget).parent();c.setActiveItem(d),c.deleteSelection()&&c.setCaret(c.items.length)}})}}()}}),L.define("restore_on_backspace",function(a){var b=this;a.text=a.text||function(a){return a[this.settings.labelField]},this.onKeyDown=function(c){var d=b.onKeyDown;return function(b){var c,e;return b.keyCode===p&&""===this.$control_input.val()&&!this.$activeItems.length&&(c=this.caretPos-1,c>=0&&c<this.items.length)?(e=this.options[this.items[c]],this.deleteSelection(b)&&(this.setTextboxValue(a.text.apply(this,[e])),this.refreshOptions(!0)),void b.preventDefault()):d.apply(this,arguments)}}()}),L}),//! moment.js
+/*jshint curly:false */
+/*jshint browser:true */
+function(a,b){"function"==typeof define&&define.amd?define("selectize",["jquery","sifter","microplugin"],b):"object"==typeof exports?module.exports=b(require("jquery"),require("sifter"),require("microplugin")):a.Selectize=b(a.jQuery,a.Sifter,a.MicroPlugin)}(this,function(a,b,c){"use strict";var d=function(a,b){if("string"!=typeof b||b.length){var c="string"==typeof b?new RegExp(b,"i"):b,d=function(a){var b=0;if(3===a.nodeType){var e=a.data.search(c);if(e>=0&&a.data.length>0){var f=a.data.match(c),g=document.createElement("span");g.className="highlight";var h=a.splitText(e),i=(h.splitText(f[0].length),h.cloneNode(!0));g.appendChild(i),h.parentNode.replaceChild(g,h),b=1}}else if(1===a.nodeType&&a.childNodes&&!/(script|style)/i.test(a.tagName))for(var j=0;j<a.childNodes.length;++j)j+=d(a.childNodes[j]);return b};return a.each(function(){d(this)})}},e=function(){};e.prototype={on:function(a,b){this._events=this._events||{},this._events[a]=this._events[a]||[],this._events[a].push(b)},off:function(a,b){var c=arguments.length;return 0===c?delete this._events:1===c?delete this._events[a]:(this._events=this._events||{},void(a in this._events!=!1&&this._events[a].splice(this._events[a].indexOf(b),1)))},trigger:function(a){if(this._events=this._events||{},a in this._events!=!1)for(var b=0;b<this._events[a].length;b++)this._events[a][b].apply(this,Array.prototype.slice.call(arguments,1))}},/**
+	 * Mixin will delegate all MicroEvent.js function in the destination object.
+	 *
+	 * - MicroEvent.mixin(Foobar) will make Foobar able to use MicroEvent
+	 *
+	 * @param {object} the object which will support MicroEvent
+	 */
+e.mixin=function(a){for(var b=["on","off","trigger"],c=0;c<b.length;c++)a.prototype[b[c]]=e.prototype[b[c]]};var f=/Mac/.test(navigator.userAgent),g=65,h=13,i=27,j=37,k=38,l=80,m=39,n=40,o=78,p=8,q=46,r=16,s=f?91:17,t=f?18:17,u=9,v=1,w=2,x=function(a){return"undefined"!=typeof a},y=function(a){return"undefined"==typeof a||null===a?"":"boolean"==typeof a?a?"1":"0":a+""},z=function(a){return(a+"").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;")},A=function(a){return(a+"").replace(/\$/g,"$$$$")},B={};/**
+	 * Wraps `method` on `self` so that `fn`
+	 * is invoked before the original method.
+	 *
+	 * @param {object} self
+	 * @param {string} method
+	 * @param {function} fn
+	 */
+B.before=function(a,b,c){var d=a[b];a[b]=function(){return c.apply(a,arguments),d.apply(a,arguments)}},/**
+	 * Wraps `method` on `self` so that `fn`
+	 * is invoked after the original method.
+	 *
+	 * @param {object} self
+	 * @param {string} method
+	 * @param {function} fn
+	 */
+B.after=function(a,b,c){var d=a[b];a[b]=function(){var b=d.apply(a,arguments);return c.apply(a,arguments),b}};/**
+	 * Builds a hash table out of an array of
+	 * objects, using the specified `key` within
+	 * each object.
+	 *
+	 * @param {string} key
+	 * @param {mixed} objects
+	 */
+var C=function(b,c){if(!a.isArray(c))return c;var d,e,f={};for(d=0,e=c.length;e>d;d++)c[d].hasOwnProperty(b)&&(f[c[d][b]]=c[d]);return f},D=function(a){var b=!1;return function(){b||(b=!0,a.apply(this,arguments))}},E=function(a,b){var c;return function(){var d=this,e=arguments;window.clearTimeout(c),c=window.setTimeout(function(){a.apply(d,e)},b)}},F=function(a,b,c){var d,e=a.trigger,f={};
+// override trigger method
+a.trigger=function(){var c=arguments[0];return-1===b.indexOf(c)?e.apply(a,arguments):void(f[c]=arguments)},
+// invoke provided function
+c.apply(a,[]),a.trigger=e;
+// trigger queued events
+for(d in f)f.hasOwnProperty(d)&&e.apply(a,f[d])},G=function(a,b,c,d){a.on(b,c,function(b){for(var c=b.target;c&&c.parentNode!==a[0];)c=c.parentNode;return b.currentTarget=c,d.apply(this,[b])})},H=function(a){var b={};if("selectionStart"in a)b.start=a.selectionStart,b.length=a.selectionEnd-b.start;else if(document.selection){a.focus();var c=document.selection.createRange(),d=document.selection.createRange().text.length;c.moveStart("character",-a.value.length),b.start=c.text.length-d,b.length=d}return b},I=function(a,b,c){var d,e,f={};if(c)for(d=0,e=c.length;e>d;d++)f[c[d]]=a.css(c[d]);else f=a.css();b.css(f)},J=function(b,c){if(!b)return 0;var d=a("<test>").css({position:"absolute",top:-99999,left:-99999,width:"auto",padding:0,whiteSpace:"pre"}).text(b).appendTo("body");I(c,d,["letterSpacing","fontSize","fontFamily","fontWeight","textTransform"]);var e=d.width();return d.remove(),e},K=function(a){var b=null,c=function(c){var d,e,f,g,h,i,j,k;c=c||window.event||{},c.metaKey||c.altKey||a.data("grow")!==!1&&(d=a.val(),c.type&&"keydown"===c.type.toLowerCase()&&(e=c.keyCode,f=e>=97&&122>=e||e>=65&&90>=e||e>=48&&57>=e||32===e,e===q||e===p?(k=H(a[0]),k.length?d=d.substring(0,k.start)+d.substring(k.start+k.length):e===p&&k.start?d=d.substring(0,k.start-1)+d.substring(k.start+1):e===q&&"undefined"!=typeof k.start&&(d=d.substring(0,k.start)+d.substring(k.start+1))):f&&(i=c.shiftKey,j=String.fromCharCode(c.keyCode),j=i?j.toUpperCase():j.toLowerCase(),d+=j)),g=a.attr("placeholder")||"",!d.length&&g.length&&(d=g),h=J(d,a)+4,h!==b&&(b=h,a.width(h),a.triggerHandler("resize")))};a.on("keydown keyup update blur",c),c()},L=function(c,d){var e,f,g=this;f=c[0],f.selectize=g,e=window.getComputedStyle?window.getComputedStyle(f,null).getPropertyValue("direction"):f.currentStyle&&f.currentStyle.direction,e=e||c.parents("[dir]:first").attr("dir")||"",a.extend(g,{settings:d,$input:c,tagType:"select"===f.tagName.toLowerCase()?v:w,rtl:/rtl/i.test(e),eventNS:".selectize"+ ++L.count,highlightedValue:null,isOpen:!1,isDisabled:!1,isRequired:c.is("[required]"),isInvalid:!1,isLocked:!1,isFocused:!1,isInputHidden:!1,isSetup:!1,isShiftDown:!1,isCmdDown:!1,isCtrlDown:!1,ignoreFocus:!1,ignoreHover:!1,hasOptions:!1,currentResults:null,lastValue:"",caretPos:0,loading:0,loadedSearches:{},$activeOption:null,$activeItems:[],optgroups:{},options:{},userOptions:{},items:[],renderCache:{},onSearchChange:E(g.onSearchChange,d.loadThrottle)}),g.sifter=new b(this.options,{diacritics:d.diacritics}),a.extend(g.options,C(d.valueField,d.options)),delete g.settings.options,a.extend(g.optgroups,C(d.optgroupValueField,d.optgroups)),delete g.settings.optgroups,g.settings.mode=g.settings.mode||(1===g.settings.maxItems?"single":"multi"),"boolean"!=typeof g.settings.hideSelected&&(g.settings.hideSelected="multi"===g.settings.mode),g.initializePlugins(g.settings.plugins),g.setupCallbacks(),g.setupTemplates(),g.setup()};
+// mixins
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// methods
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+return e.mixin(L),c.mixin(L),a.extend(L.prototype,{/**
+		 * Creates all elements and sets up event bindings.
+		 */
+setup:function(){var b,c,d,e,g,h,i,j,k,l,m=this,n=m.settings,o=m.eventNS,p=a(window),q=a(document);i=m.settings.mode,j=m.$input.attr("tabindex")||"",k=m.$input.attr("class")||"",b=a("<div>").addClass(n.wrapperClass).addClass(k).addClass(i),c=a("<div>").addClass(n.inputClass).addClass("items").appendTo(b),d=a('<input type="text" autocomplete="off" />').appendTo(c).attr("tabindex",j),h=a(n.dropdownParent||b),e=a("<div>").addClass(n.dropdownClass).addClass(k).addClass(i).hide().appendTo(h),g=a("<div>").addClass(n.dropdownContentClass).appendTo(e),b.css({width:m.$input[0].style.width}),m.plugins.names.length&&(l="plugin-"+m.plugins.names.join(" plugin-"),b.addClass(l),e.addClass(l)),(null===n.maxItems||n.maxItems>1)&&m.tagType===v&&m.$input.attr("multiple","multiple"),m.settings.placeholder&&d.attr("placeholder",n.placeholder),m.$wrapper=b,m.$control=c,m.$control_input=d,m.$dropdown=e,m.$dropdown_content=g,e.on("mouseenter","[data-selectable]",function(){return m.onOptionHover.apply(m,arguments)}),e.on("mousedown","[data-selectable]",function(){return m.onOptionSelect.apply(m,arguments)}),G(c,"mousedown","*:not(input)",function(){return m.onItemSelect.apply(m,arguments)}),K(d),c.on({mousedown:function(){return m.onMouseDown.apply(m,arguments)},click:function(){return m.onClick.apply(m,arguments)}}),d.on({mousedown:function(a){a.stopPropagation()},keydown:function(){return m.onKeyDown.apply(m,arguments)},keyup:function(){return m.onKeyUp.apply(m,arguments)},keypress:function(){return m.onKeyPress.apply(m,arguments)},resize:function(){m.positionDropdown.apply(m,[])},blur:function(){return m.onBlur.apply(m,arguments)},focus:function(){return m.onFocus.apply(m,arguments)}}),q.on("keydown"+o,function(a){m.isCmdDown=a[f?"metaKey":"ctrlKey"],m.isCtrlDown=a[f?"altKey":"ctrlKey"],m.isShiftDown=a.shiftKey}),q.on("keyup"+o,function(a){a.keyCode===t&&(m.isCtrlDown=!1),a.keyCode===r&&(m.isShiftDown=!1),a.keyCode===s&&(m.isCmdDown=!1)}),q.on("mousedown"+o,function(a){if(m.isFocused){if(a.target===m.$dropdown[0]||a.target.parentNode===m.$dropdown[0])return!1;m.$control.has(a.target).length||a.target===m.$control[0]||m.blur()}}),p.on(["scroll"+o,"resize"+o].join(" "),function(){m.isOpen&&m.positionDropdown.apply(m,arguments)}),p.on("mousemove"+o,function(){m.ignoreHover=!1}),this.revertSettings={$children:m.$input.children().detach(),tabindex:m.$input.attr("tabindex")},m.$input.attr("tabindex",-1).hide().after(m.$wrapper),a.isArray(n.items)&&(m.setValue(n.items),delete n.items),m.$input[0].validity&&m.$input.on("invalid"+o,function(a){a.preventDefault(),m.isInvalid=!0,m.refreshState()}),m.updateOriginalInput(),m.refreshItems(),m.refreshState(),m.updatePlaceholder(),m.isSetup=!0,m.$input.is(":disabled")&&m.disable(),m.on("change",this.onChange),m.trigger("initialize"),n.preload===!0&&m.onSearchChange("")},/**
+		 * Sets up default rendering functions.
+		 */
+setupTemplates:function(){var b=this,c=b.settings.labelField,d=b.settings.optgroupLabelField,e={optgroup:function(a){return'<div class="optgroup">'+a.html+"</div>"},optgroup_header:function(a,b){return'<div class="optgroup-header">'+b(a[d])+"</div>"},option:function(a,b){return'<div class="option">'+b(a[c])+"</div>"},item:function(a,b){return'<div class="item">'+b(a[c])+"</div>"},option_create:function(a,b){return'<div class="create">Add <strong>'+b(a.input)+"</strong>&hellip;</div>"}};b.settings.render=a.extend({},e,b.settings.render)},/**
+		 * Maps fired events to callbacks provided
+		 * in the settings used when creating the control.
+		 */
+setupCallbacks:function(){var a,b,c={initialize:"onInitialize",change:"onChange",item_add:"onItemAdd",item_remove:"onItemRemove",clear:"onClear",option_add:"onOptionAdd",option_remove:"onOptionRemove",option_clear:"onOptionClear",dropdown_open:"onDropdownOpen",dropdown_close:"onDropdownClose",type:"onType"};for(a in c)c.hasOwnProperty(a)&&(b=this.settings[c[a]],b&&this.on(a,b))},/**
+		 * Triggered when the main control element
+		 * has a click event.
+		 *
+		 * @param {object} e
+		 * @return {boolean}
+		 */
+onClick:function(a){var b=this;
+// necessary for mobile webkit devices (manual focus triggering
+// is ignored unless invoked within a click event)
+b.isFocused||(b.focus(),a.preventDefault())},/**
+		 * Triggered when the main control element
+		 * has a mouse down event.
+		 *
+		 * @param {object} e
+		 * @return {boolean}
+		 */
+onMouseDown:function(b){var c=this,d=b.isDefaultPrevented();a(b.target);if(c.isFocused){
+// retain focus by preventing native handling. if the
+// event target is the input it should not be modified.
+// otherwise, text selection within the input won't work.
+if(b.target!==c.$control_input[0])
+// toggle dropdown
+return"single"===c.settings.mode?c.isOpen?c.close():c.open():d||c.setActiveItem(null),!1}else
+// give control focus
+d||window.setTimeout(function(){c.focus()},0)},/**
+		 * Triggered when the value of the control has been changed.
+		 * This should propagate the event to the original DOM
+		 * input / select element.
+		 */
+onChange:function(){this.$input.trigger("change")},/**
+		 * Triggered on <input> keypress.
+		 *
+		 * @param {object} e
+		 * @returns {boolean}
+		 */
+onKeyPress:function(a){if(this.isLocked)return a&&a.preventDefault();var b=String.fromCharCode(a.keyCode||a.which);return this.settings.create&&b===this.settings.delimiter?(this.createItem(),a.preventDefault(),!1):void 0},/**
+		 * Triggered on <input> keydown.
+		 *
+		 * @param {object} e
+		 * @returns {boolean}
+		 */
+onKeyDown:function(a){var b=(a.target===this.$control_input[0],this);if(b.isLocked)return void(a.keyCode!==u&&a.preventDefault());switch(a.keyCode){case g:if(b.isCmdDown)return void b.selectAll();break;case i:return void b.close();case o:if(!a.ctrlKey)break;case n:if(!b.isOpen&&b.hasOptions)b.open();else if(b.$activeOption){b.ignoreHover=!0;var c=b.getAdjacentOption(b.$activeOption,1);c.length&&b.setActiveOption(c,!0,!0)}return void a.preventDefault();case l:if(!a.ctrlKey)break;case k:if(b.$activeOption){b.ignoreHover=!0;var d=b.getAdjacentOption(b.$activeOption,-1);d.length&&b.setActiveOption(d,!0,!0)}return void a.preventDefault();case h:return b.isOpen&&b.$activeOption&&b.onOptionSelect({currentTarget:b.$activeOption}),void a.preventDefault();case j:return void b.advanceSelection(-1,a);case m:return void b.advanceSelection(1,a);case u:return b.isOpen&&b.$activeOption&&b.onOptionSelect({currentTarget:b.$activeOption}),void(b.settings.create&&b.createItem()&&a.preventDefault());case p:case q:return void b.deleteSelection(a)}return b.isFull()||b.isInputHidden?void a.preventDefault():void 0},/**
+		 * Triggered on <input> keyup.
+		 *
+		 * @param {object} e
+		 * @returns {boolean}
+		 */
+onKeyUp:function(a){var b=this;if(b.isLocked)return a&&a.preventDefault();var c=b.$control_input.val()||"";b.lastValue!==c&&(b.lastValue=c,b.onSearchChange(c),b.refreshOptions(),b.trigger("type",c))},/**
+		 * Invokes the user-provide option provider / loader.
+		 *
+		 * Note: this function is debounced in the Selectize
+		 * constructor (by `settings.loadDelay` milliseconds)
+		 *
+		 * @param {string} value
+		 */
+onSearchChange:function(a){var b=this,c=b.settings.load;c&&(b.loadedSearches.hasOwnProperty(a)||(b.loadedSearches[a]=!0,b.load(function(d){c.apply(b,[a,d])})))},/**
+		 * Triggered on <input> focus.
+		 *
+		 * @param {object} e (optional)
+		 * @returns {boolean}
+		 */
+onFocus:function(a){var b=this;return b.isFocused=!0,b.isDisabled?(b.blur(),a&&a.preventDefault(),!1):void(b.ignoreFocus||("focus"===b.settings.preload&&b.onSearchChange(""),b.$activeItems.length||(b.showInput(),b.setActiveItem(null),b.refreshOptions(!!b.settings.openOnFocus)),b.refreshState()))},/**
+		 * Triggered on <input> blur.
+		 *
+		 * @param {object} e
+		 * @returns {boolean}
+		 */
+onBlur:function(a){var b=this;b.isFocused=!1,b.ignoreFocus||(b.settings.create&&b.settings.createOnBlur&&b.createItem(!1),b.close(),b.setTextboxValue(""),b.setActiveItem(null),b.setActiveOption(null),b.setCaret(b.items.length),b.refreshState())},/**
+		 * Triggered when the user rolls over
+		 * an option in the autocomplete dropdown menu.
+		 *
+		 * @param {object} e
+		 * @returns {boolean}
+		 */
+onOptionHover:function(a){this.ignoreHover||this.setActiveOption(a.currentTarget,!1)},/**
+		 * Triggered when the user clicks on an option
+		 * in the autocomplete dropdown menu.
+		 *
+		 * @param {object} e
+		 * @returns {boolean}
+		 */
+onOptionSelect:function(b){var c,d,e=this;b.preventDefault&&(b.preventDefault(),b.stopPropagation()),d=a(b.currentTarget),d.hasClass("create")?e.createItem():(c=d.attr("data-value"),c&&(e.lastQuery=null,e.setTextboxValue(""),e.addItem(c),!e.settings.hideSelected&&b.type&&/mouse/.test(b.type)&&e.setActiveOption(e.getOption(c))))},/**
+		 * Triggered when the user clicks on an item
+		 * that has been selected.
+		 *
+		 * @param {object} e
+		 * @returns {boolean}
+		 */
+onItemSelect:function(a){var b=this;b.isLocked||"multi"===b.settings.mode&&(a.preventDefault(),b.setActiveItem(a.currentTarget,a))},/**
+		 * Invokes the provided method that provides
+		 * results to a callback---which are then added
+		 * as options to the control.
+		 *
+		 * @param {function} fn
+		 */
+load:function(a){var b=this,c=b.$wrapper.addClass("loading");b.loading++,a.apply(b,[function(a){b.loading=Math.max(b.loading-1,0),a&&a.length&&(b.addOption(a),b.refreshOptions(b.isFocused&&!b.isInputHidden)),b.loading||c.removeClass("loading"),b.trigger("load",a)}])},/**
+		 * Sets the input field of the control to the specified value.
+		 *
+		 * @param {string} value
+		 */
+setTextboxValue:function(a){this.$control_input.val(a).triggerHandler("update"),this.lastValue=a},/**
+		 * Returns the value of the control. If multiple items
+		 * can be selected (e.g. <select multiple>), this returns
+		 * an array. If only one item can be selected, this
+		 * returns a string.
+		 *
+		 * @returns {mixed}
+		 */
+getValue:function(){return this.tagType===v&&this.$input.attr("multiple")?this.items:this.items.join(this.settings.delimiter)},/**
+		 * Resets the selected items to the given value.
+		 *
+		 * @param {mixed} value
+		 */
+setValue:function(a){F(this,["change"],function(){this.clear(),this.addItems(a)})},/**
+		 * Sets the selected item.
+		 *
+		 * @param {object} $item
+		 * @param {object} e (optional)
+		 */
+setActiveItem:function(b,c){var d,e,f,g,h,i,j,k,l=this;if("single"!==l.settings.mode){
+// clear the active selection
+if(b=a(b),!b.length)return a(l.$activeItems).removeClass("active"),l.$activeItems=[],void(l.isFocused&&l.showInput());if(d=c&&c.type.toLowerCase(),"mousedown"===d&&l.isShiftDown&&l.$activeItems.length){for(k=l.$control.children(".active:last"),g=Array.prototype.indexOf.apply(l.$control[0].childNodes,[k[0]]),h=Array.prototype.indexOf.apply(l.$control[0].childNodes,[b[0]]),g>h&&(j=g,g=h,h=j),e=g;h>=e;e++)i=l.$control[0].childNodes[e],-1===l.$activeItems.indexOf(i)&&(a(i).addClass("active"),l.$activeItems.push(i));c.preventDefault()}else"mousedown"===d&&l.isCtrlDown||"keydown"===d&&this.isShiftDown?b.hasClass("active")?(f=l.$activeItems.indexOf(b[0]),l.$activeItems.splice(f,1),b.removeClass("active")):l.$activeItems.push(b.addClass("active")[0]):(a(l.$activeItems).removeClass("active"),l.$activeItems=[b.addClass("active")[0]]);
+// ensure control has focus
+l.hideInput(),this.isFocused||l.focus()}},/**
+		 * Sets the selected item in the dropdown menu
+		 * of available options.
+		 *
+		 * @param {object} $object
+		 * @param {boolean} scroll
+		 * @param {boolean} animate
+		 */
+setActiveOption:function(b,c,d){var e,f,g,h,i,j=this;j.$activeOption&&j.$activeOption.removeClass("active"),j.$activeOption=null,b=a(b),b.length&&(j.$activeOption=b.addClass("active"),(c||!x(c))&&(e=j.$dropdown_content.height(),f=j.$activeOption.outerHeight(!0),c=j.$dropdown_content.scrollTop()||0,g=j.$activeOption.offset().top-j.$dropdown_content.offset().top+c,h=g,i=g-e+f,g+f>e+c?j.$dropdown_content.stop().animate({scrollTop:i},d?j.settings.scrollDuration:0):c>g&&j.$dropdown_content.stop().animate({scrollTop:h},d?j.settings.scrollDuration:0)))},/**
+		 * Selects all items (CTRL + A).
+		 */
+selectAll:function(){var a=this;"single"!==a.settings.mode&&(a.$activeItems=Array.prototype.slice.apply(a.$control.children(":not(input)").addClass("active")),a.$activeItems.length&&(a.hideInput(),a.close()),a.focus())},/**
+		 * Hides the input element out of view, while
+		 * retaining its focus.
+		 */
+hideInput:function(){var a=this;a.setTextboxValue(""),a.$control_input.css({opacity:0,position:"absolute",left:a.rtl?1e4:-1e4}),a.isInputHidden=!0},/**
+		 * Restores input visibility.
+		 */
+showInput:function(){this.$control_input.css({opacity:1,position:"relative",left:0}),this.isInputHidden=!1},/**
+		 * Gives the control focus. If "trigger" is falsy,
+		 * focus handlers won't be fired--causing the focus
+		 * to happen silently in the background.
+		 *
+		 * @param {boolean} trigger
+		 */
+focus:function(){var a=this;a.isDisabled||(a.ignoreFocus=!0,a.$control_input[0].focus(),window.setTimeout(function(){a.ignoreFocus=!1,a.onFocus()},0))},/**
+		 * Forces the control out of focus.
+		 */
+blur:function(){this.$control_input.trigger("blur")},/**
+		 * Returns a function that scores an object
+		 * to show how good of a match it is to the
+		 * provided query.
+		 *
+		 * @param {string} query
+		 * @param {object} options
+		 * @return {function}
+		 */
+getScoreFunction:function(a){return this.sifter.getScoreFunction(a,this.getSearchOptions())},/**
+		 * Returns search options for sifter (the system
+		 * for scoring and sorting results).
+		 *
+		 * @see https://github.com/brianreavis/sifter.js
+		 * @return {object}
+		 */
+getSearchOptions:function(){var a=this.settings,b=a.sortField;return"string"==typeof b&&(b={field:b}),{fields:a.searchField,conjunction:a.searchConjunction,sort:b}},/**
+		 * Searches through available options and returns
+		 * a sorted array of matches.
+		 *
+		 * Returns an object containing:
+		 *
+		 *   - query {string}
+		 *   - tokens {array}
+		 *   - total {int}
+		 *   - items {array}
+		 *
+		 * @param {string} query
+		 * @returns {object}
+		 */
+search:function(b){var c,d,e,f=this,g=f.settings,h=this.getSearchOptions();
+// validate user-provided result scoring function
+if(g.score&&(e=f.settings.score.apply(this,[b]),"function"!=typeof e))throw new Error('Selectize "score" setting must be a function that returns a function');
+// filter out selected items
+if(
+// perform search
+b!==f.lastQuery?(f.lastQuery=b,d=f.sifter.search(b,a.extend(h,{score:e})),f.currentResults=d):d=a.extend(!0,{},f.currentResults),g.hideSelected)for(c=d.items.length-1;c>=0;c--)-1!==f.items.indexOf(y(d.items[c].id))&&d.items.splice(c,1);return d},/**
+		 * Refreshes the list of available options shown
+		 * in the autocomplete dropdown menu.
+		 *
+		 * @param {boolean} triggerDropdown
+		 */
+refreshOptions:function(b){var c,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s;"undefined"==typeof b&&(b=!0);var t=this,u=t.$control_input.val(),v=t.search(u),w=t.$dropdown_content,x=t.$activeOption&&y(t.$activeOption.attr("data-value"));if(g=v.items.length,"number"==typeof t.settings.maxOptions&&(g=Math.min(g,t.settings.maxOptions)),h={},t.settings.optgroupOrder)for(i=t.settings.optgroupOrder,c=0;c<i.length;c++)h[i[c]]=[];else i=[];for(c=0;g>c;c++)for(j=t.options[v.items[c].id],k=t.render("option",j),l=j[t.settings.optgroupField]||"",m=a.isArray(l)?l:[l],e=0,f=m&&m.length;f>e;e++)l=m[e],t.optgroups.hasOwnProperty(l)||(l=""),h.hasOwnProperty(l)||(h[l]=[],i.push(l)),h[l].push(k);for(n=[],c=0,g=i.length;g>c;c++)l=i[c],t.optgroups.hasOwnProperty(l)&&h[l].length?(o=t.render("optgroup_header",t.optgroups[l])||"",o+=h[l].join(""),n.push(t.render("optgroup",a.extend({},t.optgroups[l],{html:o})))):n.push(h[l].join(""));
+// highlight matching terms inline
+if(w.html(n.join("")),t.settings.highlight&&v.query.length&&v.tokens.length)for(c=0,g=v.tokens.length;g>c;c++)d(w,v.tokens[c].regex);
+// add "selected" class to selected options
+if(!t.settings.hideSelected)for(c=0,g=t.items.length;g>c;c++)t.getOption(t.items[c]).addClass("selected");p=t.settings.create&&v.query.length,p&&(w.prepend(t.render("option_create",{input:u})),s=a(w[0].childNodes[0])),t.hasOptions=v.items.length>0||p,t.hasOptions?(v.items.length>0?(r=x&&t.getOption(x),r&&r.length?q=r:"single"===t.settings.mode&&t.items.length&&(q=t.getOption(t.items[0])),q&&q.length||(q=s&&!t.settings.addPrecedence?t.getAdjacentOption(s,1):w.find("[data-selectable]:first"))):q=s,t.setActiveOption(q),b&&!t.isOpen&&t.open()):(t.setActiveOption(null),b&&t.isOpen&&t.close())},/**
+		 * Adds an available option. If it already exists,
+		 * nothing will happen. Note: this does not refresh
+		 * the options list dropdown (use `refreshOptions`
+		 * for that).
+		 *
+		 * Usage:
+		 *
+		 *   this.addOption(data)
+		 *
+		 * @param {object} data
+		 */
+addOption:function(b){var c,d,e,f=this;if(a.isArray(b))for(c=0,d=b.length;d>c;c++)f.addOption(b[c]);else e=y(b[f.settings.valueField]),e&&!f.options.hasOwnProperty(e)&&(f.userOptions[e]=!0,f.options[e]=b,f.lastQuery=null,f.trigger("option_add",e,b))},/**
+		 * Registers a new optgroup for options
+		 * to be bucketed into.
+		 *
+		 * @param {string} id
+		 * @param {object} data
+		 */
+addOptionGroup:function(a,b){this.optgroups[a]=b,this.trigger("optgroup_add",a,b)},/**
+		 * Updates an option available for selection. If
+		 * it is visible in the selected items or options
+		 * dropdown, it will be re-rendered automatically.
+		 *
+		 * @param {string} value
+		 * @param {object} data
+		 */
+updateOption:function(b,c){var d,e,f,g,h,i,j=this;
+// sanity checks
+if(b=y(b),f=y(c[j.settings.valueField]),j.options.hasOwnProperty(b)){if(!f)throw new Error("Value must be set in option data");
+// update references
+f!==b&&(delete j.options[b],g=j.items.indexOf(b),-1!==g&&j.items.splice(g,1,f)),j.options[f]=c,
+// invalidate render cache
+h=j.renderCache.item,i=j.renderCache.option,x(h)&&(delete h[b],delete h[f]),x(i)&&(delete i[b],delete i[f]),
+// update the item if it's selected
+-1!==j.items.indexOf(f)&&(d=j.getItem(b),e=a(j.render("item",c)),d.hasClass("active")&&e.addClass("active"),d.replaceWith(e)),
+// update dropdown contents
+j.isOpen&&j.refreshOptions(!1)}},/**
+		 * Removes a single option.
+		 *
+		 * @param {string} value
+		 */
+removeOption:function(a){var b=this;a=y(a),delete b.userOptions[a],delete b.options[a],b.lastQuery=null,b.trigger("option_remove",a),b.removeItem(a)},/**
+		 * Clears all options.
+		 */
+clearOptions:function(){var a=this;a.loadedSearches={},a.userOptions={},a.options=a.sifter.items={},a.lastQuery=null,a.trigger("option_clear"),a.clear()},/**
+		 * Returns the jQuery element of the option
+		 * matching the given value.
+		 *
+		 * @param {string} value
+		 * @returns {object}
+		 */
+getOption:function(a){return this.getElementWithValue(a,this.$dropdown_content.find("[data-selectable]"))},/**
+		 * Returns the jQuery element of the next or
+		 * previous selectable option.
+		 *
+		 * @param {object} $option
+		 * @param {int} direction  can be 1 for next or -1 for previous
+		 * @return {object}
+		 */
+getAdjacentOption:function(b,c){var d=this.$dropdown.find("[data-selectable]"),e=d.index(b)+c;return e>=0&&e<d.length?d.eq(e):a()},/**
+		 * Finds the first element with a "data-value" attribute
+		 * that matches the given value.
+		 *
+		 * @param {mixed} value
+		 * @param {object} $els
+		 * @return {object}
+		 */
+getElementWithValue:function(b,c){if(b=y(b))for(var d=0,e=c.length;e>d;d++)if(c[d].getAttribute("data-value")===b)return a(c[d]);return a()},/**
+		 * Returns the jQuery element of the item
+		 * matching the given value.
+		 *
+		 * @param {string} value
+		 * @returns {object}
+		 */
+getItem:function(a){return this.getElementWithValue(a,this.$control.children())},/**
+		 * "Selects" multiple items at once. Adds them to the list
+		 * at the current caret position.
+		 *
+		 * @param {string} value
+		 */
+addItems:function(b){for(var c=a.isArray(b)?b:[b],d=0,e=c.length;e>d;d++)this.isPending=e-1>d,this.addItem(c[d])},/**
+		 * "Selects" an item. Adds it to the list
+		 * at the current caret position.
+		 *
+		 * @param {string} value
+		 */
+addItem:function(b){F(this,["change"],function(){var c,d,e,f,g=this,h=g.settings.mode;
+// update menu / remove the option (if this is not one item being added as part of series)
+// hide the menu if the maximum number of items have been selected or no options are left
+return b=y(b),-1!==g.items.indexOf(b)?void("single"===h&&g.close()):void(g.options.hasOwnProperty(b)&&("single"===h&&g.clear(),"multi"===h&&g.isFull()||(c=a(g.render("item",g.options[b])),g.items.splice(g.caretPos,0,b),g.insertAtCaret(c),g.refreshState(),g.isSetup&&(e=g.$dropdown_content.find("[data-selectable]"),this.isPending||(d=g.getOption(b),f=g.getAdjacentOption(d,1).attr("data-value"),g.refreshOptions(g.isFocused&&"single"!==h),f&&g.setActiveOption(g.getOption(f))),!e.length||null!==g.settings.maxItems&&g.items.length>=g.settings.maxItems?g.close():g.positionDropdown(),g.updatePlaceholder(),g.trigger("item_add",b,c),g.updateOriginalInput()))))})},/**
+		 * Removes the selected item matching
+		 * the provided value.
+		 *
+		 * @param {string} value
+		 */
+removeItem:function(a){var b,c,d,e=this;b="object"==typeof a?a:e.getItem(a),a=y(b.attr("data-value")),c=e.items.indexOf(a),-1!==c&&(b.remove(),b.hasClass("active")&&(d=e.$activeItems.indexOf(b[0]),e.$activeItems.splice(d,1)),e.items.splice(c,1),e.lastQuery=null,!e.settings.persist&&e.userOptions.hasOwnProperty(a)&&e.removeOption(a),c<e.caretPos&&e.setCaret(e.caretPos-1),e.refreshState(),e.updatePlaceholder(),e.updateOriginalInput(),e.positionDropdown(),e.trigger("item_remove",a))},/**
+		 * Invokes the `create` method provided in the
+		 * selectize options that should provide the data
+		 * for the new item, given the user input.
+		 *
+		 * Once this completes, it will be added
+		 * to the item list.
+		 *
+		 * @return {boolean}
+		 */
+createItem:function(b){var c=this,d=a.trim(c.$control_input.val()||""),e=c.caretPos;if(!d.length)return!1;c.lock(),"undefined"==typeof b&&(b=!0);var f="function"==typeof c.settings.create?this.settings.create:function(a){var b={};return b[c.settings.labelField]=a,b[c.settings.valueField]=a,b},g=D(function(a){if(c.unlock(),a&&"object"==typeof a){var d=y(a[c.settings.valueField]);d&&(c.setTextboxValue(""),c.addOption(a),c.setCaret(e),c.addItem(d),c.refreshOptions(b&&"single"!==c.settings.mode))}}),h=f.apply(this,[d,g]);return"undefined"!=typeof h&&g(h),!0},/**
+		 * Re-renders the selected item lists.
+		 */
+refreshItems:function(){if(this.lastQuery=null,this.isSetup)for(var a=0;a<this.items.length;a++)this.addItem(this.items);this.refreshState(),this.updateOriginalInput()},/**
+		 * Updates all state-dependent attributes
+		 * and CSS classes.
+		 */
+refreshState:function(){var a=this,b=a.isRequired&&!a.items.length;b||(a.isInvalid=!1),a.$control_input.prop("required",b),a.refreshClasses()},/**
+		 * Updates all state-dependent CSS classes.
+		 */
+refreshClasses:function(){var b=this,c=b.isFull(),d=b.isLocked;b.$wrapper.toggleClass("rtl",b.rtl),b.$control.toggleClass("focus",b.isFocused).toggleClass("disabled",b.isDisabled).toggleClass("required",b.isRequired).toggleClass("invalid",b.isInvalid).toggleClass("locked",d).toggleClass("full",c).toggleClass("not-full",!c).toggleClass("input-active",b.isFocused&&!b.isInputHidden).toggleClass("dropdown-active",b.isOpen).toggleClass("has-options",!a.isEmptyObject(b.options)).toggleClass("has-items",b.items.length>0),b.$control_input.data("grow",!c&&!d)},/**
+		 * Determines whether or not more items can be added
+		 * to the control without exceeding the user-defined maximum.
+		 *
+		 * @returns {boolean}
+		 */
+isFull:function(){return null!==this.settings.maxItems&&this.items.length>=this.settings.maxItems},/**
+		 * Refreshes the original <select> or <input>
+		 * element to reflect the current state.
+		 */
+updateOriginalInput:function(){var a,b,c,d=this;if("select"===d.$input[0].tagName.toLowerCase()){for(c=[],a=0,b=d.items.length;b>a;a++)c.push('<option value="'+z(d.items[a])+'" selected="selected"></option>');c.length||this.$input.attr("multiple")||c.push('<option value="" selected="selected"></option>'),d.$input.html(c.join(""))}else d.$input.val(d.getValue());d.isSetup&&d.trigger("change",d.$input.val())},/**
+		 * Shows/hide the input placeholder depending
+		 * on if there items in the list already.
+		 */
+updatePlaceholder:function(){if(this.settings.placeholder){var a=this.$control_input;this.items.length?a.removeAttr("placeholder"):a.attr("placeholder",this.settings.placeholder),a.triggerHandler("update")}},/**
+		 * Shows the autocomplete dropdown containing
+		 * the available options.
+		 */
+open:function(){var a=this;a.isLocked||a.isOpen||"multi"===a.settings.mode&&a.isFull()||(a.focus(),a.isOpen=!0,a.refreshState(),a.$dropdown.css({visibility:"hidden",display:"block"}),a.positionDropdown(),a.$dropdown.css({visibility:"visible"}),a.trigger("dropdown_open",a.$dropdown))},/**
+		 * Closes the autocomplete dropdown menu.
+		 */
+close:function(){var a=this,b=a.isOpen;"single"===a.settings.mode&&a.items.length&&a.hideInput(),a.isOpen=!1,a.$dropdown.hide(),a.setActiveOption(null),a.refreshState(),b&&a.trigger("dropdown_close",a.$dropdown)},/**
+		 * Calculates and applies the appropriate
+		 * position of the dropdown.
+		 */
+positionDropdown:function(){var a=this.$control,b="body"===this.settings.dropdownParent?a.offset():a.position();b.top+=a.outerHeight(!0),this.$dropdown.css({width:a.outerWidth(),top:b.top,left:b.left})},/**
+		 * Resets / clears all selected items
+		 * from the control.
+		 */
+clear:function(){var a=this;a.items.length&&(a.$control.children(":not(input)").remove(),a.items=[],a.setCaret(0),a.updatePlaceholder(),a.updateOriginalInput(),a.refreshState(),a.showInput(),a.trigger("clear"))},/**
+		 * A helper method for inserting an element
+		 * at the current caret position.
+		 *
+		 * @param {object} $el
+		 */
+insertAtCaret:function(b){var c=Math.min(this.caretPos,this.items.length);0===c?this.$control.prepend(b):a(this.$control[0].childNodes[c]).before(b),this.setCaret(c+1)},/**
+		 * Removes the current selected item(s).
+		 *
+		 * @param {object} e (optional)
+		 * @returns {boolean}
+		 */
+deleteSelection:function(b){var c,d,e,f,g,h,i,j,k,l=this;if(e=b&&b.keyCode===p?-1:1,f=H(l.$control_input[0]),l.$activeOption&&!l.settings.hideSelected&&(i=l.getAdjacentOption(l.$activeOption,-1).attr("data-value")),g=[],l.$activeItems.length){for(k=l.$control.children(".active:"+(e>0?"last":"first")),h=l.$control.children(":not(input)").index(k),e>0&&h++,c=0,d=l.$activeItems.length;d>c;c++)g.push(a(l.$activeItems[c]).attr("data-value"));b&&(b.preventDefault(),b.stopPropagation())}else(l.isFocused||"single"===l.settings.mode)&&l.items.length&&(0>e&&0===f.start&&0===f.length?g.push(l.items[l.caretPos-1]):e>0&&f.start===l.$control_input.val().length&&g.push(l.items[l.caretPos]));
+// allow the callback to abort
+if(!g.length||"function"==typeof l.settings.onDelete&&l.settings.onDelete.apply(l,[g])===!1)return!1;for(
+// perform removal
+"undefined"!=typeof h&&l.setCaret(h);g.length;)l.removeItem(g.pop());
+// select previous option
+return l.showInput(),l.positionDropdown(),l.refreshOptions(!0),i&&(j=l.getOption(i),j.length&&l.setActiveOption(j)),!0},/**
+		 * Selects the previous / next item (depending
+		 * on the `direction` argument).
+		 *
+		 * > 0 - right
+		 * < 0 - left
+		 *
+		 * @param {int} direction
+		 * @param {object} e (optional)
+		 */
+advanceSelection:function(a,b){var c,d,e,f,g,h,i=this;0!==a&&(i.rtl&&(a*=-1),c=a>0?"last":"first",d=H(i.$control_input[0]),i.isFocused&&!i.isInputHidden?(f=i.$control_input.val().length,g=0>a?0===d.start&&0===d.length:d.start===f,g&&!f&&i.advanceCaret(a,b)):(h=i.$control.children(".active:"+c),h.length&&(e=i.$control.children(":not(input)").index(h),i.setActiveItem(null),i.setCaret(a>0?e+1:e))))},/**
+		 * Moves the caret left / right.
+		 *
+		 * @param {int} direction
+		 * @param {object} e (optional)
+		 */
+advanceCaret:function(a,b){var c,d,e=this;0!==a&&(c=a>0?"next":"prev",e.isShiftDown?(d=e.$control_input[c](),d.length&&(e.hideInput(),e.setActiveItem(d),b&&b.preventDefault())):e.setCaret(e.caretPos+a))},/**
+		 * Moves the caret to the specified index.
+		 *
+		 * @param {int} i
+		 */
+setCaret:function(b){var c=this;b="single"===c.settings.mode?c.items.length:Math.max(0,Math.min(c.items.length,b));
+// the input must be moved by leaving it in place and moving the
+// siblings, due to the fact that focus cannot be restored once lost
+// on mobile webkit devices
+var d,e,f,g;for(f=c.$control.children(":not(input)"),d=0,e=f.length;e>d;d++)g=a(f[d]).detach(),b>d?c.$control_input.before(g):c.$control.append(g);c.caretPos=b},/**
+		 * Disables user input on the control. Used while
+		 * items are being asynchronously created.
+		 */
+lock:function(){this.close(),this.isLocked=!0,this.refreshState()},/**
+		 * Re-enables user input on the control.
+		 */
+unlock:function(){this.isLocked=!1,this.refreshState()},/**
+		 * Disables user input on the control completely.
+		 * While disabled, it cannot receive focus.
+		 */
+disable:function(){var a=this;a.$input.prop("disabled",!0),a.isDisabled=!0,a.lock()},/**
+		 * Enables the control so that it can respond
+		 * to focus and user input.
+		 */
+enable:function(){var a=this;a.$input.prop("disabled",!1),a.isDisabled=!1,a.unlock()},/**
+		 * Completely destroys the control and
+		 * unbinds all event listeners so that it can
+		 * be garbage collected.
+		 */
+destroy:function(){var b=this,c=b.eventNS,d=b.revertSettings;b.trigger("destroy"),b.off(),b.$wrapper.remove(),b.$dropdown.remove(),b.$input.html("").append(d.$children).removeAttr("tabindex").attr({tabindex:d.tabindex}).show(),a(window).off(c),a(document).off(c),a(document.body).off(c),delete b.$input[0].selectize},/**
+		 * A helper method for rendering "item" and
+		 * "option" templates, given the data.
+		 *
+		 * @param {string} templateName
+		 * @param {object} data
+		 * @returns {string}
+		 */
+render:function(a,b){var c,d,e="",f=!1,g=this,h=/^[\t ]*<([a-z][a-z0-9\-_]*(?:\:[a-z][a-z0-9\-_]*)?)/i;
+// pull markup from cache if it exists
+// pull markup from cache if it exists
+// render markup
+// add mandatory attributes
+// update cache
+return("option"===a||"item"===a)&&(c=y(b[g.settings.valueField]),f=!!c),f&&(x(g.renderCache[a])||(g.renderCache[a]={}),g.renderCache[a].hasOwnProperty(c))?g.renderCache[a][c]:(e=g.settings.render[a].apply(this,[b,z]),("option"===a||"option_create"===a)&&(e=e.replace(h,"<$1 data-selectable")),"optgroup"===a&&(d=b[g.settings.optgroupValueField]||"",e=e.replace(h,'<$1 data-group="'+A(z(d))+'"')),("option"===a||"item"===a)&&(e=e.replace(h,'<$1 data-value="'+A(z(c||""))+'"')),f&&(g.renderCache[a][c]=e),e)}}),L.count=0,L.defaults={plugins:[],delimiter:",",persist:!0,diacritics:!0,create:!1,createOnBlur:!1,highlight:!0,openOnFocus:!0,maxOptions:1e3,maxItems:null,hideSelected:null,addPrecedence:!1,preload:!1,scrollDuration:60,loadThrottle:300,dataAttr:"data-data",optgroupField:"optgroup",valueField:"value",labelField:"text",optgroupLabelField:"label",optgroupValueField:"value",optgroupOrder:null,sortField:"$order",searchField:["text"],searchConjunction:"and",mode:null,wrapperClass:"selectize-control",inputClass:"selectize-input",dropdownClass:"selectize-dropdown",dropdownContentClass:"selectize-dropdown-content",dropdownParent:null,/*
+		load            : null, // function(query, callback) { ... }
+		score           : null, // function(search) { ... }
+		onInitialize    : null, // function() { ... }
+		onChange        : null, // function(value) { ... }
+		onItemAdd       : null, // function(value, $item) { ... }
+		onItemRemove    : null, // function(value) { ... }
+		onClear         : null, // function() { ... }
+		onOptionAdd     : null, // function(value, data) { ... }
+		onOptionRemove  : null, // function(value) { ... }
+		onOptionClear   : null, // function() { ... }
+		onDropdownOpen  : null, // function($dropdown) { ... }
+		onDropdownClose : null, // function($dropdown) { ... }
+		onType          : null, // function(str) { ... }
+		onDelete        : null, // function(values) { ... }
+		*/
+render:{}},a.fn.selectize=function(b){var c=a.fn.selectize.defaults,d=a.extend({},c,b),e=d.dataAttr,f=d.labelField,g=d.valueField,h=d.optgroupField,i=d.optgroupLabelField,j=d.optgroupValueField,k=function(b,c){var e,h,i,j,k=a.trim(b.val()||"");if(k.length){for(i=k.split(d.delimiter),e=0,h=i.length;h>e;e++)j={},j[f]=i[e],j[g]=i[e],c.options[i[e]]=j;c.items=i}},l=function(b,c){var d,k,l,m,n=0,o=c.options,p=function(a){var b=e&&a.attr(e);return"string"==typeof b&&b.length?JSON.parse(b):null},q=function(b,d){var e,i;if(b=a(b),e=b.attr("value")||"",e.length){
+// if the option already exists, it's probably been
+// duplicated in another optgroup. in this case, push
+// the current group to the "optgroup" property on the
+// existing option so that it's rendered in both places.
+if(o.hasOwnProperty(e))return void(d&&(o[e].optgroup?a.isArray(o[e].optgroup)?o[e].optgroup.push(d):o[e].optgroup=[o[e].optgroup,d]:o[e].optgroup=d));i=p(b)||{},i[f]=i[f]||b.text(),i[g]=i[g]||e,i[h]=i[h]||d,i.$order=++n,o[e]=i,b.is(":selected")&&c.items.push(e)}},r=function(b){var d,e,f,g,h;for(b=a(b),f=b.attr("label"),f&&(g=p(b)||{},g[i]=f,g[j]=f,c.optgroups[f]=g),h=a("option",b),d=0,e=h.length;e>d;d++)q(h[d],f)};for(c.maxItems=b.attr("multiple")?null:1,m=b.children(),d=0,k=m.length;k>d;d++)l=m[d].tagName.toLowerCase(),"optgroup"===l?r(m[d]):"option"===l&&q(m[d])};return this.each(function(){if(!this.selectize){var d,e=a(this),f=this.tagName.toLowerCase(),g={placeholder:e.children('option[value=""]').text()||e.attr("placeholder"),options:{},optgroups:{},items:[]};"select"===f?l(e,g):k(e,g),d=new L(e,a.extend(!0,{},c,g,b)),e.data("selectize",d),e.addClass("selectized")}})},a.fn.selectize.defaults=L.defaults,L.define("drag_drop",function(b){if(!a.fn.sortable)throw new Error('The "drag_drop" plugin requires jQuery UI "sortable".');if("multi"===this.settings.mode){var c=this;c.lock=function(){var a=c.lock;return function(){var b=c.$control.data("sortable");return b&&b.disable(),a.apply(c,arguments)}}(),c.unlock=function(){var a=c.unlock;return function(){var b=c.$control.data("sortable");return b&&b.enable(),a.apply(c,arguments)}}(),c.setup=function(){var b=c.setup;return function(){b.apply(this,arguments);var d=c.$control.sortable({items:"[data-value]",forcePlaceholderSize:!0,disabled:c.isLocked,start:function(a,b){b.placeholder.css("width",b.helper.css("width")),d.css({overflow:"visible"})},stop:function(){d.css({overflow:"hidden"});var b=c.$activeItems?c.$activeItems.slice():null,e=[];d.children("[data-value]").each(function(){e.push(a(this).attr("data-value"))}),c.setValue(e),c.setActiveItem(b)}})}}()}}),L.define("dropdown_header",function(b){var c=this;b=a.extend({title:"Untitled",headerClass:"selectize-dropdown-header",titleRowClass:"selectize-dropdown-header-title",labelClass:"selectize-dropdown-header-label",closeClass:"selectize-dropdown-header-close",html:function(a){return'<div class="'+a.headerClass+'"><div class="'+a.titleRowClass+'"><span class="'+a.labelClass+'">'+a.title+'</span><a href="javascript:void(0)" class="'+a.closeClass+'">&times;</a></div></div>'}},b),c.setup=function(){var d=c.setup;return function(){d.apply(c,arguments),c.$dropdown_header=a(b.html(b)),c.$dropdown.prepend(c.$dropdown_header)}}()}),L.define("optgroup_columns",function(b){var c=this;b=a.extend({equalizeWidth:!0,equalizeHeight:!0},b),this.getAdjacentOption=function(b,c){var d=b.closest("[data-group]").find("[data-selectable]"),e=d.index(b)+c;return e>=0&&e<d.length?d.eq(e):a()},this.onKeyDown=function(){var a=c.onKeyDown;return function(b){var d,e,f,g;return!this.isOpen||b.keyCode!==j&&b.keyCode!==m?a.apply(this,arguments):(c.ignoreHover=!0,g=this.$activeOption.closest("[data-group]"),d=g.find("[data-selectable]").index(this.$activeOption),g=b.keyCode===j?g.prev("[data-group]"):g.next("[data-group]"),f=g.find("[data-selectable]"),e=f.eq(Math.min(f.length-1,d)),void(e.length&&this.setActiveOption(e)))}}();var d=function(){var d,e,f,g,h,i,j;if(j=a("[data-group]",c.$dropdown_content),e=j.length,e&&c.$dropdown_content.width()){if(b.equalizeHeight){for(f=0,d=0;e>d;d++)f=Math.max(f,j.eq(d).height());j.css({height:f})}b.equalizeWidth&&(i=c.$dropdown_content.innerWidth(),g=Math.round(i/e),j.css({width:g}),e>1&&(h=i-g*(e-1),j.eq(e-1).css({width:h})))}};(b.equalizeHeight||b.equalizeWidth)&&(B.after(this,"positionDropdown",d),B.after(this,"refreshOptions",d))}),L.define("remove_button",function(b){if("single"!==this.settings.mode){b=a.extend({label:"&times;",title:"Remove",className:"remove",append:!0},b);var c=this,d='<a href="javascript:void(0)" class="'+b.className+'" tabindex="-1" title="'+z(b.title)+'">'+b.label+"</a>",e=function(a,b){var c=a.search(/(<\/[^>]+>\s*)$/);return a.substring(0,c)+b+a.substring(c)};this.setup=function(){var f=c.setup;return function(){
+// override the item rendering method to add the button to each
+if(b.append){var g=c.settings.render.item;c.settings.render.item=function(a){return e(g.apply(this,arguments),d)}}f.apply(this,arguments),
+// add event listener
+this.$control.on("click","."+b.className,function(b){if(b.preventDefault(),!c.isLocked){var d=a(b.currentTarget).parent();c.setActiveItem(d),c.deleteSelection()&&c.setCaret(c.items.length)}})}}()}}),L.define("restore_on_backspace",function(a){var b=this;a.text=a.text||function(a){return a[this.settings.labelField]},this.onKeyDown=function(c){var d=b.onKeyDown;return function(b){var c,e;return b.keyCode===p&&""===this.$control_input.val()&&!this.$activeItems.length&&(c=this.caretPos-1,c>=0&&c<this.items.length)?(e=this.options[this.items[c]],this.deleteSelection(b)&&(this.setTextboxValue(a.text.apply(this,[e])),this.refreshOptions(!0)),void b.preventDefault()):d.apply(this,arguments)}}()}),L}),//! moment.js
 //! version : 2.9.0
 //! authors : Tim Wood, Iskren Chernev, Moment.js contributors
 //! license : MIT
 //! momentjs.com
-function(a){function b(a,b,c){switch(arguments.length){case 2:return null!=a?a:b;case 3:return null!=a?a:null!=b?b:c;default:throw new Error("Implement me")}}function c(a,b){return Ba.call(a,b)}function d(){return{empty:!1,unusedTokens:[],unusedInput:[],overflow:-2,charsLeftOver:0,nullInput:!1,invalidMonth:null,invalidFormat:!1,userInvalidated:!1,iso:!1}}function e(a){va.suppressDeprecationWarnings===!1&&"undefined"!=typeof console&&console.warn&&console.warn("Deprecation warning: "+a)}function f(a,b){var c=!0;return o(function(){return c&&(e(a),c=!1),b.apply(this,arguments)},b)}function g(a,b){sb[a]||(e(b),sb[a]=!0)}function h(a,b){return function(c){return r(a.call(this,c),b)}}function i(a,b){return function(c){return this.localeData().ordinal(a.call(this,c),b)}}function j(a,b){var c,d,e=12*(b.year()-a.year())+(b.month()-a.month()),f=a.clone().add(e,"months");return 0>b-f?(c=a.clone().add(e-1,"months"),d=(b-f)/(f-c)):(c=a.clone().add(e+1,"months"),d=(b-f)/(c-f)),-(e+d)}function k(a,b,c){var d;return null==c?b:null!=a.meridiemHour?a.meridiemHour(b,c):null!=a.isPM?(d=a.isPM(c),d&&12>b&&(b+=12),d||12!==b||(b=0),b):b}function l(){}function m(a,b){b!==!1&&H(a),p(this,a),this._d=new Date(+a._d),ub===!1&&(ub=!0,va.updateOffset(this),ub=!1)}function n(a){var b=A(a),c=b.year||0,d=b.quarter||0,e=b.month||0,f=b.week||0,g=b.day||0,h=b.hour||0,i=b.minute||0,j=b.second||0,k=b.millisecond||0;this._milliseconds=+k+1e3*j+6e4*i+36e5*h,this._days=+g+7*f,this._months=+e+3*d+12*c,this._data={},this._locale=va.localeData(),this._bubble()}function o(a,b){for(var d in b)c(b,d)&&(a[d]=b[d]);return c(b,"toString")&&(a.toString=b.toString),c(b,"valueOf")&&(a.valueOf=b.valueOf),a}function p(a,b){var c,d,e;if("undefined"!=typeof b._isAMomentObject&&(a._isAMomentObject=b._isAMomentObject),"undefined"!=typeof b._i&&(a._i=b._i),"undefined"!=typeof b._f&&(a._f=b._f),"undefined"!=typeof b._l&&(a._l=b._l),"undefined"!=typeof b._strict&&(a._strict=b._strict),"undefined"!=typeof b._tzm&&(a._tzm=b._tzm),"undefined"!=typeof b._isUTC&&(a._isUTC=b._isUTC),"undefined"!=typeof b._offset&&(a._offset=b._offset),"undefined"!=typeof b._pf&&(a._pf=b._pf),"undefined"!=typeof b._locale&&(a._locale=b._locale),Ka.length>0)for(c in Ka)d=Ka[c],e=b[d],"undefined"!=typeof e&&(a[d]=e);return a}function q(a){return 0>a?Math.ceil(a):Math.floor(a)}function r(a,b,c){for(var d=""+Math.abs(a),e=a>=0;d.length<b;)d="0"+d;return(e?c?"+":"":"-")+d}function s(a,b){var c={milliseconds:0,months:0};return c.months=b.month()-a.month()+12*(b.year()-a.year()),a.clone().add(c.months,"M").isAfter(b)&&--c.months,c.milliseconds=+b-+a.clone().add(c.months,"M"),c}function t(a,b){var c;return b=M(b,a),a.isBefore(b)?c=s(a,b):(c=s(b,a),c.milliseconds=-c.milliseconds,c.months=-c.months),c}function u(a,b){return function(c,d){var e,f;return null===d||isNaN(+d)||(g(b,"moment()."+b+"(period, number) is deprecated. Please use moment()."+b+"(number, period)."),f=c,c=d,d=f),c="string"==typeof c?+c:c,e=va.duration(c,d),v(this,e,a),this}}function v(a,b,c,d){var e=b._milliseconds,f=b._days,g=b._months;d=null==d?!0:d,e&&a._d.setTime(+a._d+e*c),f&&pa(a,"Date",oa(a,"Date")+f*c),g&&na(a,oa(a,"Month")+g*c),d&&va.updateOffset(a,f||g)}function w(a){return"[object Array]"===Object.prototype.toString.call(a)}function x(a){return"[object Date]"===Object.prototype.toString.call(a)||a instanceof Date}function y(a,b,c){var d,e=Math.min(a.length,b.length),f=Math.abs(a.length-b.length),g=0;for(d=0;e>d;d++)(c&&a[d]!==b[d]||!c&&C(a[d])!==C(b[d]))&&g++;return g+f}function z(a){if(a){var b=a.toLowerCase().replace(/(.)s$/,"$1");a=lb[a]||mb[b]||b}return a}function A(a){var b,d,e={};for(d in a)c(a,d)&&(b=z(d),b&&(e[b]=a[d]));return e}function B(b){var c,d;if(0===b.indexOf("week"))c=7,d="day";else{if(0!==b.indexOf("month"))return;c=12,d="month"}va[b]=function(e,f){var g,h,i=va._locale[b],j=[];if("number"==typeof e&&(f=e,e=a),h=function(a){var b=va().utc().set(d,a);return i.call(va._locale,b,e||"")},null!=f)return h(f);for(g=0;c>g;g++)j.push(h(g));return j}}function C(a){var b=+a,c=0;return 0!==b&&isFinite(b)&&(c=b>=0?Math.floor(b):Math.ceil(b)),c}function D(a,b){return new Date(Date.UTC(a,b+1,0)).getUTCDate()}function E(a,b,c){return ja(va([a,11,31+b-c]),b,c).week}function F(a){return G(a)?366:365}function G(a){return a%4===0&&a%100!==0||a%400===0}function H(a){var b;a._a&&-2===a._pf.overflow&&(b=a._a[Da]<0||a._a[Da]>11?Da:a._a[Ea]<1||a._a[Ea]>D(a._a[Ca],a._a[Da])?Ea:a._a[Fa]<0||a._a[Fa]>24||24===a._a[Fa]&&(0!==a._a[Ga]||0!==a._a[Ha]||0!==a._a[Ia])?Fa:a._a[Ga]<0||a._a[Ga]>59?Ga:a._a[Ha]<0||a._a[Ha]>59?Ha:a._a[Ia]<0||a._a[Ia]>999?Ia:-1,a._pf._overflowDayOfYear&&(Ca>b||b>Ea)&&(b=Ea),a._pf.overflow=b)}function I(b){return null==b._isValid&&(b._isValid=!isNaN(b._d.getTime())&&b._pf.overflow<0&&!b._pf.empty&&!b._pf.invalidMonth&&!b._pf.nullInput&&!b._pf.invalidFormat&&!b._pf.userInvalidated,b._strict&&(b._isValid=b._isValid&&0===b._pf.charsLeftOver&&0===b._pf.unusedTokens.length&&b._pf.bigHour===a)),b._isValid}function J(a){return a?a.toLowerCase().replace("_","-"):a}function K(a){for(var b,c,d,e,f=0;f<a.length;){for(e=J(a[f]).split("-"),b=e.length,c=J(a[f+1]),c=c?c.split("-"):null;b>0;){if(d=L(e.slice(0,b).join("-")))return d;if(c&&c.length>=b&&y(e,c,!0)>=b-1)break;b--}f++}return null}function L(a){var b=null;if(!Ja[a]&&La)try{b=va.locale(),require("./locale/"+a),va.locale(b)}catch(c){}return Ja[a]}function M(a,b){var c,d;return b._isUTC?(c=b.clone(),d=(va.isMoment(a)||x(a)?+a:+va(a))-+c,c._d.setTime(+c._d+d),va.updateOffset(c,!1),c):va(a).local()}function N(a){return a.match(/\[[\s\S]/)?a.replace(/^\[|\]$/g,""):a.replace(/\\/g,"")}function O(a){var b,c,d=a.match(Pa);for(b=0,c=d.length;c>b;b++)d[b]=rb[d[b]]?rb[d[b]]:N(d[b]);return function(e){var f="";for(b=0;c>b;b++)f+=d[b]instanceof Function?d[b].call(e,a):d[b];return f}}function P(a,b){return a.isValid()?(b=Q(b,a.localeData()),nb[b]||(nb[b]=O(b)),nb[b](a)):a.localeData().invalidDate()}function Q(a,b){function c(a){return b.longDateFormat(a)||a}var d=5;for(Qa.lastIndex=0;d>=0&&Qa.test(a);)a=a.replace(Qa,c),Qa.lastIndex=0,d-=1;return a}function R(a,b){var c,d=b._strict;switch(a){case"Q":return _a;case"DDDD":return bb;case"YYYY":case"GGGG":case"gggg":return d?cb:Ta;case"Y":case"G":case"g":return eb;case"YYYYYY":case"YYYYY":case"GGGGG":case"ggggg":return d?db:Ua;case"S":if(d)return _a;case"SS":if(d)return ab;case"SSS":if(d)return bb;case"DDD":return Sa;case"MMM":case"MMMM":case"dd":case"ddd":case"dddd":return Wa;case"a":case"A":return b._locale._meridiemParse;case"x":return Za;case"X":return $a;case"Z":case"ZZ":return Xa;case"T":return Ya;case"SSSS":return Va;case"MM":case"DD":case"YY":case"GG":case"gg":case"HH":case"hh":case"mm":case"ss":case"ww":case"WW":return d?ab:Ra;case"M":case"D":case"d":case"H":case"h":case"m":case"s":case"w":case"W":case"e":case"E":return Ra;case"Do":return d?b._locale._ordinalParse:b._locale._ordinalParseLenient;default:return c=new RegExp($(Z(a.replace("\\","")),"i"))}}function S(a){a=a||"";var b=a.match(Xa)||[],c=b[b.length-1]||[],d=(c+"").match(jb)||["-",0,0],e=+(60*d[1])+C(d[2]);return"+"===d[0]?e:-e}function T(a,b,c){var d,e=c._a;switch(a){case"Q":null!=b&&(e[Da]=3*(C(b)-1));break;case"M":case"MM":null!=b&&(e[Da]=C(b)-1);break;case"MMM":case"MMMM":d=c._locale.monthsParse(b,a,c._strict),null!=d?e[Da]=d:c._pf.invalidMonth=b;break;case"D":case"DD":null!=b&&(e[Ea]=C(b));break;case"Do":null!=b&&(e[Ea]=C(parseInt(b.match(/\d{1,2}/)[0],10)));break;case"DDD":case"DDDD":null!=b&&(c._dayOfYear=C(b));break;case"YY":e[Ca]=va.parseTwoDigitYear(b);break;case"YYYY":case"YYYYY":case"YYYYYY":e[Ca]=C(b);break;case"a":case"A":c._meridiem=b;break;case"h":case"hh":c._pf.bigHour=!0;case"H":case"HH":e[Fa]=C(b);break;case"m":case"mm":e[Ga]=C(b);break;case"s":case"ss":e[Ha]=C(b);break;case"S":case"SS":case"SSS":case"SSSS":e[Ia]=C(1e3*("0."+b));break;case"x":c._d=new Date(C(b));break;case"X":c._d=new Date(1e3*parseFloat(b));break;case"Z":case"ZZ":c._useUTC=!0,c._tzm=S(b);break;case"dd":case"ddd":case"dddd":d=c._locale.weekdaysParse(b),null!=d?(c._w=c._w||{},c._w.d=d):c._pf.invalidWeekday=b;break;case"w":case"ww":case"W":case"WW":case"d":case"e":case"E":a=a.substr(0,1);case"gggg":case"GGGG":case"GGGGG":a=a.substr(0,2),b&&(c._w=c._w||{},c._w[a]=C(b));break;case"gg":case"GG":c._w=c._w||{},c._w[a]=va.parseTwoDigitYear(b)}}function U(a){var c,d,e,f,g,h,i;c=a._w,null!=c.GG||null!=c.W||null!=c.E?(g=1,h=4,d=b(c.GG,a._a[Ca],ja(va(),1,4).year),e=b(c.W,1),f=b(c.E,1)):(g=a._locale._week.dow,h=a._locale._week.doy,d=b(c.gg,a._a[Ca],ja(va(),g,h).year),e=b(c.w,1),null!=c.d?(f=c.d,g>f&&++e):f=null!=c.e?c.e+g:g),i=ka(d,e,f,h,g),a._a[Ca]=i.year,a._dayOfYear=i.dayOfYear}function V(a){var c,d,e,f,g=[];if(!a._d){for(e=X(a),a._w&&null==a._a[Ea]&&null==a._a[Da]&&U(a),a._dayOfYear&&(f=b(a._a[Ca],e[Ca]),a._dayOfYear>F(f)&&(a._pf._overflowDayOfYear=!0),d=fa(f,0,a._dayOfYear),a._a[Da]=d.getUTCMonth(),a._a[Ea]=d.getUTCDate()),c=0;3>c&&null==a._a[c];++c)a._a[c]=g[c]=e[c];for(;7>c;c++)a._a[c]=g[c]=null==a._a[c]?2===c?1:0:a._a[c];24===a._a[Fa]&&0===a._a[Ga]&&0===a._a[Ha]&&0===a._a[Ia]&&(a._nextDay=!0,a._a[Fa]=0),a._d=(a._useUTC?fa:ea).apply(null,g),null!=a._tzm&&a._d.setUTCMinutes(a._d.getUTCMinutes()-a._tzm),a._nextDay&&(a._a[Fa]=24)}}function W(a){var b;a._d||(b=A(a._i),a._a=[b.year,b.month,b.day||b.date,b.hour,b.minute,b.second,b.millisecond],V(a))}function X(a){var b=new Date;return a._useUTC?[b.getUTCFullYear(),b.getUTCMonth(),b.getUTCDate()]:[b.getFullYear(),b.getMonth(),b.getDate()]}function Y(b){if(b._f===va.ISO_8601)return void aa(b);b._a=[],b._pf.empty=!0;var c,d,e,f,g,h=""+b._i,i=h.length,j=0;for(e=Q(b._f,b._locale).match(Pa)||[],c=0;c<e.length;c++)f=e[c],d=(h.match(R(f,b))||[])[0],d&&(g=h.substr(0,h.indexOf(d)),g.length>0&&b._pf.unusedInput.push(g),h=h.slice(h.indexOf(d)+d.length),j+=d.length),rb[f]?(d?b._pf.empty=!1:b._pf.unusedTokens.push(f),T(f,d,b)):b._strict&&!d&&b._pf.unusedTokens.push(f);b._pf.charsLeftOver=i-j,h.length>0&&b._pf.unusedInput.push(h),b._pf.bigHour===!0&&b._a[Fa]<=12&&(b._pf.bigHour=a),b._a[Fa]=k(b._locale,b._a[Fa],b._meridiem),V(b),H(b)}function Z(a){return a.replace(/\\(\[)|\\(\])|\[([^\]\[]*)\]|\\(.)/g,function(a,b,c,d,e){return b||c||d||e})}function $(a){return a.replace(/[-\/\\^$*+?.()|[\]{}]/g,"\\$&")}function _(a){var b,c,e,f,g;if(0===a._f.length)return a._pf.invalidFormat=!0,void(a._d=new Date(0/0));for(f=0;f<a._f.length;f++)g=0,b=p({},a),null!=a._useUTC&&(b._useUTC=a._useUTC),b._pf=d(),b._f=a._f[f],Y(b),I(b)&&(g+=b._pf.charsLeftOver,g+=10*b._pf.unusedTokens.length,b._pf.score=g,(null==e||e>g)&&(e=g,c=b));o(a,c||b)}function aa(a){var b,c,d=a._i,e=fb.exec(d);if(e){for(a._pf.iso=!0,b=0,c=hb.length;c>b;b++)if(hb[b][1].exec(d)){a._f=hb[b][0]+(e[6]||" ");break}for(b=0,c=ib.length;c>b;b++)if(ib[b][1].exec(d)){a._f+=ib[b][0];break}d.match(Xa)&&(a._f+="Z"),Y(a)}else a._isValid=!1}function ba(a){aa(a),a._isValid===!1&&(delete a._isValid,va.createFromInputFallback(a))}function ca(a,b){var c,d=[];for(c=0;c<a.length;++c)d.push(b(a[c],c));return d}function da(b){var c,d=b._i;d===a?b._d=new Date:x(d)?b._d=new Date(+d):null!==(c=Ma.exec(d))?b._d=new Date(+c[1]):"string"==typeof d?ba(b):w(d)?(b._a=ca(d.slice(0),function(a){return parseInt(a,10)}),V(b)):"object"==typeof d?W(b):"number"==typeof d?b._d=new Date(d):va.createFromInputFallback(b)}function ea(a,b,c,d,e,f,g){var h=new Date(a,b,c,d,e,f,g);return 1970>a&&h.setFullYear(a),h}function fa(a){var b=new Date(Date.UTC.apply(null,arguments));return 1970>a&&b.setUTCFullYear(a),b}function ga(a,b){if("string"==typeof a)if(isNaN(a)){if(a=b.weekdaysParse(a),"number"!=typeof a)return null}else a=parseInt(a,10);return a}function ha(a,b,c,d,e){return e.relativeTime(b||1,!!c,a,d)}function ia(a,b,c){var d=va.duration(a).abs(),e=Aa(d.as("s")),f=Aa(d.as("m")),g=Aa(d.as("h")),h=Aa(d.as("d")),i=Aa(d.as("M")),j=Aa(d.as("y")),k=e<ob.s&&["s",e]||1===f&&["m"]||f<ob.m&&["mm",f]||1===g&&["h"]||g<ob.h&&["hh",g]||1===h&&["d"]||h<ob.d&&["dd",h]||1===i&&["M"]||i<ob.M&&["MM",i]||1===j&&["y"]||["yy",j];return k[2]=b,k[3]=+a>0,k[4]=c,ha.apply({},k)}function ja(a,b,c){var d,e=c-b,f=c-a.day();return f>e&&(f-=7),e-7>f&&(f+=7),d=va(a).add(f,"d"),{week:Math.ceil(d.dayOfYear()/7),year:d.year()}}function ka(a,b,c,d,e){var f,g,h=fa(a,0,1).getUTCDay();return h=0===h?7:h,c=null!=c?c:e,f=e-h+(h>d?7:0)-(e>h?7:0),g=7*(b-1)+(c-e)+f+1,{year:g>0?a:a-1,dayOfYear:g>0?g:F(a-1)+g}}function la(b){var c,d=b._i,e=b._f;return b._locale=b._locale||va.localeData(b._l),null===d||e===a&&""===d?va.invalid({nullInput:!0}):("string"==typeof d&&(b._i=d=b._locale.preparse(d)),va.isMoment(d)?new m(d,!0):(e?w(e)?_(b):Y(b):da(b),c=new m(b),c._nextDay&&(c.add(1,"d"),c._nextDay=a),c))}function ma(a,b){var c,d;if(1===b.length&&w(b[0])&&(b=b[0]),!b.length)return va();for(c=b[0],d=1;d<b.length;++d)b[d][a](c)&&(c=b[d]);return c}function na(a,b){var c;return"string"==typeof b&&(b=a.localeData().monthsParse(b),"number"!=typeof b)?a:(c=Math.min(a.date(),D(a.year(),b)),a._d["set"+(a._isUTC?"UTC":"")+"Month"](b,c),a)}function oa(a,b){return a._d["get"+(a._isUTC?"UTC":"")+b]()}function pa(a,b,c){return"Month"===b?na(a,c):a._d["set"+(a._isUTC?"UTC":"")+b](c)}function qa(a,b){return function(c){return null!=c?(pa(this,a,c),va.updateOffset(this,b),this):oa(this,a)}}function ra(a){return 400*a/146097}function sa(a){return 146097*a/400}function ta(a){va.duration.fn[a]=function(){return this._data[a]}}function ua(a){"undefined"==typeof ender&&(wa=za.moment,za.moment=a?f("Accessing Moment through the global scope is deprecated, and will be removed in an upcoming release.",va):va)}for(var va,wa,xa,ya="2.9.0",za="undefined"==typeof global||"undefined"!=typeof window&&window!==global.window?this:global,Aa=Math.round,Ba=Object.prototype.hasOwnProperty,Ca=0,Da=1,Ea=2,Fa=3,Ga=4,Ha=5,Ia=6,Ja={},Ka=[],La="undefined"!=typeof module&&module&&module.exports,Ma=/^\/?Date\((\-?\d+)/i,Na=/(\-)?(?:(\d*)\.)?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?)?/,Oa=/^(-)?P(?:(?:([0-9,.]*)Y)?(?:([0-9,.]*)M)?(?:([0-9,.]*)D)?(?:T(?:([0-9,.]*)H)?(?:([0-9,.]*)M)?(?:([0-9,.]*)S)?)?|([0-9,.]*)W)$/,Pa=/(\[[^\[]*\])|(\\)?(Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Q|YYYYYY|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|S{1,4}|x|X|zz?|ZZ?|.)/g,Qa=/(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})/g,Ra=/\d\d?/,Sa=/\d{1,3}/,Ta=/\d{1,4}/,Ua=/[+\-]?\d{1,6}/,Va=/\d+/,Wa=/[0-9]*['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}/i,Xa=/Z|[\+\-]\d\d:?\d\d/gi,Ya=/T/i,Za=/[\+\-]?\d+/,$a=/[\+\-]?\d+(\.\d{1,3})?/,_a=/\d/,ab=/\d\d/,bb=/\d{3}/,cb=/\d{4}/,db=/[+-]?\d{6}/,eb=/[+-]?\d+/,fb=/^\s*(?:[+-]\d{6}|\d{4})-(?:(\d\d-\d\d)|(W\d\d$)|(W\d\d-\d)|(\d\d\d))((T| )(\d\d(:\d\d(:\d\d(\.\d+)?)?)?)?([\+\-]\d\d(?::?\d\d)?|\s*Z)?)?$/,gb="YYYY-MM-DDTHH:mm:ssZ",hb=[["YYYYYY-MM-DD",/[+-]\d{6}-\d{2}-\d{2}/],["YYYY-MM-DD",/\d{4}-\d{2}-\d{2}/],["GGGG-[W]WW-E",/\d{4}-W\d{2}-\d/],["GGGG-[W]WW",/\d{4}-W\d{2}/],["YYYY-DDD",/\d{4}-\d{3}/]],ib=[["HH:mm:ss.SSSS",/(T| )\d\d:\d\d:\d\d\.\d+/],["HH:mm:ss",/(T| )\d\d:\d\d:\d\d/],["HH:mm",/(T| )\d\d:\d\d/],["HH",/(T| )\d\d/]],jb=/([\+\-]|\d\d)/gi,kb=("Date|Hours|Minutes|Seconds|Milliseconds".split("|"),{Milliseconds:1,Seconds:1e3,Minutes:6e4,Hours:36e5,Days:864e5,Months:2592e6,Years:31536e6}),lb={ms:"millisecond",s:"second",m:"minute",h:"hour",d:"day",D:"date",w:"week",W:"isoWeek",M:"month",Q:"quarter",y:"year",DDD:"dayOfYear",e:"weekday",E:"isoWeekday",gg:"weekYear",GG:"isoWeekYear"},mb={dayofyear:"dayOfYear",isoweekday:"isoWeekday",isoweek:"isoWeek",weekyear:"weekYear",isoweekyear:"isoWeekYear"},nb={},ob={s:45,m:45,h:22,d:26,M:11},pb="DDD w W M D d".split(" "),qb="M D H h m s w W".split(" "),rb={M:function(){return this.month()+1},MMM:function(a){return this.localeData().monthsShort(this,a)},MMMM:function(a){return this.localeData().months(this,a)},D:function(){return this.date()},DDD:function(){return this.dayOfYear()},d:function(){return this.day()},dd:function(a){return this.localeData().weekdaysMin(this,a)},ddd:function(a){return this.localeData().weekdaysShort(this,a)},dddd:function(a){return this.localeData().weekdays(this,a)},w:function(){return this.week()},W:function(){return this.isoWeek()},YY:function(){return r(this.year()%100,2)},YYYY:function(){return r(this.year(),4)},YYYYY:function(){return r(this.year(),5)},YYYYYY:function(){var a=this.year(),b=a>=0?"+":"-";return b+r(Math.abs(a),6)},gg:function(){return r(this.weekYear()%100,2)},gggg:function(){return r(this.weekYear(),4)},ggggg:function(){return r(this.weekYear(),5)},GG:function(){return r(this.isoWeekYear()%100,2)},GGGG:function(){return r(this.isoWeekYear(),4)},GGGGG:function(){return r(this.isoWeekYear(),5)},e:function(){return this.weekday()},E:function(){return this.isoWeekday()},a:function(){return this.localeData().meridiem(this.hours(),this.minutes(),!0)},A:function(){return this.localeData().meridiem(this.hours(),this.minutes(),!1)},H:function(){return this.hours()},h:function(){return this.hours()%12||12},m:function(){return this.minutes()},s:function(){return this.seconds()},S:function(){return C(this.milliseconds()/100)},SS:function(){return r(C(this.milliseconds()/10),2)},SSS:function(){return r(this.milliseconds(),3)},SSSS:function(){return r(this.milliseconds(),3)},Z:function(){var a=this.utcOffset(),b="+";return 0>a&&(a=-a,b="-"),b+r(C(a/60),2)+":"+r(C(a)%60,2)},ZZ:function(){var a=this.utcOffset(),b="+";return 0>a&&(a=-a,b="-"),b+r(C(a/60),2)+r(C(a)%60,2)},z:function(){return this.zoneAbbr()},zz:function(){return this.zoneName()},x:function(){return this.valueOf()},X:function(){return this.unix()},Q:function(){return this.quarter()}},sb={},tb=["months","monthsShort","weekdays","weekdaysShort","weekdaysMin"],ub=!1;pb.length;)xa=pb.pop(),rb[xa+"o"]=i(rb[xa],xa);for(;qb.length;)xa=qb.pop(),rb[xa+xa]=h(rb[xa],2);rb.DDDD=h(rb.DDD,3),o(l.prototype,{set:function(a){var b,c;for(c in a)b=a[c],"function"==typeof b?this[c]=b:this["_"+c]=b;this._ordinalParseLenient=new RegExp(this._ordinalParse.source+"|"+/\d{1,2}/.source)},_months:"January_February_March_April_May_June_July_August_September_October_November_December".split("_"),months:function(a){return this._months[a.month()]},_monthsShort:"Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec".split("_"),monthsShort:function(a){return this._monthsShort[a.month()]},monthsParse:function(a,b,c){var d,e,f;for(this._monthsParse||(this._monthsParse=[],this._longMonthsParse=[],this._shortMonthsParse=[]),d=0;12>d;d++){if(e=va.utc([2e3,d]),c&&!this._longMonthsParse[d]&&(this._longMonthsParse[d]=new RegExp("^"+this.months(e,"").replace(".","")+"$","i"),this._shortMonthsParse[d]=new RegExp("^"+this.monthsShort(e,"").replace(".","")+"$","i")),c||this._monthsParse[d]||(f="^"+this.months(e,"")+"|^"+this.monthsShort(e,""),this._monthsParse[d]=new RegExp(f.replace(".",""),"i")),c&&"MMMM"===b&&this._longMonthsParse[d].test(a))return d;if(c&&"MMM"===b&&this._shortMonthsParse[d].test(a))return d;if(!c&&this._monthsParse[d].test(a))return d}},_weekdays:"Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday".split("_"),weekdays:function(a){return this._weekdays[a.day()]},_weekdaysShort:"Sun_Mon_Tue_Wed_Thu_Fri_Sat".split("_"),weekdaysShort:function(a){return this._weekdaysShort[a.day()]},_weekdaysMin:"Su_Mo_Tu_We_Th_Fr_Sa".split("_"),weekdaysMin:function(a){return this._weekdaysMin[a.day()]},weekdaysParse:function(a){var b,c,d;for(this._weekdaysParse||(this._weekdaysParse=[]),b=0;7>b;b++)if(this._weekdaysParse[b]||(c=va([2e3,1]).day(b),d="^"+this.weekdays(c,"")+"|^"+this.weekdaysShort(c,"")+"|^"+this.weekdaysMin(c,""),this._weekdaysParse[b]=new RegExp(d.replace(".",""),"i")),this._weekdaysParse[b].test(a))return b},_longDateFormat:{LTS:"h:mm:ss A",LT:"h:mm A",L:"MM/DD/YYYY",LL:"MMMM D, YYYY",LLL:"MMMM D, YYYY LT",LLLL:"dddd, MMMM D, YYYY LT"},longDateFormat:function(a){var b=this._longDateFormat[a];return!b&&this._longDateFormat[a.toUpperCase()]&&(b=this._longDateFormat[a.toUpperCase()].replace(/MMMM|MM|DD|dddd/g,function(a){return a.slice(1)}),this._longDateFormat[a]=b),b},isPM:function(a){return"p"===(a+"").toLowerCase().charAt(0)},_meridiemParse:/[ap]\.?m?\.?/i,meridiem:function(a,b,c){return a>11?c?"pm":"PM":c?"am":"AM"},_calendar:{sameDay:"[Today at] LT",nextDay:"[Tomorrow at] LT",nextWeek:"dddd [at] LT",lastDay:"[Yesterday at] LT",lastWeek:"[Last] dddd [at] LT",sameElse:"L"},calendar:function(a,b,c){var d=this._calendar[a];return"function"==typeof d?d.apply(b,[c]):d},_relativeTime:{future:"in %s",past:"%s ago",s:"a few seconds",m:"a minute",mm:"%d minutes",h:"an hour",hh:"%d hours",d:"a day",dd:"%d days",M:"a month",MM:"%d months",y:"a year",yy:"%d years"},relativeTime:function(a,b,c,d){var e=this._relativeTime[c];return"function"==typeof e?e(a,b,c,d):e.replace(/%d/i,a)},pastFuture:function(a,b){var c=this._relativeTime[a>0?"future":"past"];return"function"==typeof c?c(b):c.replace(/%s/i,b)},ordinal:function(a){return this._ordinal.replace("%d",a)},_ordinal:"%d",_ordinalParse:/\d{1,2}/,preparse:function(a){return a},postformat:function(a){return a},week:function(a){return ja(a,this._week.dow,this._week.doy).week},_week:{dow:0,doy:6},firstDayOfWeek:function(){return this._week.dow},firstDayOfYear:function(){return this._week.doy},_invalidDate:"Invalid date",invalidDate:function(){return this._invalidDate}}),va=function(b,c,e,f){var g;return"boolean"==typeof e&&(f=e,e=a),g={},g._isAMomentObject=!0,g._i=b,g._f=c,g._l=e,g._strict=f,g._isUTC=!1,g._pf=d(),la(g)},va.suppressDeprecationWarnings=!1,va.createFromInputFallback=f("moment construction falls back to js Date. This is discouraged and will be removed in upcoming major release. Please refer to https://github.com/moment/moment/issues/1407 for more info.",function(a){a._d=new Date(a._i+(a._useUTC?" UTC":""))}),va.min=function(){var a=[].slice.call(arguments,0);return ma("isBefore",a)},va.max=function(){var a=[].slice.call(arguments,0);return ma("isAfter",a)},va.utc=function(b,c,e,f){var g;return"boolean"==typeof e&&(f=e,e=a),g={},g._isAMomentObject=!0,g._useUTC=!0,g._isUTC=!0,g._l=e,g._i=b,g._f=c,g._strict=f,g._pf=d(),la(g).utc()},va.unix=function(a){return va(1e3*a)},va.duration=function(a,b){var d,e,f,g,h=a,i=null;return va.isDuration(a)?h={ms:a._milliseconds,d:a._days,M:a._months}:"number"==typeof a?(h={},b?h[b]=a:h.milliseconds=a):(i=Na.exec(a))?(d="-"===i[1]?-1:1,h={y:0,d:C(i[Ea])*d,h:C(i[Fa])*d,m:C(i[Ga])*d,s:C(i[Ha])*d,ms:C(i[Ia])*d}):(i=Oa.exec(a))?(d="-"===i[1]?-1:1,f=function(a){var b=a&&parseFloat(a.replace(",","."));return(isNaN(b)?0:b)*d},h={y:f(i[2]),M:f(i[3]),d:f(i[4]),h:f(i[5]),m:f(i[6]),s:f(i[7]),w:f(i[8])}):null==h?h={}:"object"==typeof h&&("from"in h||"to"in h)&&(g=t(va(h.from),va(h.to)),h={},h.ms=g.milliseconds,h.M=g.months),e=new n(h),va.isDuration(a)&&c(a,"_locale")&&(e._locale=a._locale),e},va.version=ya,va.defaultFormat=gb,va.ISO_8601=function(){},va.momentProperties=Ka,va.updateOffset=function(){},va.relativeTimeThreshold=function(b,c){return ob[b]===a?!1:c===a?ob[b]:(ob[b]=c,!0)},va.lang=f("moment.lang is deprecated. Use moment.locale instead.",function(a,b){return va.locale(a,b)}),va.locale=function(a,b){var c;return a&&(c="undefined"!=typeof b?va.defineLocale(a,b):va.localeData(a),c&&(va.duration._locale=va._locale=c)),va._locale._abbr},va.defineLocale=function(a,b){return null!==b?(b.abbr=a,Ja[a]||(Ja[a]=new l),Ja[a].set(b),va.locale(a),Ja[a]):(delete Ja[a],null)},va.langData=f("moment.langData is deprecated. Use moment.localeData instead.",function(a){return va.localeData(a)}),va.localeData=function(a){var b;if(a&&a._locale&&a._locale._abbr&&(a=a._locale._abbr),!a)return va._locale;if(!w(a)){if(b=L(a))return b;a=[a]}return K(a)},va.isMoment=function(a){return a instanceof m||null!=a&&c(a,"_isAMomentObject")},va.isDuration=function(a){return a instanceof n};for(xa=tb.length-1;xa>=0;--xa)B(tb[xa]);va.normalizeUnits=function(a){return z(a)},va.invalid=function(a){var b=va.utc(0/0);return null!=a?o(b._pf,a):b._pf.userInvalidated=!0,b},va.parseZone=function(){return va.apply(null,arguments).parseZone()},va.parseTwoDigitYear=function(a){return C(a)+(C(a)>68?1900:2e3)},va.isDate=x,o(va.fn=m.prototype,{clone:function(){return va(this)},valueOf:function(){return+this._d-6e4*(this._offset||0)},unix:function(){return Math.floor(+this/1e3)},toString:function(){return this.clone().locale("en").format("ddd MMM DD YYYY HH:mm:ss [GMT]ZZ")},toDate:function(){return this._offset?new Date(+this):this._d},toISOString:function(){var a=va(this).utc();return 0<a.year()&&a.year()<=9999?"function"==typeof Date.prototype.toISOString?this.toDate().toISOString():P(a,"YYYY-MM-DD[T]HH:mm:ss.SSS[Z]"):P(a,"YYYYYY-MM-DD[T]HH:mm:ss.SSS[Z]")},toArray:function(){var a=this;return[a.year(),a.month(),a.date(),a.hours(),a.minutes(),a.seconds(),a.milliseconds()]},isValid:function(){return I(this)},isDSTShifted:function(){return this._a?this.isValid()&&y(this._a,(this._isUTC?va.utc(this._a):va(this._a)).toArray())>0:!1},parsingFlags:function(){return o({},this._pf)},invalidAt:function(){return this._pf.overflow},utc:function(a){return this.utcOffset(0,a)},local:function(a){return this._isUTC&&(this.utcOffset(0,a),this._isUTC=!1,a&&this.subtract(this._dateUtcOffset(),"m")),this},format:function(a){var b=P(this,a||va.defaultFormat);return this.localeData().postformat(b)},add:u(1,"add"),subtract:u(-1,"subtract"),diff:function(a,b,c){var d,e,f=M(a,this),g=6e4*(f.utcOffset()-this.utcOffset());return b=z(b),"year"===b||"month"===b||"quarter"===b?(e=j(this,f),"quarter"===b?e/=3:"year"===b&&(e/=12)):(d=this-f,e="second"===b?d/1e3:"minute"===b?d/6e4:"hour"===b?d/36e5:"day"===b?(d-g)/864e5:"week"===b?(d-g)/6048e5:d),c?e:q(e)},from:function(a,b){return va.duration({to:this,from:a}).locale(this.locale()).humanize(!b)},fromNow:function(a){return this.from(va(),a)},calendar:function(a){var b=a||va(),c=M(b,this).startOf("day"),d=this.diff(c,"days",!0),e=-6>d?"sameElse":-1>d?"lastWeek":0>d?"lastDay":1>d?"sameDay":2>d?"nextDay":7>d?"nextWeek":"sameElse";return this.format(this.localeData().calendar(e,this,va(b)))},isLeapYear:function(){return G(this.year())},isDST:function(){return this.utcOffset()>this.clone().month(0).utcOffset()||this.utcOffset()>this.clone().month(5).utcOffset()},day:function(a){var b=this._isUTC?this._d.getUTCDay():this._d.getDay();return null!=a?(a=ga(a,this.localeData()),this.add(a-b,"d")):b},month:qa("Month",!0),startOf:function(a){switch(a=z(a)){case"year":this.month(0);case"quarter":case"month":this.date(1);case"week":case"isoWeek":case"day":this.hours(0);case"hour":this.minutes(0);case"minute":this.seconds(0);case"second":this.milliseconds(0)}return"week"===a?this.weekday(0):"isoWeek"===a&&this.isoWeekday(1),"quarter"===a&&this.month(3*Math.floor(this.month()/3)),this},endOf:function(b){return b=z(b),b===a||"millisecond"===b?this:this.startOf(b).add(1,"isoWeek"===b?"week":b).subtract(1,"ms")},isAfter:function(a,b){var c;return b=z("undefined"!=typeof b?b:"millisecond"),"millisecond"===b?(a=va.isMoment(a)?a:va(a),+this>+a):(c=va.isMoment(a)?+a:+va(a),c<+this.clone().startOf(b))},isBefore:function(a,b){var c;return b=z("undefined"!=typeof b?b:"millisecond"),"millisecond"===b?(a=va.isMoment(a)?a:va(a),+a>+this):(c=va.isMoment(a)?+a:+va(a),+this.clone().endOf(b)<c)},isBetween:function(a,b,c){return this.isAfter(a,c)&&this.isBefore(b,c)},isSame:function(a,b){var c;return b=z(b||"millisecond"),"millisecond"===b?(a=va.isMoment(a)?a:va(a),+this===+a):(c=+va(a),+this.clone().startOf(b)<=c&&c<=+this.clone().endOf(b))},min:f("moment().min is deprecated, use moment.min instead. https://github.com/moment/moment/issues/1548",function(a){return a=va.apply(null,arguments),this>a?this:a}),max:f("moment().max is deprecated, use moment.max instead. https://github.com/moment/moment/issues/1548",function(a){return a=va.apply(null,arguments),a>this?this:a}),zone:f("moment().zone is deprecated, use moment().utcOffset instead. https://github.com/moment/moment/issues/1779",function(a,b){return null!=a?("string"!=typeof a&&(a=-a),this.utcOffset(a,b),this):-this.utcOffset()}),utcOffset:function(a,b){var c,d=this._offset||0;return null!=a?("string"==typeof a&&(a=S(a)),Math.abs(a)<16&&(a=60*a),!this._isUTC&&b&&(c=this._dateUtcOffset()),this._offset=a,this._isUTC=!0,null!=c&&this.add(c,"m"),d!==a&&(!b||this._changeInProgress?v(this,va.duration(a-d,"m"),1,!1):this._changeInProgress||(this._changeInProgress=!0,va.updateOffset(this,!0),this._changeInProgress=null)),this):this._isUTC?d:this._dateUtcOffset()},isLocal:function(){return!this._isUTC},isUtcOffset:function(){return this._isUTC},isUtc:function(){return this._isUTC&&0===this._offset},zoneAbbr:function(){return this._isUTC?"UTC":""},zoneName:function(){return this._isUTC?"Coordinated Universal Time":""},parseZone:function(){return this._tzm?this.utcOffset(this._tzm):"string"==typeof this._i&&this.utcOffset(S(this._i)),this},hasAlignedHourOffset:function(a){return a=a?va(a).utcOffset():0,(this.utcOffset()-a)%60===0},daysInMonth:function(){return D(this.year(),this.month())},dayOfYear:function(a){var b=Aa((va(this).startOf("day")-va(this).startOf("year"))/864e5)+1;return null==a?b:this.add(a-b,"d")},quarter:function(a){return null==a?Math.ceil((this.month()+1)/3):this.month(3*(a-1)+this.month()%3)},weekYear:function(a){var b=ja(this,this.localeData()._week.dow,this.localeData()._week.doy).year;return null==a?b:this.add(a-b,"y")},isoWeekYear:function(a){var b=ja(this,1,4).year;return null==a?b:this.add(a-b,"y")},week:function(a){var b=this.localeData().week(this);return null==a?b:this.add(7*(a-b),"d")},isoWeek:function(a){var b=ja(this,1,4).week;return null==a?b:this.add(7*(a-b),"d")},weekday:function(a){var b=(this.day()+7-this.localeData()._week.dow)%7;return null==a?b:this.add(a-b,"d")},isoWeekday:function(a){return null==a?this.day()||7:this.day(this.day()%7?a:a-7)},isoWeeksInYear:function(){return E(this.year(),1,4)},weeksInYear:function(){var a=this.localeData()._week;return E(this.year(),a.dow,a.doy)},get:function(a){return a=z(a),this[a]()},set:function(a,b){var c;if("object"==typeof a)for(c in a)this.set(c,a[c]);else a=z(a),"function"==typeof this[a]&&this[a](b);return this},locale:function(b){var c;return b===a?this._locale._abbr:(c=va.localeData(b),null!=c&&(this._locale=c),this)},lang:f("moment().lang() is deprecated. Instead, use moment().localeData() to get the language configuration. Use moment().locale() to change languages.",function(b){return b===a?this.localeData():this.locale(b)}),localeData:function(){return this._locale},_dateUtcOffset:function(){return 15*-Math.round(this._d.getTimezoneOffset()/15)}}),va.fn.millisecond=va.fn.milliseconds=qa("Milliseconds",!1),va.fn.second=va.fn.seconds=qa("Seconds",!1),va.fn.minute=va.fn.minutes=qa("Minutes",!1),va.fn.hour=va.fn.hours=qa("Hours",!0),va.fn.date=qa("Date",!0),va.fn.dates=f("dates accessor is deprecated. Use date instead.",qa("Date",!0)),va.fn.year=qa("FullYear",!0),va.fn.years=f("years accessor is deprecated. Use year instead.",qa("FullYear",!0)),va.fn.days=va.fn.day,va.fn.months=va.fn.month,va.fn.weeks=va.fn.week,va.fn.isoWeeks=va.fn.isoWeek,va.fn.quarters=va.fn.quarter,va.fn.toJSON=va.fn.toISOString,va.fn.isUTC=va.fn.isUtc,o(va.duration.fn=n.prototype,{_bubble:function(){var a,b,c,d=this._milliseconds,e=this._days,f=this._months,g=this._data,h=0;g.milliseconds=d%1e3,a=q(d/1e3),g.seconds=a%60,b=q(a/60),g.minutes=b%60,c=q(b/60),g.hours=c%24,e+=q(c/24),h=q(ra(e)),e-=q(sa(h)),f+=q(e/30),e%=30,h+=q(f/12),f%=12,g.days=e,g.months=f,g.years=h},abs:function(){return this._milliseconds=Math.abs(this._milliseconds),this._days=Math.abs(this._days),this._months=Math.abs(this._months),this._data.milliseconds=Math.abs(this._data.milliseconds),this._data.seconds=Math.abs(this._data.seconds),this._data.minutes=Math.abs(this._data.minutes),this._data.hours=Math.abs(this._data.hours),this._data.months=Math.abs(this._data.months),this._data.years=Math.abs(this._data.years),this},weeks:function(){return q(this.days()/7)},valueOf:function(){return this._milliseconds+864e5*this._days+this._months%12*2592e6+31536e6*C(this._months/12);
-
+function(a){function b(a,b,c){switch(arguments.length){case 2:return null!=a?a:b;case 3:return null!=a?a:null!=b?b:c;default:throw new Error("Implement me")}}function c(a,b){return Ba.call(a,b)}function d(){return{empty:!1,unusedTokens:[],unusedInput:[],overflow:-2,charsLeftOver:0,nullInput:!1,invalidMonth:null,invalidFormat:!1,userInvalidated:!1,iso:!1}}function e(a){va.suppressDeprecationWarnings===!1&&"undefined"!=typeof console&&console.warn&&console.warn("Deprecation warning: "+a)}function f(a,b){var c=!0;return o(function(){return c&&(e(a),c=!1),b.apply(this,arguments)},b)}function g(a,b){sb[a]||(e(b),sb[a]=!0)}function h(a,b){return function(c){return r(a.call(this,c),b)}}function i(a,b){return function(c){return this.localeData().ordinal(a.call(this,c),b)}}function j(a,b){var c,d,e=12*(b.year()-a.year())+(b.month()-a.month()),f=a.clone().add(e,"months");return 0>b-f?(c=a.clone().add(e-1,"months"),d=(b-f)/(f-c)):(c=a.clone().add(e+1,"months"),d=(b-f)/(c-f)),-(e+d)}function k(a,b,c){var d;return null==c?b:null!=a.meridiemHour?a.meridiemHour(b,c):null!=a.isPM?(d=a.isPM(c),d&&12>b&&(b+=12),d||12!==b||(b=0),b):b}function l(){}function m(a,b){b!==!1&&H(a),p(this,a),this._d=new Date(+a._d),ub===!1&&(ub=!0,va.updateOffset(this),ub=!1)}function n(a){var b=A(a),c=b.year||0,d=b.quarter||0,e=b.month||0,f=b.week||0,g=b.day||0,h=b.hour||0,i=b.minute||0,j=b.second||0,k=b.millisecond||0;this._milliseconds=+k+1e3*j+6e4*i+36e5*h,this._days=+g+7*f,this._months=+e+3*d+12*c,this._data={},this._locale=va.localeData(),this._bubble()}function o(a,b){for(var d in b)c(b,d)&&(a[d]=b[d]);return c(b,"toString")&&(a.toString=b.toString),c(b,"valueOf")&&(a.valueOf=b.valueOf),a}function p(a,b){var c,d,e;if("undefined"!=typeof b._isAMomentObject&&(a._isAMomentObject=b._isAMomentObject),"undefined"!=typeof b._i&&(a._i=b._i),"undefined"!=typeof b._f&&(a._f=b._f),"undefined"!=typeof b._l&&(a._l=b._l),"undefined"!=typeof b._strict&&(a._strict=b._strict),"undefined"!=typeof b._tzm&&(a._tzm=b._tzm),"undefined"!=typeof b._isUTC&&(a._isUTC=b._isUTC),"undefined"!=typeof b._offset&&(a._offset=b._offset),"undefined"!=typeof b._pf&&(a._pf=b._pf),"undefined"!=typeof b._locale&&(a._locale=b._locale),Ka.length>0)for(c in Ka)d=Ka[c],e=b[d],"undefined"!=typeof e&&(a[d]=e);return a}function q(a){return 0>a?Math.ceil(a):Math.floor(a)}function r(a,b,c){for(var d=""+Math.abs(a),e=a>=0;d.length<b;)d="0"+d;return(e?c?"+":"":"-")+d}function s(a,b){var c={milliseconds:0,months:0};return c.months=b.month()-a.month()+12*(b.year()-a.year()),a.clone().add(c.months,"M").isAfter(b)&&--c.months,c.milliseconds=+b-+a.clone().add(c.months,"M"),c}function t(a,b){var c;return b=M(b,a),a.isBefore(b)?c=s(a,b):(c=s(b,a),c.milliseconds=-c.milliseconds,c.months=-c.months),c}function u(a,b){return function(c,d){var e,f;return null===d||isNaN(+d)||(g(b,"moment()."+b+"(period, number) is deprecated. Please use moment()."+b+"(number, period)."),f=c,c=d,d=f),c="string"==typeof c?+c:c,e=va.duration(c,d),v(this,e,a),this}}function v(a,b,c,d){var e=b._milliseconds,f=b._days,g=b._months;d=null==d?!0:d,e&&a._d.setTime(+a._d+e*c),f&&pa(a,"Date",oa(a,"Date")+f*c),g&&na(a,oa(a,"Month")+g*c),d&&va.updateOffset(a,f||g)}function w(a){return"[object Array]"===Object.prototype.toString.call(a)}function x(a){return"[object Date]"===Object.prototype.toString.call(a)||a instanceof Date}function y(a,b,c){var d,e=Math.min(a.length,b.length),f=Math.abs(a.length-b.length),g=0;for(d=0;e>d;d++)(c&&a[d]!==b[d]||!c&&C(a[d])!==C(b[d]))&&g++;return g+f}function z(a){if(a){var b=a.toLowerCase().replace(/(.)s$/,"$1");a=lb[a]||mb[b]||b}return a}function A(a){var b,d,e={};for(d in a)c(a,d)&&(b=z(d),b&&(e[b]=a[d]));return e}function B(b){var c,d;if(0===b.indexOf("week"))c=7,d="day";else{if(0!==b.indexOf("month"))return;c=12,d="month"}va[b]=function(e,f){var g,h,i=va._locale[b],j=[];if("number"==typeof e&&(f=e,e=a),h=function(a){var b=va().utc().set(d,a);return i.call(va._locale,b,e||"")},null!=f)return h(f);for(g=0;c>g;g++)j.push(h(g));return j}}function C(a){var b=+a,c=0;return 0!==b&&isFinite(b)&&(c=b>=0?Math.floor(b):Math.ceil(b)),c}function D(a,b){return new Date(Date.UTC(a,b+1,0)).getUTCDate()}function E(a,b,c){return ja(va([a,11,31+b-c]),b,c).week}function F(a){return G(a)?366:365}function G(a){return a%4===0&&a%100!==0||a%400===0}function H(a){var b;a._a&&-2===a._pf.overflow&&(b=a._a[Da]<0||a._a[Da]>11?Da:a._a[Ea]<1||a._a[Ea]>D(a._a[Ca],a._a[Da])?Ea:a._a[Fa]<0||a._a[Fa]>24||24===a._a[Fa]&&(0!==a._a[Ga]||0!==a._a[Ha]||0!==a._a[Ia])?Fa:a._a[Ga]<0||a._a[Ga]>59?Ga:a._a[Ha]<0||a._a[Ha]>59?Ha:a._a[Ia]<0||a._a[Ia]>999?Ia:-1,a._pf._overflowDayOfYear&&(Ca>b||b>Ea)&&(b=Ea),a._pf.overflow=b)}function I(b){return null==b._isValid&&(b._isValid=!isNaN(b._d.getTime())&&b._pf.overflow<0&&!b._pf.empty&&!b._pf.invalidMonth&&!b._pf.nullInput&&!b._pf.invalidFormat&&!b._pf.userInvalidated,b._strict&&(b._isValid=b._isValid&&0===b._pf.charsLeftOver&&0===b._pf.unusedTokens.length&&b._pf.bigHour===a)),b._isValid}function J(a){return a?a.toLowerCase().replace("_","-"):a}function K(a){for(var b,c,d,e,f=0;f<a.length;){for(e=J(a[f]).split("-"),b=e.length,c=J(a[f+1]),c=c?c.split("-"):null;b>0;){if(d=L(e.slice(0,b).join("-")))return d;if(c&&c.length>=b&&y(e,c,!0)>=b-1)break;b--}f++}return null}function L(a){var b=null;if(!Ja[a]&&La)try{b=va.locale(),require("./locale/"+a),va.locale(b)}catch(c){}return Ja[a]}function M(a,b){var c,d;return b._isUTC?(c=b.clone(),d=(va.isMoment(a)||x(a)?+a:+va(a))-+c,c._d.setTime(+c._d+d),va.updateOffset(c,!1),c):va(a).local()}function N(a){return a.match(/\[[\s\S]/)?a.replace(/^\[|\]$/g,""):a.replace(/\\/g,"")}function O(a){var b,c,d=a.match(Pa);for(b=0,c=d.length;c>b;b++)d[b]=rb[d[b]]?rb[d[b]]:N(d[b]);return function(e){var f="";for(b=0;c>b;b++)f+=d[b]instanceof Function?d[b].call(e,a):d[b];return f}}function P(a,b){return a.isValid()?(b=Q(b,a.localeData()),nb[b]||(nb[b]=O(b)),nb[b](a)):a.localeData().invalidDate()}function Q(a,b){function c(a){return b.longDateFormat(a)||a}var d=5;for(Qa.lastIndex=0;d>=0&&Qa.test(a);)a=a.replace(Qa,c),Qa.lastIndex=0,d-=1;return a}function R(a,b){var c,d=b._strict;switch(a){case"Q":return _a;case"DDDD":return bb;case"YYYY":case"GGGG":case"gggg":return d?cb:Ta;case"Y":case"G":case"g":return eb;case"YYYYYY":case"YYYYY":case"GGGGG":case"ggggg":return d?db:Ua;case"S":if(d)return _a;case"SS":if(d)return ab;case"SSS":if(d)return bb;case"DDD":return Sa;case"MMM":case"MMMM":case"dd":case"ddd":case"dddd":return Wa;case"a":case"A":return b._locale._meridiemParse;case"x":return Za;case"X":return $a;case"Z":case"ZZ":return Xa;case"T":return Ya;case"SSSS":return Va;case"MM":case"DD":case"YY":case"GG":case"gg":case"HH":case"hh":case"mm":case"ss":case"ww":case"WW":return d?ab:Ra;case"M":case"D":case"d":case"H":case"h":case"m":case"s":case"w":case"W":case"e":case"E":return Ra;case"Do":return d?b._locale._ordinalParse:b._locale._ordinalParseLenient;default:return c=new RegExp($(Z(a.replace("\\","")),"i"))}}function S(a){a=a||"";var b=a.match(Xa)||[],c=b[b.length-1]||[],d=(c+"").match(jb)||["-",0,0],e=+(60*d[1])+C(d[2]);return"+"===d[0]?e:-e}function T(a,b,c){var d,e=c._a;switch(a){case"Q":null!=b&&(e[Da]=3*(C(b)-1));break;case"M":case"MM":null!=b&&(e[Da]=C(b)-1);break;case"MMM":case"MMMM":d=c._locale.monthsParse(b,a,c._strict),null!=d?e[Da]=d:c._pf.invalidMonth=b;break;case"D":case"DD":null!=b&&(e[Ea]=C(b));break;case"Do":null!=b&&(e[Ea]=C(parseInt(b.match(/\d{1,2}/)[0],10)));break;case"DDD":case"DDDD":null!=b&&(c._dayOfYear=C(b));break;case"YY":e[Ca]=va.parseTwoDigitYear(b);break;case"YYYY":case"YYYYY":case"YYYYYY":e[Ca]=C(b);break;case"a":case"A":c._meridiem=b;break;case"h":case"hh":c._pf.bigHour=!0;case"H":case"HH":e[Fa]=C(b);break;case"m":case"mm":e[Ga]=C(b);break;case"s":case"ss":e[Ha]=C(b);break;case"S":case"SS":case"SSS":case"SSSS":e[Ia]=C(1e3*("0."+b));break;case"x":c._d=new Date(C(b));break;case"X":c._d=new Date(1e3*parseFloat(b));break;case"Z":case"ZZ":c._useUTC=!0,c._tzm=S(b);break;case"dd":case"ddd":case"dddd":d=c._locale.weekdaysParse(b),null!=d?(c._w=c._w||{},c._w.d=d):c._pf.invalidWeekday=b;break;case"w":case"ww":case"W":case"WW":case"d":case"e":case"E":a=a.substr(0,1);case"gggg":case"GGGG":case"GGGGG":a=a.substr(0,2),b&&(c._w=c._w||{},c._w[a]=C(b));break;case"gg":case"GG":c._w=c._w||{},c._w[a]=va.parseTwoDigitYear(b)}}function U(a){var c,d,e,f,g,h,i;c=a._w,null!=c.GG||null!=c.W||null!=c.E?(g=1,h=4,d=b(c.GG,a._a[Ca],ja(va(),1,4).year),e=b(c.W,1),f=b(c.E,1)):(g=a._locale._week.dow,h=a._locale._week.doy,d=b(c.gg,a._a[Ca],ja(va(),g,h).year),e=b(c.w,1),null!=c.d?(f=c.d,g>f&&++e):f=null!=c.e?c.e+g:g),i=ka(d,e,f,h,g),a._a[Ca]=i.year,a._dayOfYear=i.dayOfYear}function V(a){var c,d,e,f,g=[];if(!a._d){for(e=X(a),a._w&&null==a._a[Ea]&&null==a._a[Da]&&U(a),a._dayOfYear&&(f=b(a._a[Ca],e[Ca]),a._dayOfYear>F(f)&&(a._pf._overflowDayOfYear=!0),d=fa(f,0,a._dayOfYear),a._a[Da]=d.getUTCMonth(),a._a[Ea]=d.getUTCDate()),c=0;3>c&&null==a._a[c];++c)a._a[c]=g[c]=e[c];for(;7>c;c++)a._a[c]=g[c]=null==a._a[c]?2===c?1:0:a._a[c];24===a._a[Fa]&&0===a._a[Ga]&&0===a._a[Ha]&&0===a._a[Ia]&&(a._nextDay=!0,a._a[Fa]=0),a._d=(a._useUTC?fa:ea).apply(null,g),null!=a._tzm&&a._d.setUTCMinutes(a._d.getUTCMinutes()-a._tzm),a._nextDay&&(a._a[Fa]=24)}}function W(a){var b;a._d||(b=A(a._i),a._a=[b.year,b.month,b.day||b.date,b.hour,b.minute,b.second,b.millisecond],V(a))}function X(a){var b=new Date;return a._useUTC?[b.getUTCFullYear(),b.getUTCMonth(),b.getUTCDate()]:[b.getFullYear(),b.getMonth(),b.getDate()]}function Y(b){if(b._f===va.ISO_8601)return void aa(b);b._a=[],b._pf.empty=!0;var c,d,e,f,g,h=""+b._i,i=h.length,j=0;for(e=Q(b._f,b._locale).match(Pa)||[],c=0;c<e.length;c++)f=e[c],d=(h.match(R(f,b))||[])[0],d&&(g=h.substr(0,h.indexOf(d)),g.length>0&&b._pf.unusedInput.push(g),h=h.slice(h.indexOf(d)+d.length),j+=d.length),rb[f]?(d?b._pf.empty=!1:b._pf.unusedTokens.push(f),T(f,d,b)):b._strict&&!d&&b._pf.unusedTokens.push(f);b._pf.charsLeftOver=i-j,h.length>0&&b._pf.unusedInput.push(h),b._pf.bigHour===!0&&b._a[Fa]<=12&&(b._pf.bigHour=a),b._a[Fa]=k(b._locale,b._a[Fa],b._meridiem),V(b),H(b)}function Z(a){return a.replace(/\\(\[)|\\(\])|\[([^\]\[]*)\]|\\(.)/g,function(a,b,c,d,e){return b||c||d||e})}function $(a){return a.replace(/[-\/\\^$*+?.()|[\]{}]/g,"\\$&")}function _(a){var b,c,e,f,g;if(0===a._f.length)return a._pf.invalidFormat=!0,void(a._d=new Date(NaN));for(f=0;f<a._f.length;f++)g=0,b=p({},a),null!=a._useUTC&&(b._useUTC=a._useUTC),b._pf=d(),b._f=a._f[f],Y(b),I(b)&&(g+=b._pf.charsLeftOver,g+=10*b._pf.unusedTokens.length,b._pf.score=g,(null==e||e>g)&&(e=g,c=b));o(a,c||b)}function aa(a){var b,c,d=a._i,e=fb.exec(d);if(e){for(a._pf.iso=!0,b=0,c=hb.length;c>b;b++)if(hb[b][1].exec(d)){a._f=hb[b][0]+(e[6]||" ");break}for(b=0,c=ib.length;c>b;b++)if(ib[b][1].exec(d)){a._f+=ib[b][0];break}d.match(Xa)&&(a._f+="Z"),Y(a)}else a._isValid=!1}function ba(a){aa(a),a._isValid===!1&&(delete a._isValid,va.createFromInputFallback(a))}function ca(a,b){var c,d=[];for(c=0;c<a.length;++c)d.push(b(a[c],c));return d}function da(b){var c,d=b._i;d===a?b._d=new Date:x(d)?b._d=new Date(+d):null!==(c=Ma.exec(d))?b._d=new Date(+c[1]):"string"==typeof d?ba(b):w(d)?(b._a=ca(d.slice(0),function(a){return parseInt(a,10)}),V(b)):"object"==typeof d?W(b):"number"==typeof d?b._d=new Date(d):va.createFromInputFallback(b)}function ea(a,b,c,d,e,f,g){var h=new Date(a,b,c,d,e,f,g);return 1970>a&&h.setFullYear(a),h}function fa(a){var b=new Date(Date.UTC.apply(null,arguments));return 1970>a&&b.setUTCFullYear(a),b}function ga(a,b){if("string"==typeof a)if(isNaN(a)){if(a=b.weekdaysParse(a),"number"!=typeof a)return null}else a=parseInt(a,10);return a}function ha(a,b,c,d,e){return e.relativeTime(b||1,!!c,a,d)}function ia(a,b,c){var d=va.duration(a).abs(),e=Aa(d.as("s")),f=Aa(d.as("m")),g=Aa(d.as("h")),h=Aa(d.as("d")),i=Aa(d.as("M")),j=Aa(d.as("y")),k=e<ob.s&&["s",e]||1===f&&["m"]||f<ob.m&&["mm",f]||1===g&&["h"]||g<ob.h&&["hh",g]||1===h&&["d"]||h<ob.d&&["dd",h]||1===i&&["M"]||i<ob.M&&["MM",i]||1===j&&["y"]||["yy",j];return k[2]=b,k[3]=+a>0,k[4]=c,ha.apply({},k)}function ja(a,b,c){var d,e=c-b,f=c-a.day();return f>e&&(f-=7),e-7>f&&(f+=7),d=va(a).add(f,"d"),{week:Math.ceil(d.dayOfYear()/7),year:d.year()}}function ka(a,b,c,d,e){var f,g,h=fa(a,0,1).getUTCDay();return h=0===h?7:h,c=null!=c?c:e,f=e-h+(h>d?7:0)-(e>h?7:0),g=7*(b-1)+(c-e)+f+1,{year:g>0?a:a-1,dayOfYear:g>0?g:F(a-1)+g}}function la(b){var c,d=b._i,e=b._f;return b._locale=b._locale||va.localeData(b._l),null===d||e===a&&""===d?va.invalid({nullInput:!0}):("string"==typeof d&&(b._i=d=b._locale.preparse(d)),va.isMoment(d)?new m(d,!0):(e?w(e)?_(b):Y(b):da(b),c=new m(b),c._nextDay&&(c.add(1,"d"),c._nextDay=a),c))}function ma(a,b){var c,d;if(1===b.length&&w(b[0])&&(b=b[0]),!b.length)return va();for(c=b[0],d=1;d<b.length;++d)b[d][a](c)&&(c=b[d]);return c}function na(a,b){var c;return"string"==typeof b&&(b=a.localeData().monthsParse(b),"number"!=typeof b)?a:(c=Math.min(a.date(),D(a.year(),b)),a._d["set"+(a._isUTC?"UTC":"")+"Month"](b,c),a)}function oa(a,b){return a._d["get"+(a._isUTC?"UTC":"")+b]()}function pa(a,b,c){return"Month"===b?na(a,c):a._d["set"+(a._isUTC?"UTC":"")+b](c)}function qa(a,b){return function(c){return null!=c?(pa(this,a,c),va.updateOffset(this,b),this):oa(this,a)}}function ra(a){return 400*a/146097}function sa(a){return 146097*a/400}function ta(a){va.duration.fn[a]=function(){return this._data[a]}}function ua(a){"undefined"==typeof ender&&(wa=za.moment,za.moment=a?f("Accessing Moment through the global scope is deprecated, and will be removed in an upcoming release.",va):va)}for(var va,wa,xa,ya="2.9.0",za="undefined"==typeof global||"undefined"!=typeof window&&window!==global.window?this:global,Aa=Math.round,Ba=Object.prototype.hasOwnProperty,Ca=0,Da=1,Ea=2,Fa=3,Ga=4,Ha=5,Ia=6,Ja={},Ka=[],La="undefined"!=typeof module&&module&&module.exports,Ma=/^\/?Date\((\-?\d+)/i,Na=/(\-)?(?:(\d*)\.)?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?)?/,Oa=/^(-)?P(?:(?:([0-9,.]*)Y)?(?:([0-9,.]*)M)?(?:([0-9,.]*)D)?(?:T(?:([0-9,.]*)H)?(?:([0-9,.]*)M)?(?:([0-9,.]*)S)?)?|([0-9,.]*)W)$/,Pa=/(\[[^\[]*\])|(\\)?(Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Q|YYYYYY|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|S{1,4}|x|X|zz?|ZZ?|.)/g,Qa=/(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})/g,Ra=/\d\d?/,Sa=/\d{1,3}/,Ta=/\d{1,4}/,Ua=/[+\-]?\d{1,6}/,Va=/\d+/,Wa=/[0-9]*['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}/i,Xa=/Z|[\+\-]\d\d:?\d\d/gi,Ya=/T/i,Za=/[\+\-]?\d+/,$a=/[\+\-]?\d+(\.\d{1,3})?/,_a=/\d/,ab=/\d\d/,bb=/\d{3}/,cb=/\d{4}/,db=/[+-]?\d{6}/,eb=/[+-]?\d+/,fb=/^\s*(?:[+-]\d{6}|\d{4})-(?:(\d\d-\d\d)|(W\d\d$)|(W\d\d-\d)|(\d\d\d))((T| )(\d\d(:\d\d(:\d\d(\.\d+)?)?)?)?([\+\-]\d\d(?::?\d\d)?|\s*Z)?)?$/,gb="YYYY-MM-DDTHH:mm:ssZ",hb=[["YYYYYY-MM-DD",/[+-]\d{6}-\d{2}-\d{2}/],["YYYY-MM-DD",/\d{4}-\d{2}-\d{2}/],["GGGG-[W]WW-E",/\d{4}-W\d{2}-\d/],["GGGG-[W]WW",/\d{4}-W\d{2}/],["YYYY-DDD",/\d{4}-\d{3}/]],ib=[["HH:mm:ss.SSSS",/(T| )\d\d:\d\d:\d\d\.\d+/],["HH:mm:ss",/(T| )\d\d:\d\d:\d\d/],["HH:mm",/(T| )\d\d:\d\d/],["HH",/(T| )\d\d/]],jb=/([\+\-]|\d\d)/gi,kb=("Date|Hours|Minutes|Seconds|Milliseconds".split("|"),{Milliseconds:1,Seconds:1e3,Minutes:6e4,Hours:36e5,Days:864e5,Months:2592e6,Years:31536e6}),lb={ms:"millisecond",s:"second",m:"minute",h:"hour",d:"day",D:"date",w:"week",W:"isoWeek",M:"month",Q:"quarter",y:"year",DDD:"dayOfYear",e:"weekday",E:"isoWeekday",gg:"weekYear",GG:"isoWeekYear"},mb={dayofyear:"dayOfYear",isoweekday:"isoWeekday",isoweek:"isoWeek",weekyear:"weekYear",isoweekyear:"isoWeekYear"},nb={},ob={s:45,m:45,h:22,d:26,M:11},pb="DDD w W M D d".split(" "),qb="M D H h m s w W".split(" "),rb={M:function(){return this.month()+1},MMM:function(a){return this.localeData().monthsShort(this,a)},MMMM:function(a){return this.localeData().months(this,a)},D:function(){return this.date()},DDD:function(){return this.dayOfYear()},d:function(){return this.day()},dd:function(a){return this.localeData().weekdaysMin(this,a)},ddd:function(a){return this.localeData().weekdaysShort(this,a)},dddd:function(a){return this.localeData().weekdays(this,a)},w:function(){return this.week()},W:function(){return this.isoWeek()},YY:function(){return r(this.year()%100,2)},YYYY:function(){return r(this.year(),4)},YYYYY:function(){return r(this.year(),5)},YYYYYY:function(){var a=this.year(),b=a>=0?"+":"-";return b+r(Math.abs(a),6)},gg:function(){return r(this.weekYear()%100,2)},gggg:function(){return r(this.weekYear(),4)},ggggg:function(){return r(this.weekYear(),5)},GG:function(){return r(this.isoWeekYear()%100,2)},GGGG:function(){return r(this.isoWeekYear(),4)},GGGGG:function(){return r(this.isoWeekYear(),5)},e:function(){return this.weekday()},E:function(){return this.isoWeekday()},a:function(){return this.localeData().meridiem(this.hours(),this.minutes(),!0)},A:function(){return this.localeData().meridiem(this.hours(),this.minutes(),!1)},H:function(){return this.hours()},h:function(){return this.hours()%12||12},m:function(){return this.minutes()},s:function(){return this.seconds()},S:function(){return C(this.milliseconds()/100)},SS:function(){return r(C(this.milliseconds()/10),2)},SSS:function(){return r(this.milliseconds(),3)},SSSS:function(){return r(this.milliseconds(),3)},Z:function(){var a=this.utcOffset(),b="+";return 0>a&&(a=-a,b="-"),b+r(C(a/60),2)+":"+r(C(a)%60,2)},ZZ:function(){var a=this.utcOffset(),b="+";return 0>a&&(a=-a,b="-"),b+r(C(a/60),2)+r(C(a)%60,2)},z:function(){return this.zoneAbbr()},zz:function(){return this.zoneName()},x:function(){return this.valueOf()},X:function(){return this.unix()},Q:function(){return this.quarter()}},sb={},tb=["months","monthsShort","weekdays","weekdaysShort","weekdaysMin"],ub=!1;pb.length;)xa=pb.pop(),rb[xa+"o"]=i(rb[xa],xa);for(;qb.length;)xa=qb.pop(),rb[xa+xa]=h(rb[xa],2);rb.DDDD=h(rb.DDD,3),o(l.prototype,{set:function(a){var b,c;for(c in a)b=a[c],"function"==typeof b?this[c]=b:this["_"+c]=b;this._ordinalParseLenient=new RegExp(this._ordinalParse.source+"|"+/\d{1,2}/.source)},_months:"January_February_March_April_May_June_July_August_September_October_November_December".split("_"),months:function(a){return this._months[a.month()]},_monthsShort:"Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec".split("_"),monthsShort:function(a){return this._monthsShort[a.month()]},monthsParse:function(a,b,c){var d,e,f;for(this._monthsParse||(this._monthsParse=[],this._longMonthsParse=[],this._shortMonthsParse=[]),d=0;12>d;d++){if(e=va.utc([2e3,d]),c&&!this._longMonthsParse[d]&&(this._longMonthsParse[d]=new RegExp("^"+this.months(e,"").replace(".","")+"$","i"),this._shortMonthsParse[d]=new RegExp("^"+this.monthsShort(e,"").replace(".","")+"$","i")),c||this._monthsParse[d]||(f="^"+this.months(e,"")+"|^"+this.monthsShort(e,""),this._monthsParse[d]=new RegExp(f.replace(".",""),"i")),c&&"MMMM"===b&&this._longMonthsParse[d].test(a))return d;if(c&&"MMM"===b&&this._shortMonthsParse[d].test(a))return d;if(!c&&this._monthsParse[d].test(a))return d}},_weekdays:"Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday".split("_"),weekdays:function(a){return this._weekdays[a.day()]},_weekdaysShort:"Sun_Mon_Tue_Wed_Thu_Fri_Sat".split("_"),weekdaysShort:function(a){return this._weekdaysShort[a.day()]},_weekdaysMin:"Su_Mo_Tu_We_Th_Fr_Sa".split("_"),weekdaysMin:function(a){return this._weekdaysMin[a.day()]},weekdaysParse:function(a){var b,c,d;for(this._weekdaysParse||(this._weekdaysParse=[]),b=0;7>b;b++)if(this._weekdaysParse[b]||(c=va([2e3,1]).day(b),d="^"+this.weekdays(c,"")+"|^"+this.weekdaysShort(c,"")+"|^"+this.weekdaysMin(c,""),this._weekdaysParse[b]=new RegExp(d.replace(".",""),"i")),this._weekdaysParse[b].test(a))return b},_longDateFormat:{LTS:"h:mm:ss A",LT:"h:mm A",L:"MM/DD/YYYY",LL:"MMMM D, YYYY",LLL:"MMMM D, YYYY LT",LLLL:"dddd, MMMM D, YYYY LT"},longDateFormat:function(a){var b=this._longDateFormat[a];return!b&&this._longDateFormat[a.toUpperCase()]&&(b=this._longDateFormat[a.toUpperCase()].replace(/MMMM|MM|DD|dddd/g,function(a){return a.slice(1)}),this._longDateFormat[a]=b),b},isPM:function(a){return"p"===(a+"").toLowerCase().charAt(0)},_meridiemParse:/[ap]\.?m?\.?/i,meridiem:function(a,b,c){return a>11?c?"pm":"PM":c?"am":"AM"},_calendar:{sameDay:"[Today at] LT",nextDay:"[Tomorrow at] LT",nextWeek:"dddd [at] LT",lastDay:"[Yesterday at] LT",lastWeek:"[Last] dddd [at] LT",sameElse:"L"},calendar:function(a,b,c){var d=this._calendar[a];return"function"==typeof d?d.apply(b,[c]):d},_relativeTime:{future:"in %s",past:"%s ago",s:"a few seconds",m:"a minute",mm:"%d minutes",h:"an hour",hh:"%d hours",d:"a day",dd:"%d days",M:"a month",MM:"%d months",y:"a year",yy:"%d years"},relativeTime:function(a,b,c,d){var e=this._relativeTime[c];return"function"==typeof e?e(a,b,c,d):e.replace(/%d/i,a)},pastFuture:function(a,b){var c=this._relativeTime[a>0?"future":"past"];return"function"==typeof c?c(b):c.replace(/%s/i,b)},ordinal:function(a){return this._ordinal.replace("%d",a)},_ordinal:"%d",_ordinalParse:/\d{1,2}/,preparse:function(a){return a},postformat:function(a){return a},week:function(a){return ja(a,this._week.dow,this._week.doy).week},_week:{dow:0,doy:6},firstDayOfWeek:function(){return this._week.dow},firstDayOfYear:function(){return this._week.doy},_invalidDate:"Invalid date",invalidDate:function(){return this._invalidDate}}),va=function(b,c,e,f){var g;return"boolean"==typeof e&&(f=e,e=a),g={},g._isAMomentObject=!0,g._i=b,g._f=c,g._l=e,g._strict=f,g._isUTC=!1,g._pf=d(),la(g)},va.suppressDeprecationWarnings=!1,va.createFromInputFallback=f("moment construction falls back to js Date. This is discouraged and will be removed in upcoming major release. Please refer to https://github.com/moment/moment/issues/1407 for more info.",function(a){a._d=new Date(a._i+(a._useUTC?" UTC":""))}),va.min=function(){var a=[].slice.call(arguments,0);return ma("isBefore",a)},va.max=function(){var a=[].slice.call(arguments,0);return ma("isAfter",a)},va.utc=function(b,c,e,f){var g;return"boolean"==typeof e&&(f=e,e=a),g={},g._isAMomentObject=!0,g._useUTC=!0,g._isUTC=!0,g._l=e,g._i=b,g._f=c,g._strict=f,g._pf=d(),la(g).utc()},va.unix=function(a){return va(1e3*a)},va.duration=function(a,b){var d,e,f,g,h=a,i=null;return va.isDuration(a)?h={ms:a._milliseconds,d:a._days,M:a._months}:"number"==typeof a?(h={},b?h[b]=a:h.milliseconds=a):(i=Na.exec(a))?(d="-"===i[1]?-1:1,h={y:0,d:C(i[Ea])*d,h:C(i[Fa])*d,m:C(i[Ga])*d,s:C(i[Ha])*d,ms:C(i[Ia])*d}):(i=Oa.exec(a))?(d="-"===i[1]?-1:1,f=function(a){var b=a&&parseFloat(a.replace(",","."));return(isNaN(b)?0:b)*d},h={y:f(i[2]),M:f(i[3]),d:f(i[4]),h:f(i[5]),m:f(i[6]),s:f(i[7]),w:f(i[8])}):null==h?h={}:"object"==typeof h&&("from"in h||"to"in h)&&(g=t(va(h.from),va(h.to)),h={},h.ms=g.milliseconds,h.M=g.months),e=new n(h),va.isDuration(a)&&c(a,"_locale")&&(e._locale=a._locale),e},va.version=ya,va.defaultFormat=gb,va.ISO_8601=function(){},va.momentProperties=Ka,va.updateOffset=function(){},va.relativeTimeThreshold=function(b,c){return ob[b]===a?!1:c===a?ob[b]:(ob[b]=c,!0)},va.lang=f("moment.lang is deprecated. Use moment.locale instead.",function(a,b){return va.locale(a,b)}),va.locale=function(a,b){var c;return a&&(c="undefined"!=typeof b?va.defineLocale(a,b):va.localeData(a),c&&(va.duration._locale=va._locale=c)),va._locale._abbr},va.defineLocale=function(a,b){return null!==b?(b.abbr=a,Ja[a]||(Ja[a]=new l),Ja[a].set(b),va.locale(a),Ja[a]):(delete Ja[a],null)},va.langData=f("moment.langData is deprecated. Use moment.localeData instead.",function(a){return va.localeData(a)}),va.localeData=function(a){var b;if(a&&a._locale&&a._locale._abbr&&(a=a._locale._abbr),!a)return va._locale;if(!w(a)){if(b=L(a))return b;a=[a]}return K(a)},va.isMoment=function(a){return a instanceof m||null!=a&&c(a,"_isAMomentObject")},va.isDuration=function(a){return a instanceof n};for(xa=tb.length-1;xa>=0;--xa)B(tb[xa]);va.normalizeUnits=function(a){return z(a)},va.invalid=function(a){var b=va.utc(NaN);return null!=a?o(b._pf,a):b._pf.userInvalidated=!0,b},va.parseZone=function(){return va.apply(null,arguments).parseZone()},va.parseTwoDigitYear=function(a){return C(a)+(C(a)>68?1900:2e3)},va.isDate=x,o(va.fn=m.prototype,{clone:function(){return va(this)},valueOf:function(){return+this._d-6e4*(this._offset||0)},unix:function(){return Math.floor(+this/1e3)},toString:function(){return this.clone().locale("en").format("ddd MMM DD YYYY HH:mm:ss [GMT]ZZ")},toDate:function(){return this._offset?new Date(+this):this._d},toISOString:function(){var a=va(this).utc();return 0<a.year()&&a.year()<=9999?"function"==typeof Date.prototype.toISOString?this.toDate().toISOString():P(a,"YYYY-MM-DD[T]HH:mm:ss.SSS[Z]"):P(a,"YYYYYY-MM-DD[T]HH:mm:ss.SSS[Z]")},toArray:function(){var a=this;return[a.year(),a.month(),a.date(),a.hours(),a.minutes(),a.seconds(),a.milliseconds()]},isValid:function(){return I(this)},isDSTShifted:function(){return this._a?this.isValid()&&y(this._a,(this._isUTC?va.utc(this._a):va(this._a)).toArray())>0:!1},parsingFlags:function(){return o({},this._pf)},invalidAt:function(){return this._pf.overflow},utc:function(a){return this.utcOffset(0,a)},local:function(a){return this._isUTC&&(this.utcOffset(0,a),this._isUTC=!1,a&&this.subtract(this._dateUtcOffset(),"m")),this},format:function(a){var b=P(this,a||va.defaultFormat);return this.localeData().postformat(b)},add:u(1,"add"),subtract:u(-1,"subtract"),diff:function(a,b,c){var d,e,f=M(a,this),g=6e4*(f.utcOffset()-this.utcOffset());return b=z(b),"year"===b||"month"===b||"quarter"===b?(e=j(this,f),"quarter"===b?e/=3:"year"===b&&(e/=12)):(d=this-f,e="second"===b?d/1e3:"minute"===b?d/6e4:"hour"===b?d/36e5:"day"===b?(d-g)/864e5:"week"===b?(d-g)/6048e5:d),c?e:q(e)},from:function(a,b){return va.duration({to:this,from:a}).locale(this.locale()).humanize(!b)},fromNow:function(a){return this.from(va(),a)},calendar:function(a){var b=a||va(),c=M(b,this).startOf("day"),d=this.diff(c,"days",!0),e=-6>d?"sameElse":-1>d?"lastWeek":0>d?"lastDay":1>d?"sameDay":2>d?"nextDay":7>d?"nextWeek":"sameElse";return this.format(this.localeData().calendar(e,this,va(b)))},isLeapYear:function(){return G(this.year())},isDST:function(){return this.utcOffset()>this.clone().month(0).utcOffset()||this.utcOffset()>this.clone().month(5).utcOffset()},day:function(a){var b=this._isUTC?this._d.getUTCDay():this._d.getDay();return null!=a?(a=ga(a,this.localeData()),this.add(a-b,"d")):b},month:qa("Month",!0),startOf:function(a){switch(a=z(a)){case"year":this.month(0);case"quarter":case"month":this.date(1);case"week":case"isoWeek":case"day":this.hours(0);case"hour":this.minutes(0);case"minute":this.seconds(0);case"second":this.milliseconds(0)}return"week"===a?this.weekday(0):"isoWeek"===a&&this.isoWeekday(1),"quarter"===a&&this.month(3*Math.floor(this.month()/3)),this},endOf:function(b){return b=z(b),b===a||"millisecond"===b?this:this.startOf(b).add(1,"isoWeek"===b?"week":b).subtract(1,"ms")},isAfter:function(a,b){var c;return b=z("undefined"!=typeof b?b:"millisecond"),"millisecond"===b?(a=va.isMoment(a)?a:va(a),+this>+a):(c=va.isMoment(a)?+a:+va(a),c<+this.clone().startOf(b))},isBefore:function(a,b){var c;return b=z("undefined"!=typeof b?b:"millisecond"),"millisecond"===b?(a=va.isMoment(a)?a:va(a),+a>+this):(c=va.isMoment(a)?+a:+va(a),+this.clone().endOf(b)<c)},isBetween:function(a,b,c){return this.isAfter(a,c)&&this.isBefore(b,c)},isSame:function(a,b){var c;return b=z(b||"millisecond"),"millisecond"===b?(a=va.isMoment(a)?a:va(a),+this===+a):(c=+va(a),+this.clone().startOf(b)<=c&&c<=+this.clone().endOf(b))},min:f("moment().min is deprecated, use moment.min instead. https://github.com/moment/moment/issues/1548",function(a){return a=va.apply(null,arguments),this>a?this:a}),max:f("moment().max is deprecated, use moment.max instead. https://github.com/moment/moment/issues/1548",function(a){return a=va.apply(null,arguments),a>this?this:a}),zone:f("moment().zone is deprecated, use moment().utcOffset instead. https://github.com/moment/moment/issues/1779",function(a,b){return null!=a?("string"!=typeof a&&(a=-a),this.utcOffset(a,b),this):-this.utcOffset()}),utcOffset:function(a,b){var c,d=this._offset||0;return null!=a?("string"==typeof a&&(a=S(a)),Math.abs(a)<16&&(a=60*a),!this._isUTC&&b&&(c=this._dateUtcOffset()),this._offset=a,this._isUTC=!0,null!=c&&this.add(c,"m"),d!==a&&(!b||this._changeInProgress?v(this,va.duration(a-d,"m"),1,!1):this._changeInProgress||(this._changeInProgress=!0,va.updateOffset(this,!0),this._changeInProgress=null)),this):this._isUTC?d:this._dateUtcOffset()},isLocal:function(){return!this._isUTC},isUtcOffset:function(){return this._isUTC},isUtc:function(){return this._isUTC&&0===this._offset},zoneAbbr:function(){return this._isUTC?"UTC":""},zoneName:function(){return this._isUTC?"Coordinated Universal Time":""},parseZone:function(){return this._tzm?this.utcOffset(this._tzm):"string"==typeof this._i&&this.utcOffset(S(this._i)),this},hasAlignedHourOffset:function(a){return a=a?va(a).utcOffset():0,(this.utcOffset()-a)%60===0},daysInMonth:function(){return D(this.year(),this.month())},dayOfYear:function(a){var b=Aa((va(this).startOf("day")-va(this).startOf("year"))/864e5)+1;return null==a?b:this.add(a-b,"d")},quarter:function(a){return null==a?Math.ceil((this.month()+1)/3):this.month(3*(a-1)+this.month()%3)},weekYear:function(a){var b=ja(this,this.localeData()._week.dow,this.localeData()._week.doy).year;return null==a?b:this.add(a-b,"y")},isoWeekYear:function(a){var b=ja(this,1,4).year;return null==a?b:this.add(a-b,"y")},week:function(a){var b=this.localeData().week(this);return null==a?b:this.add(7*(a-b),"d")},isoWeek:function(a){var b=ja(this,1,4).week;return null==a?b:this.add(7*(a-b),"d")},weekday:function(a){var b=(this.day()+7-this.localeData()._week.dow)%7;return null==a?b:this.add(a-b,"d")},isoWeekday:function(a){return null==a?this.day()||7:this.day(this.day()%7?a:a-7)},isoWeeksInYear:function(){return E(this.year(),1,4)},weeksInYear:function(){var a=this.localeData()._week;return E(this.year(),a.dow,a.doy)},get:function(a){return a=z(a),this[a]()},set:function(a,b){var c;if("object"==typeof a)for(c in a)this.set(c,a[c]);else a=z(a),"function"==typeof this[a]&&this[a](b);return this},locale:function(b){var c;return b===a?this._locale._abbr:(c=va.localeData(b),null!=c&&(this._locale=c),this)},lang:f("moment().lang() is deprecated. Instead, use moment().localeData() to get the language configuration. Use moment().locale() to change languages.",function(b){return b===a?this.localeData():this.locale(b)}),localeData:function(){return this._locale},_dateUtcOffset:function(){return 15*-Math.round(this._d.getTimezoneOffset()/15)}}),va.fn.millisecond=va.fn.milliseconds=qa("Milliseconds",!1),va.fn.second=va.fn.seconds=qa("Seconds",!1),va.fn.minute=va.fn.minutes=qa("Minutes",!1),va.fn.hour=va.fn.hours=qa("Hours",!0),va.fn.date=qa("Date",!0),va.fn.dates=f("dates accessor is deprecated. Use date instead.",qa("Date",!0)),va.fn.year=qa("FullYear",!0),va.fn.years=f("years accessor is deprecated. Use year instead.",qa("FullYear",!0)),va.fn.days=va.fn.day,va.fn.months=va.fn.month,va.fn.weeks=va.fn.week,va.fn.isoWeeks=va.fn.isoWeek,va.fn.quarters=va.fn.quarter,va.fn.toJSON=va.fn.toISOString,va.fn.isUTC=va.fn.isUtc,o(va.duration.fn=n.prototype,{_bubble:function(){var a,b,c,d=this._milliseconds,e=this._days,f=this._months,g=this._data,h=0;g.milliseconds=d%1e3,a=q(d/1e3),g.seconds=a%60,b=q(a/60),g.minutes=b%60,c=q(b/60),g.hours=c%24,e+=q(c/24),h=q(ra(e)),e-=q(sa(h)),f+=q(e/30),e%=30,h+=q(f/12),f%=12,g.days=e,g.months=f,g.years=h},abs:function(){return this._milliseconds=Math.abs(this._milliseconds),this._days=Math.abs(this._days),this._months=Math.abs(this._months),this._data.milliseconds=Math.abs(this._data.milliseconds),this._data.seconds=Math.abs(this._data.seconds),this._data.minutes=Math.abs(this._data.minutes),this._data.hours=Math.abs(this._data.hours),this._data.months=Math.abs(this._data.months),this._data.years=Math.abs(this._data.years),this},weeks:function(){return q(this.days()/7)},valueOf:function(){return this._milliseconds+864e5*this._days+this._months%12*2592e6+31536e6*C(this._months/12);
 },humanize:function(a){var b=ia(this,!a,this.localeData());return a&&(b=this.localeData().pastFuture(+this,b)),this.localeData().postformat(b)},add:function(a,b){var c=va.duration(a,b);return this._milliseconds+=c._milliseconds,this._days+=c._days,this._months+=c._months,this._bubble(),this},subtract:function(a,b){var c=va.duration(a,b);return this._milliseconds-=c._milliseconds,this._days-=c._days,this._months-=c._months,this._bubble(),this},get:function(a){return a=z(a),this[a.toLowerCase()+"s"]()},as:function(a){var b,c;if(a=z(a),"month"===a||"year"===a)return b=this._days+this._milliseconds/864e5,c=this._months+12*ra(b),"month"===a?c:c/12;switch(b=this._days+Math.round(sa(this._months/12)),a){case"week":return b/7+this._milliseconds/6048e5;case"day":return b+this._milliseconds/864e5;case"hour":return 24*b+this._milliseconds/36e5;case"minute":return 24*b*60+this._milliseconds/6e4;case"second":return 24*b*60*60+this._milliseconds/1e3;case"millisecond":return Math.floor(24*b*60*60*1e3)+this._milliseconds;default:throw new Error("Unknown unit "+a)}},lang:va.fn.lang,locale:va.fn.locale,toIsoString:f("toIsoString() is deprecated. Please use toISOString() instead (notice the capitals)",function(){return this.toISOString()}),toISOString:function(){var a=Math.abs(this.years()),b=Math.abs(this.months()),c=Math.abs(this.days()),d=Math.abs(this.hours()),e=Math.abs(this.minutes()),f=Math.abs(this.seconds()+this.milliseconds()/1e3);return this.asSeconds()?(this.asSeconds()<0?"-":"")+"P"+(a?a+"Y":"")+(b?b+"M":"")+(c?c+"D":"")+(d||e||f?"T":"")+(d?d+"H":"")+(e?e+"M":"")+(f?f+"S":""):"P0D"},localeData:function(){return this._locale},toJSON:function(){return this.toISOString()}}),va.duration.fn.toString=va.duration.fn.toISOString;for(xa in kb)c(kb,xa)&&ta(xa.toLowerCase());va.duration.fn.asMilliseconds=function(){return this.as("ms")},va.duration.fn.asSeconds=function(){return this.as("s")},va.duration.fn.asMinutes=function(){return this.as("m")},va.duration.fn.asHours=function(){return this.as("h")},va.duration.fn.asDays=function(){return this.as("d")},va.duration.fn.asWeeks=function(){return this.as("weeks")},va.duration.fn.asMonths=function(){return this.as("M")},va.duration.fn.asYears=function(){return this.as("y")},va.locale("en",{ordinalParse:/\d{1,2}(th|st|nd|rd)/,ordinal:function(a){var b=a%10,c=1===C(a%100/10)?"th":1===b?"st":2===b?"nd":3===b?"rd":"th";return a+c}}),function(a){a(va)}(function(a){return a.defineLocale("af",{months:"Januarie_Februarie_Maart_April_Mei_Junie_Julie_Augustus_September_Oktober_November_Desember".split("_"),monthsShort:"Jan_Feb_Mar_Apr_Mei_Jun_Jul_Aug_Sep_Okt_Nov_Des".split("_"),weekdays:"Sondag_Maandag_Dinsdag_Woensdag_Donderdag_Vrydag_Saterdag".split("_"),weekdaysShort:"Son_Maa_Din_Woe_Don_Vry_Sat".split("_"),weekdaysMin:"So_Ma_Di_Wo_Do_Vr_Sa".split("_"),meridiemParse:/vm|nm/i,isPM:function(a){return/^nm$/i.test(a)},meridiem:function(a,b,c){return 12>a?c?"vm":"VM":c?"nm":"NM"},longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendar:{sameDay:"[Vandag om] LT",nextDay:"[Môre om] LT",nextWeek:"dddd [om] LT",lastDay:"[Gister om] LT",lastWeek:"[Laas] dddd [om] LT",sameElse:"L"},relativeTime:{future:"oor %s",past:"%s gelede",s:"'n paar sekondes",m:"'n minuut",mm:"%d minute",h:"'n uur",hh:"%d ure",d:"'n dag",dd:"%d dae",M:"'n maand",MM:"%d maande",y:"'n jaar",yy:"%d jaar"},ordinalParse:/\d{1,2}(ste|de)/,ordinal:function(a){return a+(1===a||8===a||a>=20?"ste":"de")},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("ar-ma",{months:"يناير_فبراير_مارس_أبريل_ماي_يونيو_يوليوز_غشت_شتنبر_أكتوبر_نونبر_دجنبر".split("_"),monthsShort:"يناير_فبراير_مارس_أبريل_ماي_يونيو_يوليوز_غشت_شتنبر_أكتوبر_نونبر_دجنبر".split("_"),weekdays:"الأحد_الإتنين_الثلاثاء_الأربعاء_الخميس_الجمعة_السبت".split("_"),weekdaysShort:"احد_اتنين_ثلاثاء_اربعاء_خميس_جمعة_سبت".split("_"),weekdaysMin:"ح_ن_ث_ر_خ_ج_س".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},calendar:{sameDay:"[اليوم على الساعة] LT",nextDay:"[غدا على الساعة] LT",nextWeek:"dddd [على الساعة] LT",lastDay:"[أمس على الساعة] LT",lastWeek:"dddd [على الساعة] LT",sameElse:"L"},relativeTime:{future:"في %s",past:"منذ %s",s:"ثوان",m:"دقيقة",mm:"%d دقائق",h:"ساعة",hh:"%d ساعات",d:"يوم",dd:"%d أيام",M:"شهر",MM:"%d أشهر",y:"سنة",yy:"%d سنوات"},week:{dow:6,doy:12}})}),function(a){a(va)}(function(a){var b={1:"١",2:"٢",3:"٣",4:"٤",5:"٥",6:"٦",7:"٧",8:"٨",9:"٩",0:"٠"},c={"١":"1","٢":"2","٣":"3","٤":"4","٥":"5","٦":"6","٧":"7","٨":"8","٩":"9","٠":"0"};return a.defineLocale("ar-sa",{months:"يناير_فبراير_مارس_أبريل_مايو_يونيو_يوليو_أغسطس_سبتمبر_أكتوبر_نوفمبر_ديسمبر".split("_"),monthsShort:"يناير_فبراير_مارس_أبريل_مايو_يونيو_يوليو_أغسطس_سبتمبر_أكتوبر_نوفمبر_ديسمبر".split("_"),weekdays:"الأحد_الإثنين_الثلاثاء_الأربعاء_الخميس_الجمعة_السبت".split("_"),weekdaysShort:"أحد_إثنين_ثلاثاء_أربعاء_خميس_جمعة_سبت".split("_"),weekdaysMin:"ح_ن_ث_ر_خ_ج_س".split("_"),longDateFormat:{LT:"HH:mm",LTS:"HH:mm:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},meridiemParse:/ص|م/,isPM:function(a){return"م"===a},meridiem:function(a){return 12>a?"ص":"م"},calendar:{sameDay:"[اليوم على الساعة] LT",nextDay:"[غدا على الساعة] LT",nextWeek:"dddd [على الساعة] LT",lastDay:"[أمس على الساعة] LT",lastWeek:"dddd [على الساعة] LT",sameElse:"L"},relativeTime:{future:"في %s",past:"منذ %s",s:"ثوان",m:"دقيقة",mm:"%d دقائق",h:"ساعة",hh:"%d ساعات",d:"يوم",dd:"%d أيام",M:"شهر",MM:"%d أشهر",y:"سنة",yy:"%d سنوات"},preparse:function(a){return a.replace(/[١٢٣٤٥٦٧٨٩٠]/g,function(a){return c[a]}).replace(/،/g,",")},postformat:function(a){return a.replace(/\d/g,function(a){return b[a]}).replace(/,/g,"،")},week:{dow:6,doy:12}})}),function(a){a(va)}(function(a){return a.defineLocale("ar-tn",{months:"جانفي_فيفري_مارس_أفريل_ماي_جوان_جويلية_أوت_سبتمبر_أكتوبر_نوفمبر_ديسمبر".split("_"),monthsShort:"جانفي_فيفري_مارس_أفريل_ماي_جوان_جويلية_أوت_سبتمبر_أكتوبر_نوفمبر_ديسمبر".split("_"),weekdays:"الأحد_الإثنين_الثلاثاء_الأربعاء_الخميس_الجمعة_السبت".split("_"),weekdaysShort:"أحد_إثنين_ثلاثاء_أربعاء_خميس_جمعة_سبت".split("_"),weekdaysMin:"ح_ن_ث_ر_خ_ج_س".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},calendar:{sameDay:"[اليوم على الساعة] LT",nextDay:"[غدا على الساعة] LT",nextWeek:"dddd [على الساعة] LT",lastDay:"[أمس على الساعة] LT",lastWeek:"dddd [على الساعة] LT",sameElse:"L"},relativeTime:{future:"في %s",past:"منذ %s",s:"ثوان",m:"دقيقة",mm:"%d دقائق",h:"ساعة",hh:"%d ساعات",d:"يوم",dd:"%d أيام",M:"شهر",MM:"%d أشهر",y:"سنة",yy:"%d سنوات"},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){var b={1:"١",2:"٢",3:"٣",4:"٤",5:"٥",6:"٦",7:"٧",8:"٨",9:"٩",0:"٠"},c={"١":"1","٢":"2","٣":"3","٤":"4","٥":"5","٦":"6","٧":"7","٨":"8","٩":"9","٠":"0"},d=function(a){return 0===a?0:1===a?1:2===a?2:a%100>=3&&10>=a%100?3:a%100>=11?4:5},e={s:["أقل من ثانية","ثانية واحدة",["ثانيتان","ثانيتين"],"%d ثوان","%d ثانية","%d ثانية"],m:["أقل من دقيقة","دقيقة واحدة",["دقيقتان","دقيقتين"],"%d دقائق","%d دقيقة","%d دقيقة"],h:["أقل من ساعة","ساعة واحدة",["ساعتان","ساعتين"],"%d ساعات","%d ساعة","%d ساعة"],d:["أقل من يوم","يوم واحد",["يومان","يومين"],"%d أيام","%d يومًا","%d يوم"],M:["أقل من شهر","شهر واحد",["شهران","شهرين"],"%d أشهر","%d شهرا","%d شهر"],y:["أقل من عام","عام واحد",["عامان","عامين"],"%d أعوام","%d عامًا","%d عام"]},f=function(a){return function(b,c){var f=d(b),g=e[a][d(b)];return 2===f&&(g=g[c?0:1]),g.replace(/%d/i,b)}},g=["كانون الثاني يناير","شباط فبراير","آذار مارس","نيسان أبريل","أيار مايو","حزيران يونيو","تموز يوليو","آب أغسطس","أيلول سبتمبر","تشرين الأول أكتوبر","تشرين الثاني نوفمبر","كانون الأول ديسمبر"];return a.defineLocale("ar",{months:g,monthsShort:g,weekdays:"الأحد_الإثنين_الثلاثاء_الأربعاء_الخميس_الجمعة_السبت".split("_"),weekdaysShort:"أحد_إثنين_ثلاثاء_أربعاء_خميس_جمعة_سبت".split("_"),weekdaysMin:"ح_ن_ث_ر_خ_ج_س".split("_"),longDateFormat:{LT:"HH:mm",LTS:"HH:mm:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},meridiemParse:/ص|م/,isPM:function(a){return"م"===a},meridiem:function(a){return 12>a?"ص":"م"},calendar:{sameDay:"[اليوم عند الساعة] LT",nextDay:"[غدًا عند الساعة] LT",nextWeek:"dddd [عند الساعة] LT",lastDay:"[أمس عند الساعة] LT",lastWeek:"dddd [عند الساعة] LT",sameElse:"L"},relativeTime:{future:"بعد %s",past:"منذ %s",s:f("s"),m:f("m"),mm:f("m"),h:f("h"),hh:f("h"),d:f("d"),dd:f("d"),M:f("M"),MM:f("M"),y:f("y"),yy:f("y")},preparse:function(a){return a.replace(/[١٢٣٤٥٦٧٨٩٠]/g,function(a){return c[a]}).replace(/،/g,",")},postformat:function(a){return a.replace(/\d/g,function(a){return b[a]}).replace(/,/g,"،")},week:{dow:6,doy:12}})}),function(a){a(va)}(function(a){var b={1:"-inci",5:"-inci",8:"-inci",70:"-inci",80:"-inci",2:"-nci",7:"-nci",20:"-nci",50:"-nci",3:"-üncü",4:"-üncü",100:"-üncü",6:"-ncı",9:"-uncu",10:"-uncu",30:"-uncu",60:"-ıncı",90:"-ıncı"};return a.defineLocale("az",{months:"yanvar_fevral_mart_aprel_may_iyun_iyul_avqust_sentyabr_oktyabr_noyabr_dekabr".split("_"),monthsShort:"yan_fev_mar_apr_may_iyn_iyl_avq_sen_okt_noy_dek".split("_"),weekdays:"Bazar_Bazar ertəsi_Çərşənbə axşamı_Çərşənbə_Cümə axşamı_Cümə_Şənbə".split("_"),weekdaysShort:"Baz_BzE_ÇAx_Çər_CAx_Cüm_Şən".split("_"),weekdaysMin:"Bz_BE_ÇA_Çə_CA_Cü_Şə".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD.MM.YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendar:{sameDay:"[bugün saat] LT",nextDay:"[sabah saat] LT",nextWeek:"[gələn həftə] dddd [saat] LT",lastDay:"[dünən] LT",lastWeek:"[keçən həftə] dddd [saat] LT",sameElse:"L"},relativeTime:{future:"%s sonra",past:"%s əvvəl",s:"birneçə saniyyə",m:"bir dəqiqə",mm:"%d dəqiqə",h:"bir saat",hh:"%d saat",d:"bir gün",dd:"%d gün",M:"bir ay",MM:"%d ay",y:"bir il",yy:"%d il"},meridiemParse:/gecə|səhər|gündüz|axşam/,isPM:function(a){return/^(gündüz|axşam)$/.test(a)},meridiem:function(a){return 4>a?"gecə":12>a?"səhər":17>a?"gündüz":"axşam"},ordinalParse:/\d{1,2}-(ıncı|inci|nci|üncü|ncı|uncu)/,ordinal:function(a){if(0===a)return a+"-ıncı";var c=a%10,d=a%100-c,e=a>=100?100:null;return a+(b[c]||b[d]||b[e])},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){function b(a,b){var c=a.split("_");return b%10===1&&b%100!==11?c[0]:b%10>=2&&4>=b%10&&(10>b%100||b%100>=20)?c[1]:c[2]}function c(a,c,d){var e={mm:c?"хвіліна_хвіліны_хвілін":"хвіліну_хвіліны_хвілін",hh:c?"гадзіна_гадзіны_гадзін":"гадзіну_гадзіны_гадзін",dd:"дзень_дні_дзён",MM:"месяц_месяцы_месяцаў",yy:"год_гады_гадоў"};return"m"===d?c?"хвіліна":"хвіліну":"h"===d?c?"гадзіна":"гадзіну":a+" "+b(e[d],+a)}function d(a,b){var c={nominative:"студзень_люты_сакавік_красавік_травень_чэрвень_ліпень_жнівень_верасень_кастрычнік_лістапад_снежань".split("_"),accusative:"студзеня_лютага_сакавіка_красавіка_траўня_чэрвеня_ліпеня_жніўня_верасня_кастрычніка_лістапада_снежня".split("_")},d=/D[oD]?(\[[^\[\]]*\]|\s+)+MMMM?/.test(b)?"accusative":"nominative";return c[d][a.month()]}function e(a,b){var c={nominative:"нядзеля_панядзелак_аўторак_серада_чацвер_пятніца_субота".split("_"),accusative:"нядзелю_панядзелак_аўторак_сераду_чацвер_пятніцу_суботу".split("_")},d=/\[ ?[Вв] ?(?:мінулую|наступную)? ?\] ?dddd/.test(b)?"accusative":"nominative";return c[d][a.day()]}return a.defineLocale("be",{months:d,monthsShort:"студ_лют_сак_крас_трав_чэрв_ліп_жнів_вер_каст_ліст_снеж".split("_"),weekdays:e,weekdaysShort:"нд_пн_ат_ср_чц_пт_сб".split("_"),weekdaysMin:"нд_пн_ат_ср_чц_пт_сб".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD.MM.YYYY",LL:"D MMMM YYYY г.",LLL:"D MMMM YYYY г., LT",LLLL:"dddd, D MMMM YYYY г., LT"},calendar:{sameDay:"[Сёння ў] LT",nextDay:"[Заўтра ў] LT",lastDay:"[Учора ў] LT",nextWeek:function(){return"[У] dddd [ў] LT"},lastWeek:function(){switch(this.day()){case 0:case 3:case 5:case 6:return"[У мінулую] dddd [ў] LT";case 1:case 2:case 4:return"[У мінулы] dddd [ў] LT"}},sameElse:"L"},relativeTime:{future:"праз %s",past:"%s таму",s:"некалькі секунд",m:c,mm:c,h:c,hh:c,d:"дзень",dd:c,M:"месяц",MM:c,y:"год",yy:c},meridiemParse:/ночы|раніцы|дня|вечара/,isPM:function(a){return/^(дня|вечара)$/.test(a)},meridiem:function(a){return 4>a?"ночы":12>a?"раніцы":17>a?"дня":"вечара"},ordinalParse:/\d{1,2}-(і|ы|га)/,ordinal:function(a,b){switch(b){case"M":case"d":case"DDD":case"w":case"W":return a%10!==2&&a%10!==3||a%100===12||a%100===13?a+"-ы":a+"-і";case"D":return a+"-га";default:return a}},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){return a.defineLocale("bg",{months:"януари_февруари_март_април_май_юни_юли_август_септември_октомври_ноември_декември".split("_"),monthsShort:"янр_фев_мар_апр_май_юни_юли_авг_сеп_окт_ное_дек".split("_"),weekdays:"неделя_понеделник_вторник_сряда_четвъртък_петък_събота".split("_"),weekdaysShort:"нед_пон_вто_сря_чет_пет_съб".split("_"),weekdaysMin:"нд_пн_вт_ср_чт_пт_сб".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"D.MM.YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendar:{sameDay:"[Днес в] LT",nextDay:"[Утре в] LT",nextWeek:"dddd [в] LT",lastDay:"[Вчера в] LT",lastWeek:function(){switch(this.day()){case 0:case 3:case 6:return"[В изминалата] dddd [в] LT";case 1:case 2:case 4:case 5:return"[В изминалия] dddd [в] LT"}},sameElse:"L"},relativeTime:{future:"след %s",past:"преди %s",s:"няколко секунди",m:"минута",mm:"%d минути",h:"час",hh:"%d часа",d:"ден",dd:"%d дни",M:"месец",MM:"%d месеца",y:"година",yy:"%d години"},ordinalParse:/\d{1,2}-(ев|ен|ти|ви|ри|ми)/,ordinal:function(a){var b=a%10,c=a%100;return 0===a?a+"-ев":0===c?a+"-ен":c>10&&20>c?a+"-ти":1===b?a+"-ви":2===b?a+"-ри":7===b||8===b?a+"-ми":a+"-ти"},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){var b={1:"১",2:"২",3:"৩",4:"৪",5:"৫",6:"৬",7:"৭",8:"৮",9:"৯",0:"০"},c={"১":"1","২":"2","৩":"3","৪":"4","৫":"5","৬":"6","৭":"7","৮":"8","৯":"9","০":"0"};return a.defineLocale("bn",{months:"জানুয়ারী_ফেবুয়ারী_মার্চ_এপ্রিল_মে_জুন_জুলাই_অগাস্ট_সেপ্টেম্বর_অক্টোবর_নভেম্বর_ডিসেম্বর".split("_"),monthsShort:"জানু_ফেব_মার্চ_এপর_মে_জুন_জুল_অগ_সেপ্ট_অক্টো_নভ_ডিসেম্".split("_"),weekdays:"রবিবার_সোমবার_মঙ্গলবার_বুধবার_বৃহস্পত্তিবার_শুক্রুবার_শনিবার".split("_"),weekdaysShort:"রবি_সোম_মঙ্গল_বুধ_বৃহস্পত্তি_শুক্রু_শনি".split("_"),weekdaysMin:"রব_সম_মঙ্গ_বু_ব্রিহ_শু_শনি".split("_"),longDateFormat:{LT:"A h:mm সময়",LTS:"A h:mm:ss সময়",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY, LT",LLLL:"dddd, D MMMM YYYY, LT"},calendar:{sameDay:"[আজ] LT",nextDay:"[আগামীকাল] LT",nextWeek:"dddd, LT",lastDay:"[গতকাল] LT",lastWeek:"[গত] dddd, LT",sameElse:"L"},relativeTime:{future:"%s পরে",past:"%s আগে",s:"কএক সেকেন্ড",m:"এক মিনিট",mm:"%d মিনিট",h:"এক ঘন্টা",hh:"%d ঘন্টা",d:"এক দিন",dd:"%d দিন",M:"এক মাস",MM:"%d মাস",y:"এক বছর",yy:"%d বছর"},preparse:function(a){return a.replace(/[১২৩৪৫৬৭৮৯০]/g,function(a){return c[a]})},postformat:function(a){return a.replace(/\d/g,function(a){return b[a]})},meridiemParse:/রাত|শকাল|দুপুর|বিকেল|রাত/,isPM:function(a){return/^(দুপুর|বিকেল|রাত)$/.test(a)},meridiem:function(a){return 4>a?"রাত":10>a?"শকাল":17>a?"দুপুর":20>a?"বিকেল":"রাত"},week:{dow:0,doy:6}})}),function(a){a(va)}(function(a){var b={1:"༡",2:"༢",3:"༣",4:"༤",5:"༥",6:"༦",7:"༧",8:"༨",9:"༩",0:"༠"},c={"༡":"1","༢":"2","༣":"3","༤":"4","༥":"5","༦":"6","༧":"7","༨":"8","༩":"9","༠":"0"};return a.defineLocale("bo",{months:"ཟླ་བ་དང་པོ_ཟླ་བ་གཉིས་པ_ཟླ་བ་གསུམ་པ_ཟླ་བ་བཞི་པ_ཟླ་བ་ལྔ་པ_ཟླ་བ་དྲུག་པ_ཟླ་བ་བདུན་པ_ཟླ་བ་བརྒྱད་པ_ཟླ་བ་དགུ་པ_ཟླ་བ་བཅུ་པ_ཟླ་བ་བཅུ་གཅིག་པ_ཟླ་བ་བཅུ་གཉིས་པ".split("_"),monthsShort:"ཟླ་བ་དང་པོ_ཟླ་བ་གཉིས་པ_ཟླ་བ་གསུམ་པ_ཟླ་བ་བཞི་པ_ཟླ་བ་ལྔ་པ_ཟླ་བ་དྲུག་པ_ཟླ་བ་བདུན་པ_ཟླ་བ་བརྒྱད་པ_ཟླ་བ་དགུ་པ_ཟླ་བ་བཅུ་པ_ཟླ་བ་བཅུ་གཅིག་པ_ཟླ་བ་བཅུ་གཉིས་པ".split("_"),weekdays:"གཟའ་ཉི་མ་_གཟའ་ཟླ་བ་_གཟའ་མིག་དམར་_གཟའ་ལྷག་པ་_གཟའ་ཕུར་བུ_གཟའ་པ་སངས་_གཟའ་སྤེན་པ་".split("_"),weekdaysShort:"ཉི་མ་_ཟླ་བ་_མིག་དམར་_ལྷག་པ་_ཕུར་བུ_པ་སངས་_སྤེན་པ་".split("_"),weekdaysMin:"ཉི་མ་_ཟླ་བ་_མིག་དམར་_ལྷག་པ་_ཕུར་བུ_པ་སངས་_སྤེན་པ་".split("_"),longDateFormat:{LT:"A h:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY, LT",LLLL:"dddd, D MMMM YYYY, LT"},calendar:{sameDay:"[དི་རིང] LT",nextDay:"[སང་ཉིན] LT",nextWeek:"[བདུན་ཕྲག་རྗེས་མ], LT",lastDay:"[ཁ་སང] LT",lastWeek:"[བདུན་ཕྲག་མཐའ་མ] dddd, LT",sameElse:"L"},relativeTime:{future:"%s ལ་",past:"%s སྔན་ལ",s:"ལམ་སང",m:"སྐར་མ་གཅིག",mm:"%d སྐར་མ",h:"ཆུ་ཚོད་གཅིག",hh:"%d ཆུ་ཚོད",d:"ཉིན་གཅིག",dd:"%d ཉིན་",M:"ཟླ་བ་གཅིག",MM:"%d ཟླ་བ",y:"ལོ་གཅིག",yy:"%d ལོ"},preparse:function(a){return a.replace(/[༡༢༣༤༥༦༧༨༩༠]/g,function(a){return c[a]})},postformat:function(a){return a.replace(/\d/g,function(a){return b[a]})},meridiemParse:/མཚན་མོ|ཞོགས་ཀས|ཉིན་གུང|དགོང་དག|མཚན་མོ/,isPM:function(a){return/^(ཉིན་གུང|དགོང་དག|མཚན་མོ)$/.test(a)},meridiem:function(a){return 4>a?"མཚན་མོ":10>a?"ཞོགས་ཀས":17>a?"ཉིན་གུང":20>a?"དགོང་དག":"མཚན་མོ"},week:{dow:0,doy:6}})}),function(a){a(va)}(function(b){function c(a,b,c){var d={mm:"munutenn",MM:"miz",dd:"devezh"};return a+" "+f(d[c],a)}function d(a){switch(e(a)){case 1:case 3:case 4:case 5:case 9:return a+" bloaz";default:return a+" vloaz"}}function e(a){return a>9?e(a%10):a}function f(a,b){return 2===b?g(a):a}function g(b){var c={m:"v",b:"v",d:"z"};return c[b.charAt(0)]===a?b:c[b.charAt(0)]+b.substring(1)}return b.defineLocale("br",{months:"Genver_C'hwevrer_Meurzh_Ebrel_Mae_Mezheven_Gouere_Eost_Gwengolo_Here_Du_Kerzu".split("_"),monthsShort:"Gen_C'hwe_Meu_Ebr_Mae_Eve_Gou_Eos_Gwe_Her_Du_Ker".split("_"),weekdays:"Sul_Lun_Meurzh_Merc'her_Yaou_Gwener_Sadorn".split("_"),weekdaysShort:"Sul_Lun_Meu_Mer_Yao_Gwe_Sad".split("_"),weekdaysMin:"Su_Lu_Me_Mer_Ya_Gw_Sa".split("_"),longDateFormat:{LT:"h[e]mm A",LTS:"h[e]mm:ss A",L:"DD/MM/YYYY",LL:"D [a viz] MMMM YYYY",LLL:"D [a viz] MMMM YYYY LT",LLLL:"dddd, D [a viz] MMMM YYYY LT"},calendar:{sameDay:"[Hiziv da] LT",nextDay:"[Warc'hoazh da] LT",nextWeek:"dddd [da] LT",lastDay:"[Dec'h da] LT",lastWeek:"dddd [paset da] LT",sameElse:"L"},relativeTime:{future:"a-benn %s",past:"%s 'zo",s:"un nebeud segondennoù",m:"ur vunutenn",mm:c,h:"un eur",hh:"%d eur",d:"un devezh",dd:c,M:"ur miz",MM:c,y:"ur bloaz",yy:d},ordinalParse:/\d{1,2}(añ|vet)/,ordinal:function(a){var b=1===a?"añ":"vet";return a+b},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){function b(a,b,c){var d=a+" ";switch(c){case"m":return b?"jedna minuta":"jedne minute";case"mm":return d+=1===a?"minuta":2===a||3===a||4===a?"minute":"minuta";case"h":return b?"jedan sat":"jednog sata";case"hh":return d+=1===a?"sat":2===a||3===a||4===a?"sata":"sati";case"dd":return d+=1===a?"dan":"dana";case"MM":return d+=1===a?"mjesec":2===a||3===a||4===a?"mjeseca":"mjeseci";case"yy":return d+=1===a?"godina":2===a||3===a||4===a?"godine":"godina"}}return a.defineLocale("bs",{months:"januar_februar_mart_april_maj_juni_juli_august_septembar_oktobar_novembar_decembar".split("_"),monthsShort:"jan._feb._mar._apr._maj._jun._jul._aug._sep._okt._nov._dec.".split("_"),weekdays:"nedjelja_ponedjeljak_utorak_srijeda_četvrtak_petak_subota".split("_"),weekdaysShort:"ned._pon._uto._sri._čet._pet._sub.".split("_"),weekdaysMin:"ne_po_ut_sr_če_pe_su".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"DD. MM. YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY LT",LLLL:"dddd, D. MMMM YYYY LT"},calendar:{sameDay:"[danas u] LT",nextDay:"[sutra u] LT",nextWeek:function(){switch(this.day()){case 0:return"[u] [nedjelju] [u] LT";case 3:return"[u] [srijedu] [u] LT";case 6:return"[u] [subotu] [u] LT";case 1:case 2:case 4:case 5:return"[u] dddd [u] LT"}},lastDay:"[jučer u] LT",lastWeek:function(){switch(this.day()){case 0:case 3:return"[prošlu] dddd [u] LT";case 6:return"[prošle] [subote] [u] LT";case 1:case 2:case 4:case 5:return"[prošli] dddd [u] LT"}},sameElse:"L"},relativeTime:{future:"za %s",past:"prije %s",s:"par sekundi",m:b,mm:b,h:b,hh:b,d:"dan",dd:b,M:"mjesec",MM:b,y:"godinu",yy:b},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){return a.defineLocale("ca",{months:"gener_febrer_març_abril_maig_juny_juliol_agost_setembre_octubre_novembre_desembre".split("_"),monthsShort:"gen._febr._mar._abr._mai._jun._jul._ag._set._oct._nov._des.".split("_"),weekdays:"diumenge_dilluns_dimarts_dimecres_dijous_divendres_dissabte".split("_"),weekdaysShort:"dg._dl._dt._dc._dj._dv._ds.".split("_"),weekdaysMin:"Dg_Dl_Dt_Dc_Dj_Dv_Ds".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},calendar:{sameDay:function(){return"[avui a "+(1!==this.hours()?"les":"la")+"] LT"},nextDay:function(){return"[demà a "+(1!==this.hours()?"les":"la")+"] LT"},nextWeek:function(){return"dddd [a "+(1!==this.hours()?"les":"la")+"] LT"},lastDay:function(){return"[ahir a "+(1!==this.hours()?"les":"la")+"] LT"},lastWeek:function(){return"[el] dddd [passat a "+(1!==this.hours()?"les":"la")+"] LT"},sameElse:"L"},relativeTime:{future:"en %s",past:"fa %s",s:"uns segons",m:"un minut",mm:"%d minuts",h:"una hora",hh:"%d hores",d:"un dia",dd:"%d dies",M:"un mes",MM:"%d mesos",y:"un any",yy:"%d anys"},ordinalParse:/\d{1,2}(r|n|t|è|a)/,ordinal:function(a,b){var c=1===a?"r":2===a?"n":3===a?"r":4===a?"t":"è";return("w"===b||"W"===b)&&(c="a"),a+c},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){function b(a){return a>1&&5>a&&1!==~~(a/10)}function c(a,c,d,e){var f=a+" ";switch(d){case"s":return c||e?"pár sekund":"pár sekundami";case"m":return c?"minuta":e?"minutu":"minutou";case"mm":return c||e?f+(b(a)?"minuty":"minut"):f+"minutami";case"h":return c?"hodina":e?"hodinu":"hodinou";case"hh":return c||e?f+(b(a)?"hodiny":"hodin"):f+"hodinami";case"d":return c||e?"den":"dnem";case"dd":return c||e?f+(b(a)?"dny":"dní"):f+"dny";case"M":return c||e?"měsíc":"měsícem";case"MM":return c||e?f+(b(a)?"měsíce":"měsíců"):f+"měsíci";case"y":return c||e?"rok":"rokem";case"yy":return c||e?f+(b(a)?"roky":"let"):f+"lety"}}var d="leden_únor_březen_duben_květen_červen_červenec_srpen_září_říjen_listopad_prosinec".split("_"),e="led_úno_bře_dub_kvě_čvn_čvc_srp_zář_říj_lis_pro".split("_");return a.defineLocale("cs",{months:d,monthsShort:e,monthsParse:function(a,b){var c,d=[];for(c=0;12>c;c++)d[c]=new RegExp("^"+a[c]+"$|^"+b[c]+"$","i");return d}(d,e),weekdays:"neděle_pondělí_úterý_středa_čtvrtek_pátek_sobota".split("_"),weekdaysShort:"ne_po_út_st_čt_pá_so".split("_"),weekdaysMin:"ne_po_út_st_čt_pá_so".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"DD.MM.YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY LT",LLLL:"dddd D. MMMM YYYY LT"},calendar:{sameDay:"[dnes v] LT",nextDay:"[zítra v] LT",nextWeek:function(){switch(this.day()){case 0:return"[v neděli v] LT";case 1:case 2:return"[v] dddd [v] LT";case 3:return"[ve středu v] LT";case 4:return"[ve čtvrtek v] LT";case 5:return"[v pátek v] LT";case 6:return"[v sobotu v] LT"}},lastDay:"[včera v] LT",lastWeek:function(){switch(this.day()){case 0:return"[minulou neděli v] LT";case 1:case 2:return"[minulé] dddd [v] LT";case 3:return"[minulou středu v] LT";case 4:case 5:return"[minulý] dddd [v] LT";case 6:return"[minulou sobotu v] LT"}},sameElse:"L"},relativeTime:{future:"za %s",past:"před %s",s:c,m:c,mm:c,h:c,hh:c,d:c,dd:c,M:c,MM:c,y:c,yy:c},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("cv",{months:"кăрлач_нарăс_пуш_ака_май_çĕртме_утă_çурла_авăн_юпа_чӳк_раштав".split("_"),monthsShort:"кăр_нар_пуш_ака_май_çĕр_утă_çур_ав_юпа_чӳк_раш".split("_"),weekdays:"вырсарникун_тунтикун_ытларикун_юнкун_кĕçнерникун_эрнекун_шăматкун".split("_"),weekdaysShort:"выр_тун_ытл_юн_кĕç_эрн_шăм".split("_"),weekdaysMin:"вр_тн_ыт_юн_кç_эр_шм".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD-MM-YYYY",LL:"YYYY [çулхи] MMMM [уйăхĕн] D[-мĕшĕ]",LLL:"YYYY [çулхи] MMMM [уйăхĕн] D[-мĕшĕ], LT",LLLL:"dddd, YYYY [çулхи] MMMM [уйăхĕн] D[-мĕшĕ], LT"},calendar:{sameDay:"[Паян] LT [сехетре]",nextDay:"[Ыран] LT [сехетре]",lastDay:"[Ĕнер] LT [сехетре]",nextWeek:"[Çитес] dddd LT [сехетре]",lastWeek:"[Иртнĕ] dddd LT [сехетре]",sameElse:"L"},relativeTime:{future:function(a){var b=/сехет$/i.exec(a)?"рен":/çул$/i.exec(a)?"тан":"ран";return a+b},past:"%s каялла",s:"пĕр-ик çеккунт",m:"пĕр минут",mm:"%d минут",h:"пĕр сехет",hh:"%d сехет",d:"пĕр кун",dd:"%d кун",M:"пĕр уйăх",MM:"%d уйăх",y:"пĕр çул",yy:"%d çул"},ordinalParse:/\d{1,2}-мĕш/,ordinal:"%d-мĕш",week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){return a.defineLocale("cy",{months:"Ionawr_Chwefror_Mawrth_Ebrill_Mai_Mehefin_Gorffennaf_Awst_Medi_Hydref_Tachwedd_Rhagfyr".split("_"),monthsShort:"Ion_Chwe_Maw_Ebr_Mai_Meh_Gor_Aws_Med_Hyd_Tach_Rhag".split("_"),weekdays:"Dydd Sul_Dydd Llun_Dydd Mawrth_Dydd Mercher_Dydd Iau_Dydd Gwener_Dydd Sadwrn".split("_"),weekdaysShort:"Sul_Llun_Maw_Mer_Iau_Gwe_Sad".split("_"),weekdaysMin:"Su_Ll_Ma_Me_Ia_Gw_Sa".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendar:{sameDay:"[Heddiw am] LT",nextDay:"[Yfory am] LT",nextWeek:"dddd [am] LT",lastDay:"[Ddoe am] LT",lastWeek:"dddd [diwethaf am] LT",sameElse:"L"},relativeTime:{future:"mewn %s",past:"%s yn ôl",s:"ychydig eiliadau",m:"munud",mm:"%d munud",h:"awr",hh:"%d awr",d:"diwrnod",dd:"%d diwrnod",M:"mis",MM:"%d mis",y:"blwyddyn",yy:"%d flynedd"},ordinalParse:/\d{1,2}(fed|ain|af|il|ydd|ed|eg)/,ordinal:function(a){var b=a,c="",d=["","af","il","ydd","ydd","ed","ed","ed","fed","fed","fed","eg","fed","eg","eg","fed","eg","eg","fed","eg","fed"];return b>20?c=40===b||50===b||60===b||80===b||100===b?"fed":"ain":b>0&&(c=d[b]),a+c},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("da",{months:"januar_februar_marts_april_maj_juni_juli_august_september_oktober_november_december".split("_"),monthsShort:"jan_feb_mar_apr_maj_jun_jul_aug_sep_okt_nov_dec".split("_"),weekdays:"søndag_mandag_tirsdag_onsdag_torsdag_fredag_lørdag".split("_"),weekdaysShort:"søn_man_tir_ons_tor_fre_lør".split("_"),weekdaysMin:"sø_ma_ti_on_to_fr_lø".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY LT",LLLL:"dddd [d.] D. MMMM YYYY LT"},calendar:{sameDay:"[I dag kl.] LT",nextDay:"[I morgen kl.] LT",nextWeek:"dddd [kl.] LT",lastDay:"[I går kl.] LT",lastWeek:"[sidste] dddd [kl] LT",sameElse:"L"},relativeTime:{future:"om %s",past:"%s siden",s:"få sekunder",m:"et minut",mm:"%d minutter",h:"en time",hh:"%d timer",d:"en dag",dd:"%d dage",M:"en måned",MM:"%d måneder",y:"et år",yy:"%d år"},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){function b(a,b,c){var d={m:["eine Minute","einer Minute"],h:["eine Stunde","einer Stunde"],d:["ein Tag","einem Tag"],dd:[a+" Tage",a+" Tagen"],M:["ein Monat","einem Monat"],MM:[a+" Monate",a+" Monaten"],y:["ein Jahr","einem Jahr"],yy:[a+" Jahre",a+" Jahren"]};return b?d[c][0]:d[c][1]}return a.defineLocale("de-at",{months:"Jänner_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember".split("_"),monthsShort:"Jän._Febr._Mrz._Apr._Mai_Jun._Jul._Aug._Sept._Okt._Nov._Dez.".split("_"),weekdays:"Sonntag_Montag_Dienstag_Mittwoch_Donnerstag_Freitag_Samstag".split("_"),weekdaysShort:"So._Mo._Di._Mi._Do._Fr._Sa.".split("_"),weekdaysMin:"So_Mo_Di_Mi_Do_Fr_Sa".split("_"),longDateFormat:{LT:"HH:mm",LTS:"HH:mm:ss",L:"DD.MM.YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY LT",LLLL:"dddd, D. MMMM YYYY LT"},calendar:{sameDay:"[Heute um] LT [Uhr]",sameElse:"L",nextDay:"[Morgen um] LT [Uhr]",nextWeek:"dddd [um] LT [Uhr]",lastDay:"[Gestern um] LT [Uhr]",lastWeek:"[letzten] dddd [um] LT [Uhr]"},relativeTime:{future:"in %s",past:"vor %s",s:"ein paar Sekunden",m:b,mm:"%d Minuten",h:b,hh:"%d Stunden",d:b,dd:b,M:b,MM:b,y:b,yy:b},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){function b(a,b,c){var d={m:["eine Minute","einer Minute"],h:["eine Stunde","einer Stunde"],d:["ein Tag","einem Tag"],dd:[a+" Tage",a+" Tagen"],M:["ein Monat","einem Monat"],MM:[a+" Monate",a+" Monaten"],y:["ein Jahr","einem Jahr"],yy:[a+" Jahre",a+" Jahren"]};return b?d[c][0]:d[c][1]}return a.defineLocale("de",{months:"Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember".split("_"),monthsShort:"Jan._Febr._Mrz._Apr._Mai_Jun._Jul._Aug._Sept._Okt._Nov._Dez.".split("_"),weekdays:"Sonntag_Montag_Dienstag_Mittwoch_Donnerstag_Freitag_Samstag".split("_"),weekdaysShort:"So._Mo._Di._Mi._Do._Fr._Sa.".split("_"),weekdaysMin:"So_Mo_Di_Mi_Do_Fr_Sa".split("_"),longDateFormat:{LT:"HH:mm",LTS:"HH:mm:ss",L:"DD.MM.YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY LT",LLLL:"dddd, D. MMMM YYYY LT"},calendar:{sameDay:"[Heute um] LT [Uhr]",sameElse:"L",nextDay:"[Morgen um] LT [Uhr]",nextWeek:"dddd [um] LT [Uhr]",lastDay:"[Gestern um] LT [Uhr]",lastWeek:"[letzten] dddd [um] LT [Uhr]"},relativeTime:{future:"in %s",past:"vor %s",s:"ein paar Sekunden",m:b,mm:"%d Minuten",h:b,hh:"%d Stunden",d:b,dd:b,M:b,MM:b,y:b,yy:b},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("el",{monthsNominativeEl:"Ιανουάριος_Φεβρουάριος_Μάρτιος_Απρίλιος_Μάιος_Ιούνιος_Ιούλιος_Αύγουστος_Σεπτέμβριος_Οκτώβριος_Νοέμβριος_Δεκέμβριος".split("_"),monthsGenitiveEl:"Ιανουαρίου_Φεβρουαρίου_Μαρτίου_Απριλίου_Μαΐου_Ιουνίου_Ιουλίου_Αυγούστου_Σεπτεμβρίου_Οκτωβρίου_Νοεμβρίου_Δεκεμβρίου".split("_"),months:function(a,b){return/D/.test(b.substring(0,b.indexOf("MMMM")))?this._monthsGenitiveEl[a.month()]:this._monthsNominativeEl[a.month()]},monthsShort:"Ιαν_Φεβ_Μαρ_Απρ_Μαϊ_Ιουν_Ιουλ_Αυγ_Σεπ_Οκτ_Νοε_Δεκ".split("_"),weekdays:"Κυριακή_Δευτέρα_Τρίτη_Τετάρτη_Πέμπτη_Παρασκευή_Σάββατο".split("_"),weekdaysShort:"Κυρ_Δευ_Τρι_Τετ_Πεμ_Παρ_Σαβ".split("_"),weekdaysMin:"Κυ_Δε_Τρ_Τε_Πε_Πα_Σα".split("_"),meridiem:function(a,b,c){return a>11?c?"μμ":"ΜΜ":c?"πμ":"ΠΜ"},isPM:function(a){return"μ"===(a+"").toLowerCase()[0]},meridiemParse:/[ΠΜ]\.?Μ?\.?/i,longDateFormat:{LT:"h:mm A",LTS:"h:mm:ss A",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendarEl:{sameDay:"[Σήμερα {}] LT",nextDay:"[Αύριο {}] LT",nextWeek:"dddd [{}] LT",lastDay:"[Χθες {}] LT",lastWeek:function(){switch(this.day()){case 6:return"[το προηγούμενο] dddd [{}] LT";default:return"[την προηγούμενη] dddd [{}] LT"}},sameElse:"L"},calendar:function(a,b){var c=this._calendarEl[a],d=b&&b.hours();return"function"==typeof c&&(c=c.apply(b)),c.replace("{}",d%12===1?"στη":"στις")},relativeTime:{future:"σε %s",past:"%s πριν",s:"λίγα δευτερόλεπτα",m:"ένα λεπτό",mm:"%d λεπτά",h:"μία ώρα",hh:"%d ώρες",d:"μία μέρα",dd:"%d μέρες",M:"ένας μήνας",MM:"%d μήνες",y:"ένας χρόνος",yy:"%d χρόνια"},ordinalParse:/\d{1,2}η/,ordinal:"%dη",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("en-au",{months:"January_February_March_April_May_June_July_August_September_October_November_December".split("_"),monthsShort:"Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec".split("_"),weekdays:"Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday".split("_"),weekdaysShort:"Sun_Mon_Tue_Wed_Thu_Fri_Sat".split("_"),weekdaysMin:"Su_Mo_Tu_We_Th_Fr_Sa".split("_"),longDateFormat:{LT:"h:mm A",LTS:"h:mm:ss A",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendar:{sameDay:"[Today at] LT",nextDay:"[Tomorrow at] LT",nextWeek:"dddd [at] LT",lastDay:"[Yesterday at] LT",lastWeek:"[Last] dddd [at] LT",sameElse:"L"},relativeTime:{future:"in %s",past:"%s ago",s:"a few seconds",m:"a minute",mm:"%d minutes",h:"an hour",hh:"%d hours",d:"a day",dd:"%d days",M:"a month",MM:"%d months",y:"a year",yy:"%d years"},ordinalParse:/\d{1,2}(st|nd|rd|th)/,ordinal:function(a){var b=a%10,c=1===~~(a%100/10)?"th":1===b?"st":2===b?"nd":3===b?"rd":"th";return a+c},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("en-ca",{months:"January_February_March_April_May_June_July_August_September_October_November_December".split("_"),monthsShort:"Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec".split("_"),weekdays:"Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday".split("_"),weekdaysShort:"Sun_Mon_Tue_Wed_Thu_Fri_Sat".split("_"),weekdaysMin:"Su_Mo_Tu_We_Th_Fr_Sa".split("_"),longDateFormat:{
 LT:"h:mm A",LTS:"h:mm:ss A",L:"YYYY-MM-DD",LL:"D MMMM, YYYY",LLL:"D MMMM, YYYY LT",LLLL:"dddd, D MMMM, YYYY LT"},calendar:{sameDay:"[Today at] LT",nextDay:"[Tomorrow at] LT",nextWeek:"dddd [at] LT",lastDay:"[Yesterday at] LT",lastWeek:"[Last] dddd [at] LT",sameElse:"L"},relativeTime:{future:"in %s",past:"%s ago",s:"a few seconds",m:"a minute",mm:"%d minutes",h:"an hour",hh:"%d hours",d:"a day",dd:"%d days",M:"a month",MM:"%d months",y:"a year",yy:"%d years"},ordinalParse:/\d{1,2}(st|nd|rd|th)/,ordinal:function(a){var b=a%10,c=1===~~(a%100/10)?"th":1===b?"st":2===b?"nd":3===b?"rd":"th";return a+c}})}),function(a){a(va)}(function(a){return a.defineLocale("en-gb",{months:"January_February_March_April_May_June_July_August_September_October_November_December".split("_"),monthsShort:"Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec".split("_"),weekdays:"Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday".split("_"),weekdaysShort:"Sun_Mon_Tue_Wed_Thu_Fri_Sat".split("_"),weekdaysMin:"Su_Mo_Tu_We_Th_Fr_Sa".split("_"),longDateFormat:{LT:"HH:mm",LTS:"HH:mm:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendar:{sameDay:"[Today at] LT",nextDay:"[Tomorrow at] LT",nextWeek:"dddd [at] LT",lastDay:"[Yesterday at] LT",lastWeek:"[Last] dddd [at] LT",sameElse:"L"},relativeTime:{future:"in %s",past:"%s ago",s:"a few seconds",m:"a minute",mm:"%d minutes",h:"an hour",hh:"%d hours",d:"a day",dd:"%d days",M:"a month",MM:"%d months",y:"a year",yy:"%d years"},ordinalParse:/\d{1,2}(st|nd|rd|th)/,ordinal:function(a){var b=a%10,c=1===~~(a%100/10)?"th":1===b?"st":2===b?"nd":3===b?"rd":"th";return a+c},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("eo",{months:"januaro_februaro_marto_aprilo_majo_junio_julio_aŭgusto_septembro_oktobro_novembro_decembro".split("_"),monthsShort:"jan_feb_mar_apr_maj_jun_jul_aŭg_sep_okt_nov_dec".split("_"),weekdays:"Dimanĉo_Lundo_Mardo_Merkredo_Ĵaŭdo_Vendredo_Sabato".split("_"),weekdaysShort:"Dim_Lun_Mard_Merk_Ĵaŭ_Ven_Sab".split("_"),weekdaysMin:"Di_Lu_Ma_Me_Ĵa_Ve_Sa".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"YYYY-MM-DD",LL:"D[-an de] MMMM, YYYY",LLL:"D[-an de] MMMM, YYYY LT",LLLL:"dddd, [la] D[-an de] MMMM, YYYY LT"},meridiemParse:/[ap]\.t\.m/i,isPM:function(a){return"p"===a.charAt(0).toLowerCase()},meridiem:function(a,b,c){return a>11?c?"p.t.m.":"P.T.M.":c?"a.t.m.":"A.T.M."},calendar:{sameDay:"[Hodiaŭ je] LT",nextDay:"[Morgaŭ je] LT",nextWeek:"dddd [je] LT",lastDay:"[Hieraŭ je] LT",lastWeek:"[pasinta] dddd [je] LT",sameElse:"L"},relativeTime:{future:"je %s",past:"antaŭ %s",s:"sekundoj",m:"minuto",mm:"%d minutoj",h:"horo",hh:"%d horoj",d:"tago",dd:"%d tagoj",M:"monato",MM:"%d monatoj",y:"jaro",yy:"%d jaroj"},ordinalParse:/\d{1,2}a/,ordinal:"%da",week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){var b="ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.".split("_"),c="ene_feb_mar_abr_may_jun_jul_ago_sep_oct_nov_dic".split("_");return a.defineLocale("es",{months:"enero_febrero_marzo_abril_mayo_junio_julio_agosto_septiembre_octubre_noviembre_diciembre".split("_"),monthsShort:function(a,d){return/-MMM-/.test(d)?c[a.month()]:b[a.month()]},weekdays:"domingo_lunes_martes_miércoles_jueves_viernes_sábado".split("_"),weekdaysShort:"dom._lun._mar._mié._jue._vie._sáb.".split("_"),weekdaysMin:"Do_Lu_Ma_Mi_Ju_Vi_Sá".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D [de] MMMM [de] YYYY",LLL:"D [de] MMMM [de] YYYY LT",LLLL:"dddd, D [de] MMMM [de] YYYY LT"},calendar:{sameDay:function(){return"[hoy a la"+(1!==this.hours()?"s":"")+"] LT"},nextDay:function(){return"[mañana a la"+(1!==this.hours()?"s":"")+"] LT"},nextWeek:function(){return"dddd [a la"+(1!==this.hours()?"s":"")+"] LT"},lastDay:function(){return"[ayer a la"+(1!==this.hours()?"s":"")+"] LT"},lastWeek:function(){return"[el] dddd [pasado a la"+(1!==this.hours()?"s":"")+"] LT"},sameElse:"L"},relativeTime:{future:"en %s",past:"hace %s",s:"unos segundos",m:"un minuto",mm:"%d minutos",h:"una hora",hh:"%d horas",d:"un día",dd:"%d días",M:"un mes",MM:"%d meses",y:"un año",yy:"%d años"},ordinalParse:/\d{1,2}º/,ordinal:"%dº",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){function b(a,b,c,d){var e={s:["mõne sekundi","mõni sekund","paar sekundit"],m:["ühe minuti","üks minut"],mm:[a+" minuti",a+" minutit"],h:["ühe tunni","tund aega","üks tund"],hh:[a+" tunni",a+" tundi"],d:["ühe päeva","üks päev"],M:["kuu aja","kuu aega","üks kuu"],MM:[a+" kuu",a+" kuud"],y:["ühe aasta","aasta","üks aasta"],yy:[a+" aasta",a+" aastat"]};return b?e[c][2]?e[c][2]:e[c][1]:d?e[c][0]:e[c][1]}return a.defineLocale("et",{months:"jaanuar_veebruar_märts_aprill_mai_juuni_juuli_august_september_oktoober_november_detsember".split("_"),monthsShort:"jaan_veebr_märts_apr_mai_juuni_juuli_aug_sept_okt_nov_dets".split("_"),weekdays:"pühapäev_esmaspäev_teisipäev_kolmapäev_neljapäev_reede_laupäev".split("_"),weekdaysShort:"P_E_T_K_N_R_L".split("_"),weekdaysMin:"P_E_T_K_N_R_L".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"DD.MM.YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY LT",LLLL:"dddd, D. MMMM YYYY LT"},calendar:{sameDay:"[Täna,] LT",nextDay:"[Homme,] LT",nextWeek:"[Järgmine] dddd LT",lastDay:"[Eile,] LT",lastWeek:"[Eelmine] dddd LT",sameElse:"L"},relativeTime:{future:"%s pärast",past:"%s tagasi",s:b,m:b,mm:b,h:b,hh:b,d:b,dd:"%d päeva",M:b,MM:b,y:b,yy:b},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("eu",{months:"urtarrila_otsaila_martxoa_apirila_maiatza_ekaina_uztaila_abuztua_iraila_urria_azaroa_abendua".split("_"),monthsShort:"urt._ots._mar._api._mai._eka._uzt._abu._ira._urr._aza._abe.".split("_"),weekdays:"igandea_astelehena_asteartea_asteazkena_osteguna_ostirala_larunbata".split("_"),weekdaysShort:"ig._al._ar._az._og._ol._lr.".split("_"),weekdaysMin:"ig_al_ar_az_og_ol_lr".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"YYYY-MM-DD",LL:"YYYY[ko] MMMM[ren] D[a]",LLL:"YYYY[ko] MMMM[ren] D[a] LT",LLLL:"dddd, YYYY[ko] MMMM[ren] D[a] LT",l:"YYYY-M-D",ll:"YYYY[ko] MMM D[a]",lll:"YYYY[ko] MMM D[a] LT",llll:"ddd, YYYY[ko] MMM D[a] LT"},calendar:{sameDay:"[gaur] LT[etan]",nextDay:"[bihar] LT[etan]",nextWeek:"dddd LT[etan]",lastDay:"[atzo] LT[etan]",lastWeek:"[aurreko] dddd LT[etan]",sameElse:"L"},relativeTime:{future:"%s barru",past:"duela %s",s:"segundo batzuk",m:"minutu bat",mm:"%d minutu",h:"ordu bat",hh:"%d ordu",d:"egun bat",dd:"%d egun",M:"hilabete bat",MM:"%d hilabete",y:"urte bat",yy:"%d urte"},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){var b={1:"۱",2:"۲",3:"۳",4:"۴",5:"۵",6:"۶",7:"۷",8:"۸",9:"۹",0:"۰"},c={"۱":"1","۲":"2","۳":"3","۴":"4","۵":"5","۶":"6","۷":"7","۸":"8","۹":"9","۰":"0"};return a.defineLocale("fa",{months:"ژانویه_فوریه_مارس_آوریل_مه_ژوئن_ژوئیه_اوت_سپتامبر_اکتبر_نوامبر_دسامبر".split("_"),monthsShort:"ژانویه_فوریه_مارس_آوریل_مه_ژوئن_ژوئیه_اوت_سپتامبر_اکتبر_نوامبر_دسامبر".split("_"),weekdays:"یک‌شنبه_دوشنبه_سه‌شنبه_چهارشنبه_پنج‌شنبه_جمعه_شنبه".split("_"),weekdaysShort:"یک‌شنبه_دوشنبه_سه‌شنبه_چهارشنبه_پنج‌شنبه_جمعه_شنبه".split("_"),weekdaysMin:"ی_د_س_چ_پ_ج_ش".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},meridiemParse:/قبل از ظهر|بعد از ظهر/,isPM:function(a){return/بعد از ظهر/.test(a)},meridiem:function(a){return 12>a?"قبل از ظهر":"بعد از ظهر"},calendar:{sameDay:"[امروز ساعت] LT",nextDay:"[فردا ساعت] LT",nextWeek:"dddd [ساعت] LT",lastDay:"[دیروز ساعت] LT",lastWeek:"dddd [پیش] [ساعت] LT",sameElse:"L"},relativeTime:{future:"در %s",past:"%s پیش",s:"چندین ثانیه",m:"یک دقیقه",mm:"%d دقیقه",h:"یک ساعت",hh:"%d ساعت",d:"یک روز",dd:"%d روز",M:"یک ماه",MM:"%d ماه",y:"یک سال",yy:"%d سال"},preparse:function(a){return a.replace(/[۰-۹]/g,function(a){return c[a]}).replace(/،/g,",")},postformat:function(a){return a.replace(/\d/g,function(a){return b[a]}).replace(/,/g,"،")},ordinalParse:/\d{1,2}م/,ordinal:"%dم",week:{dow:6,doy:12}})}),function(a){a(va)}(function(a){function b(a,b,d,e){var f="";switch(d){case"s":return e?"muutaman sekunnin":"muutama sekunti";case"m":return e?"minuutin":"minuutti";case"mm":f=e?"minuutin":"minuuttia";break;case"h":return e?"tunnin":"tunti";case"hh":f=e?"tunnin":"tuntia";break;case"d":return e?"päivän":"päivä";case"dd":f=e?"päivän":"päivää";break;case"M":return e?"kuukauden":"kuukausi";case"MM":f=e?"kuukauden":"kuukautta";break;case"y":return e?"vuoden":"vuosi";case"yy":f=e?"vuoden":"vuotta"}return f=c(a,e)+" "+f}function c(a,b){return 10>a?b?e[a]:d[a]:a}var d="nolla yksi kaksi kolme neljä viisi kuusi seitsemän kahdeksan yhdeksän".split(" "),e=["nolla","yhden","kahden","kolmen","neljän","viiden","kuuden",d[7],d[8],d[9]];return a.defineLocale("fi",{months:"tammikuu_helmikuu_maaliskuu_huhtikuu_toukokuu_kesäkuu_heinäkuu_elokuu_syyskuu_lokakuu_marraskuu_joulukuu".split("_"),monthsShort:"tammi_helmi_maalis_huhti_touko_kesä_heinä_elo_syys_loka_marras_joulu".split("_"),weekdays:"sunnuntai_maanantai_tiistai_keskiviikko_torstai_perjantai_lauantai".split("_"),weekdaysShort:"su_ma_ti_ke_to_pe_la".split("_"),weekdaysMin:"su_ma_ti_ke_to_pe_la".split("_"),longDateFormat:{LT:"HH.mm",LTS:"HH.mm.ss",L:"DD.MM.YYYY",LL:"Do MMMM[ta] YYYY",LLL:"Do MMMM[ta] YYYY, [klo] LT",LLLL:"dddd, Do MMMM[ta] YYYY, [klo] LT",l:"D.M.YYYY",ll:"Do MMM YYYY",lll:"Do MMM YYYY, [klo] LT",llll:"ddd, Do MMM YYYY, [klo] LT"},calendar:{sameDay:"[tänään] [klo] LT",nextDay:"[huomenna] [klo] LT",nextWeek:"dddd [klo] LT",lastDay:"[eilen] [klo] LT",lastWeek:"[viime] dddd[na] [klo] LT",sameElse:"L"},relativeTime:{future:"%s päästä",past:"%s sitten",s:b,m:b,mm:b,h:b,hh:b,d:b,dd:b,M:b,MM:b,y:b,yy:b},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("fo",{months:"januar_februar_mars_apríl_mai_juni_juli_august_september_oktober_november_desember".split("_"),monthsShort:"jan_feb_mar_apr_mai_jun_jul_aug_sep_okt_nov_des".split("_"),weekdays:"sunnudagur_mánadagur_týsdagur_mikudagur_hósdagur_fríggjadagur_leygardagur".split("_"),weekdaysShort:"sun_mán_týs_mik_hós_frí_ley".split("_"),weekdaysMin:"su_má_tý_mi_hó_fr_le".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D. MMMM, YYYY LT"},calendar:{sameDay:"[Í dag kl.] LT",nextDay:"[Í morgin kl.] LT",nextWeek:"dddd [kl.] LT",lastDay:"[Í gjár kl.] LT",lastWeek:"[síðstu] dddd [kl] LT",sameElse:"L"},relativeTime:{future:"um %s",past:"%s síðani",s:"fá sekund",m:"ein minutt",mm:"%d minuttir",h:"ein tími",hh:"%d tímar",d:"ein dagur",dd:"%d dagar",M:"ein mánaði",MM:"%d mánaðir",y:"eitt ár",yy:"%d ár"},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("fr-ca",{months:"janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre".split("_"),monthsShort:"janv._févr._mars_avr._mai_juin_juil._août_sept._oct._nov._déc.".split("_"),weekdays:"dimanche_lundi_mardi_mercredi_jeudi_vendredi_samedi".split("_"),weekdaysShort:"dim._lun._mar._mer._jeu._ven._sam.".split("_"),weekdaysMin:"Di_Lu_Ma_Me_Je_Ve_Sa".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"YYYY-MM-DD",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},calendar:{sameDay:"[Aujourd'hui à] LT",nextDay:"[Demain à] LT",nextWeek:"dddd [à] LT",lastDay:"[Hier à] LT",lastWeek:"dddd [dernier à] LT",sameElse:"L"},relativeTime:{future:"dans %s",past:"il y a %s",s:"quelques secondes",m:"une minute",mm:"%d minutes",h:"une heure",hh:"%d heures",d:"un jour",dd:"%d jours",M:"un mois",MM:"%d mois",y:"un an",yy:"%d ans"},ordinalParse:/\d{1,2}(er|)/,ordinal:function(a){return a+(1===a?"er":"")}})}),function(a){a(va)}(function(a){return a.defineLocale("fr",{months:"janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre".split("_"),monthsShort:"janv._févr._mars_avr._mai_juin_juil._août_sept._oct._nov._déc.".split("_"),weekdays:"dimanche_lundi_mardi_mercredi_jeudi_vendredi_samedi".split("_"),weekdaysShort:"dim._lun._mar._mer._jeu._ven._sam.".split("_"),weekdaysMin:"Di_Lu_Ma_Me_Je_Ve_Sa".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},calendar:{sameDay:"[Aujourd'hui à] LT",nextDay:"[Demain à] LT",nextWeek:"dddd [à] LT",lastDay:"[Hier à] LT",lastWeek:"dddd [dernier à] LT",sameElse:"L"},relativeTime:{future:"dans %s",past:"il y a %s",s:"quelques secondes",m:"une minute",mm:"%d minutes",h:"une heure",hh:"%d heures",d:"un jour",dd:"%d jours",M:"un mois",MM:"%d mois",y:"un an",yy:"%d ans"},ordinalParse:/\d{1,2}(er|)/,ordinal:function(a){return a+(1===a?"er":"")},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){var b="jan._feb._mrt._apr._mai_jun._jul._aug._sep._okt._nov._des.".split("_"),c="jan_feb_mrt_apr_mai_jun_jul_aug_sep_okt_nov_des".split("_");return a.defineLocale("fy",{months:"jannewaris_febrewaris_maart_april_maaie_juny_july_augustus_septimber_oktober_novimber_desimber".split("_"),monthsShort:function(a,d){return/-MMM-/.test(d)?c[a.month()]:b[a.month()]},weekdays:"snein_moandei_tiisdei_woansdei_tongersdei_freed_sneon".split("_"),weekdaysShort:"si._mo._ti._wo._to._fr._so.".split("_"),weekdaysMin:"Si_Mo_Ti_Wo_To_Fr_So".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD-MM-YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},calendar:{sameDay:"[hjoed om] LT",nextDay:"[moarn om] LT",nextWeek:"dddd [om] LT",lastDay:"[juster om] LT",lastWeek:"[ôfrûne] dddd [om] LT",sameElse:"L"},relativeTime:{future:"oer %s",past:"%s lyn",s:"in pear sekonden",m:"ien minút",mm:"%d minuten",h:"ien oere",hh:"%d oeren",d:"ien dei",dd:"%d dagen",M:"ien moanne",MM:"%d moannen",y:"ien jier",yy:"%d jierren"},ordinalParse:/\d{1,2}(ste|de)/,ordinal:function(a){return a+(1===a||8===a||a>=20?"ste":"de")},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("gl",{months:"Xaneiro_Febreiro_Marzo_Abril_Maio_Xuño_Xullo_Agosto_Setembro_Outubro_Novembro_Decembro".split("_"),monthsShort:"Xan._Feb._Mar._Abr._Mai._Xuñ._Xul._Ago._Set._Out._Nov._Dec.".split("_"),weekdays:"Domingo_Luns_Martes_Mércores_Xoves_Venres_Sábado".split("_"),weekdaysShort:"Dom._Lun._Mar._Mér._Xov._Ven._Sáb.".split("_"),weekdaysMin:"Do_Lu_Ma_Mé_Xo_Ve_Sá".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},calendar:{sameDay:function(){return"[hoxe "+(1!==this.hours()?"ás":"á")+"] LT"},nextDay:function(){return"[mañá "+(1!==this.hours()?"ás":"á")+"] LT"},nextWeek:function(){return"dddd ["+(1!==this.hours()?"ás":"a")+"] LT"},lastDay:function(){return"[onte "+(1!==this.hours()?"á":"a")+"] LT"},lastWeek:function(){return"[o] dddd [pasado "+(1!==this.hours()?"ás":"a")+"] LT"},sameElse:"L"},relativeTime:{future:function(a){return"uns segundos"===a?"nuns segundos":"en "+a},past:"hai %s",s:"uns segundos",m:"un minuto",mm:"%d minutos",h:"unha hora",hh:"%d horas",d:"un día",dd:"%d días",M:"un mes",MM:"%d meses",y:"un ano",yy:"%d anos"},ordinalParse:/\d{1,2}º/,ordinal:"%dº",week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){return a.defineLocale("he",{months:"ינואר_פברואר_מרץ_אפריל_מאי_יוני_יולי_אוגוסט_ספטמבר_אוקטובר_נובמבר_דצמבר".split("_"),monthsShort:"ינו׳_פבר׳_מרץ_אפר׳_מאי_יוני_יולי_אוג׳_ספט׳_אוק׳_נוב׳_דצמ׳".split("_"),weekdays:"ראשון_שני_שלישי_רביעי_חמישי_שישי_שבת".split("_"),weekdaysShort:"א׳_ב׳_ג׳_ד׳_ה׳_ו׳_ש׳".split("_"),weekdaysMin:"א_ב_ג_ד_ה_ו_ש".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D [ב]MMMM YYYY",LLL:"D [ב]MMMM YYYY LT",LLLL:"dddd, D [ב]MMMM YYYY LT",l:"D/M/YYYY",ll:"D MMM YYYY",lll:"D MMM YYYY LT",llll:"ddd, D MMM YYYY LT"},calendar:{sameDay:"[היום ב־]LT",nextDay:"[מחר ב־]LT",nextWeek:"dddd [בשעה] LT",lastDay:"[אתמול ב־]LT",lastWeek:"[ביום] dddd [האחרון בשעה] LT",sameElse:"L"},relativeTime:{future:"בעוד %s",past:"לפני %s",s:"מספר שניות",m:"דקה",mm:"%d דקות",h:"שעה",hh:function(a){return 2===a?"שעתיים":a+" שעות"},d:"יום",dd:function(a){return 2===a?"יומיים":a+" ימים"},M:"חודש",MM:function(a){return 2===a?"חודשיים":a+" חודשים"},y:"שנה",yy:function(a){return 2===a?"שנתיים":a%10===0&&10!==a?a+" שנה":a+" שנים"}}})}),function(a){a(va)}(function(a){var b={1:"१",2:"२",3:"३",4:"४",5:"५",6:"६",7:"७",8:"८",9:"९",0:"०"},c={"१":"1","२":"2","३":"3","४":"4","५":"5","६":"6","७":"7","८":"8","९":"9","०":"0"};return a.defineLocale("hi",{months:"जनवरी_फ़रवरी_मार्च_अप्रैल_मई_जून_जुलाई_अगस्त_सितम्बर_अक्टूबर_नवम्बर_दिसम्बर".split("_"),monthsShort:"जन._फ़र._मार्च_अप्रै._मई_जून_जुल._अग._सित._अक्टू._नव._दिस.".split("_"),weekdays:"रविवार_सोमवार_मंगलवार_बुधवार_गुरूवार_शुक्रवार_शनिवार".split("_"),weekdaysShort:"रवि_सोम_मंगल_बुध_गुरू_शुक्र_शनि".split("_"),weekdaysMin:"र_सो_मं_बु_गु_शु_श".split("_"),longDateFormat:{LT:"A h:mm बजे",LTS:"A h:mm:ss बजे",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY, LT",LLLL:"dddd, D MMMM YYYY, LT"},calendar:{sameDay:"[आज] LT",nextDay:"[कल] LT",nextWeek:"dddd, LT",lastDay:"[कल] LT",lastWeek:"[पिछले] dddd, LT",sameElse:"L"},relativeTime:{future:"%s में",past:"%s पहले",s:"कुछ ही क्षण",m:"एक मिनट",mm:"%d मिनट",h:"एक घंटा",hh:"%d घंटे",d:"एक दिन",dd:"%d दिन",M:"एक महीने",MM:"%d महीने",y:"एक वर्ष",yy:"%d वर्ष"},preparse:function(a){return a.replace(/[१२३४५६७८९०]/g,function(a){return c[a]})},postformat:function(a){return a.replace(/\d/g,function(a){return b[a]})},meridiemParse:/रात|सुबह|दोपहर|शाम/,meridiemHour:function(a,b){return 12===a&&(a=0),"रात"===b?4>a?a:a+12:"सुबह"===b?a:"दोपहर"===b?a>=10?a:a+12:"शाम"===b?a+12:void 0},meridiem:function(a){return 4>a?"रात":10>a?"सुबह":17>a?"दोपहर":20>a?"शाम":"रात"},week:{dow:0,doy:6}})}),function(a){a(va)}(function(a){function b(a,b,c){var d=a+" ";switch(c){case"m":return b?"jedna minuta":"jedne minute";case"mm":return d+=1===a?"minuta":2===a||3===a||4===a?"minute":"minuta";case"h":return b?"jedan sat":"jednog sata";case"hh":return d+=1===a?"sat":2===a||3===a||4===a?"sata":"sati";case"dd":return d+=1===a?"dan":"dana";case"MM":return d+=1===a?"mjesec":2===a||3===a||4===a?"mjeseca":"mjeseci";case"yy":return d+=1===a?"godina":2===a||3===a||4===a?"godine":"godina"}}return a.defineLocale("hr",{months:"sječanj_veljača_ožujak_travanj_svibanj_lipanj_srpanj_kolovoz_rujan_listopad_studeni_prosinac".split("_"),monthsShort:"sje._vel._ožu._tra._svi._lip._srp._kol._ruj._lis._stu._pro.".split("_"),weekdays:"nedjelja_ponedjeljak_utorak_srijeda_četvrtak_petak_subota".split("_"),weekdaysShort:"ned._pon._uto._sri._čet._pet._sub.".split("_"),weekdaysMin:"ne_po_ut_sr_če_pe_su".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"DD. MM. YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY LT",LLLL:"dddd, D. MMMM YYYY LT"},calendar:{sameDay:"[danas u] LT",nextDay:"[sutra u] LT",nextWeek:function(){switch(this.day()){case 0:return"[u] [nedjelju] [u] LT";case 3:return"[u] [srijedu] [u] LT";case 6:return"[u] [subotu] [u] LT";case 1:case 2:case 4:case 5:return"[u] dddd [u] LT"}},lastDay:"[jučer u] LT",lastWeek:function(){switch(this.day()){case 0:case 3:return"[prošlu] dddd [u] LT";case 6:return"[prošle] [subote] [u] LT";case 1:case 2:case 4:case 5:return"[prošli] dddd [u] LT"}},sameElse:"L"},relativeTime:{future:"za %s",past:"prije %s",s:"par sekundi",m:b,mm:b,h:b,hh:b,d:"dan",dd:b,M:"mjesec",MM:b,y:"godinu",yy:b},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){function b(a,b,c,d){var e=a;switch(c){case"s":return d||b?"néhány másodperc":"néhány másodperce";case"m":return"egy"+(d||b?" perc":" perce");case"mm":return e+(d||b?" perc":" perce");case"h":return"egy"+(d||b?" óra":" órája");case"hh":return e+(d||b?" óra":" órája");case"d":return"egy"+(d||b?" nap":" napja");case"dd":return e+(d||b?" nap":" napja");case"M":return"egy"+(d||b?" hónap":" hónapja");case"MM":return e+(d||b?" hónap":" hónapja");case"y":return"egy"+(d||b?" év":" éve");case"yy":return e+(d||b?" év":" éve")}return""}function c(a){return(a?"":"[múlt] ")+"["+d[this.day()]+"] LT[-kor]"}var d="vasárnap hétfőn kedden szerdán csütörtökön pénteken szombaton".split(" ");return a.defineLocale("hu",{months:"január_február_március_április_május_június_július_augusztus_szeptember_október_november_december".split("_"),monthsShort:"jan_feb_márc_ápr_máj_jún_júl_aug_szept_okt_nov_dec".split("_"),weekdays:"vasárnap_hétfő_kedd_szerda_csütörtök_péntek_szombat".split("_"),weekdaysShort:"vas_hét_kedd_sze_csüt_pén_szo".split("_"),weekdaysMin:"v_h_k_sze_cs_p_szo".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"YYYY.MM.DD.",LL:"YYYY. MMMM D.",LLL:"YYYY. MMMM D., LT",LLLL:"YYYY. MMMM D., dddd LT"},meridiemParse:/de|du/i,isPM:function(a){return"u"===a.charAt(1).toLowerCase()},meridiem:function(a,b,c){return 12>a?c===!0?"de":"DE":c===!0?"du":"DU"},calendar:{sameDay:"[ma] LT[-kor]",nextDay:"[holnap] LT[-kor]",nextWeek:function(){return c.call(this,!0)},lastDay:"[tegnap] LT[-kor]",lastWeek:function(){return c.call(this,!1)},sameElse:"L"},relativeTime:{future:"%s múlva",past:"%s",s:b,m:b,mm:b,h:b,hh:b,d:b,dd:b,M:b,MM:b,y:b,yy:b},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){function b(a,b){var c={nominative:"հունվար_փետրվար_մարտ_ապրիլ_մայիս_հունիս_հուլիս_օգոստոս_սեպտեմբեր_հոկտեմբեր_նոյեմբեր_դեկտեմբեր".split("_"),accusative:"հունվարի_փետրվարի_մարտի_ապրիլի_մայիսի_հունիսի_հուլիսի_օգոստոսի_սեպտեմբերի_հոկտեմբերի_նոյեմբերի_դեկտեմբերի".split("_")},d=/D[oD]?(\[[^\[\]]*\]|\s+)+MMMM?/.test(b)?"accusative":"nominative";return c[d][a.month()]}function c(a){var b="հնվ_փտր_մրտ_ապր_մյս_հնս_հլս_օգս_սպտ_հկտ_նմբ_դկտ".split("_");return b[a.month()]}function d(a){var b="կիրակի_երկուշաբթի_երեքշաբթի_չորեքշաբթի_հինգշաբթի_ուրբաթ_շաբաթ".split("_");return b[a.day()]}return a.defineLocale("hy-am",{months:b,monthsShort:c,weekdays:d,weekdaysShort:"կրկ_երկ_երք_չրք_հնգ_ուրբ_շբթ".split("_"),weekdaysMin:"կրկ_երկ_երք_չրք_հնգ_ուրբ_շբթ".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD.MM.YYYY",LL:"D MMMM YYYY թ.",LLL:"D MMMM YYYY թ., LT",LLLL:"dddd, D MMMM YYYY թ., LT"},calendar:{sameDay:"[այսօր] LT",nextDay:"[վաղը] LT",lastDay:"[երեկ] LT",nextWeek:function(){return"dddd [օրը ժամը] LT"},lastWeek:function(){return"[անցած] dddd [օրը ժամը] LT"},sameElse:"L"},relativeTime:{future:"%s հետո",past:"%s առաջ",s:"մի քանի վայրկյան",m:"րոպե",mm:"%d րոպե",h:"ժամ",hh:"%d ժամ",d:"օր",dd:"%d օր",M:"ամիս",MM:"%d ամիս",y:"տարի",yy:"%d տարի"},meridiemParse:/գիշերվա|առավոտվա|ցերեկվա|երեկոյան/,isPM:function(a){return/^(ցերեկվա|երեկոյան)$/.test(a)},meridiem:function(a){return 4>a?"գիշերվա":12>a?"առավոտվա":17>a?"ցերեկվա":"երեկոյան"},ordinalParse:/\d{1,2}|\d{1,2}-(ին|րդ)/,ordinal:function(a,b){switch(b){case"DDD":case"w":case"W":case"DDDo":return 1===a?a+"-ին":a+"-րդ";default:return a}},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){return a.defineLocale("id",{months:"Januari_Februari_Maret_April_Mei_Juni_Juli_Agustus_September_Oktober_November_Desember".split("_"),monthsShort:"Jan_Feb_Mar_Apr_Mei_Jun_Jul_Ags_Sep_Okt_Nov_Des".split("_"),weekdays:"Minggu_Senin_Selasa_Rabu_Kamis_Jumat_Sabtu".split("_"),weekdaysShort:"Min_Sen_Sel_Rab_Kam_Jum_Sab".split("_"),weekdaysMin:"Mg_Sn_Sl_Rb_Km_Jm_Sb".split("_"),longDateFormat:{LT:"HH.mm",LTS:"LT.ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY [pukul] LT",LLLL:"dddd, D MMMM YYYY [pukul] LT"},meridiemParse:/pagi|siang|sore|malam/,meridiemHour:function(a,b){return 12===a&&(a=0),"pagi"===b?a:"siang"===b?a>=11?a:a+12:"sore"===b||"malam"===b?a+12:void 0},meridiem:function(a){return 11>a?"pagi":15>a?"siang":19>a?"sore":"malam"},calendar:{sameDay:"[Hari ini pukul] LT",nextDay:"[Besok pukul] LT",nextWeek:"dddd [pukul] LT",lastDay:"[Kemarin pukul] LT",lastWeek:"dddd [lalu pukul] LT",sameElse:"L"},relativeTime:{future:"dalam %s",past:"%s yang lalu",s:"beberapa detik",m:"semenit",mm:"%d menit",h:"sejam",hh:"%d jam",d:"sehari",dd:"%d hari",M:"sebulan",MM:"%d bulan",y:"setahun",yy:"%d tahun"},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){function b(a){return a%100===11?!0:a%10===1?!1:!0}function c(a,c,d,e){var f=a+" ";switch(d){case"s":return c||e?"nokkrar sekúndur":"nokkrum sekúndum";case"m":return c?"mínúta":"mínútu";case"mm":return b(a)?f+(c||e?"mínútur":"mínútum"):c?f+"mínúta":f+"mínútu";case"hh":return b(a)?f+(c||e?"klukkustundir":"klukkustundum"):f+"klukkustund";case"d":return c?"dagur":e?"dag":"degi";case"dd":return b(a)?c?f+"dagar":f+(e?"daga":"dögum"):c?f+"dagur":f+(e?"dag":"degi");case"M":return c?"mánuður":e?"mánuð":"mánuði";case"MM":return b(a)?c?f+"mánuðir":f+(e?"mánuði":"mánuðum"):c?f+"mánuður":f+(e?"mánuð":"mánuði");case"y":return c||e?"ár":"ári";case"yy":return b(a)?f+(c||e?"ár":"árum"):f+(c||e?"ár":"ári")}}return a.defineLocale("is",{months:"janúar_febrúar_mars_apríl_maí_júní_júlí_ágúst_september_október_nóvember_desember".split("_"),monthsShort:"jan_feb_mar_apr_maí_jún_júl_ágú_sep_okt_nóv_des".split("_"),weekdays:"sunnudagur_mánudagur_þriðjudagur_miðvikudagur_fimmtudagur_föstudagur_laugardagur".split("_"),weekdaysShort:"sun_mán_þri_mið_fim_fös_lau".split("_"),weekdaysMin:"Su_Má_Þr_Mi_Fi_Fö_La".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY [kl.] LT",LLLL:"dddd, D. MMMM YYYY [kl.] LT"},calendar:{sameDay:"[í dag kl.] LT",nextDay:"[á morgun kl.] LT",nextWeek:"dddd [kl.] LT",lastDay:"[í gær kl.] LT",lastWeek:"[síðasta] dddd [kl.] LT",sameElse:"L"},relativeTime:{future:"eftir %s",past:"fyrir %s síðan",s:c,m:c,mm:c,h:"klukkustund",hh:c,d:c,dd:c,M:c,MM:c,y:c,yy:c},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("it",{months:"gennaio_febbraio_marzo_aprile_maggio_giugno_luglio_agosto_settembre_ottobre_novembre_dicembre".split("_"),monthsShort:"gen_feb_mar_apr_mag_giu_lug_ago_set_ott_nov_dic".split("_"),weekdays:"Domenica_Lunedì_Martedì_Mercoledì_Giovedì_Venerdì_Sabato".split("_"),weekdaysShort:"Dom_Lun_Mar_Mer_Gio_Ven_Sab".split("_"),weekdaysMin:"D_L_Ma_Me_G_V_S".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendar:{sameDay:"[Oggi alle] LT",nextDay:"[Domani alle] LT",nextWeek:"dddd [alle] LT",lastDay:"[Ieri alle] LT",lastWeek:function(){switch(this.day()){case 0:return"[la scorsa] dddd [alle] LT";default:return"[lo scorso] dddd [alle] LT"}},sameElse:"L"},relativeTime:{future:function(a){return(/^[0-9].+$/.test(a)?"tra":"in")+" "+a},past:"%s fa",s:"alcuni secondi",m:"un minuto",mm:"%d minuti",h:"un'ora",hh:"%d ore",d:"un giorno",dd:"%d giorni",M:"un mese",MM:"%d mesi",y:"un anno",yy:"%d anni"},ordinalParse:/\d{1,2}º/,ordinal:"%dº",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("ja",{months:"1月_2月_3月_4月_5月_6月_7月_8月_9月_10月_11月_12月".split("_"),monthsShort:"1月_2月_3月_4月_5月_6月_7月_8月_9月_10月_11月_12月".split("_"),weekdays:"日曜日_月曜日_火曜日_水曜日_木曜日_金曜日_土曜日".split("_"),weekdaysShort:"日_月_火_水_木_金_土".split("_"),weekdaysMin:"日_月_火_水_木_金_土".split("_"),longDateFormat:{LT:"Ah時m分",LTS:"LTs秒",L:"YYYY/MM/DD",LL:"YYYY年M月D日",LLL:"YYYY年M月D日LT",LLLL:"YYYY年M月D日LT dddd"},meridiemParse:/午前|午後/i,isPM:function(a){return"午後"===a},meridiem:function(a){return 12>a?"午前":"午後"},calendar:{sameDay:"[今日] LT",nextDay:"[明日] LT",nextWeek:"[来週]dddd LT",lastDay:"[昨日] LT",lastWeek:"[前週]dddd LT",sameElse:"L"},relativeTime:{future:"%s後",past:"%s前",s:"数秒",m:"1分",mm:"%d分",h:"1時間",hh:"%d時間",d:"1日",dd:"%d日",M:"1ヶ月",MM:"%dヶ月",y:"1年",yy:"%d年"}})}),function(a){a(va)}(function(a){function b(a,b){var c={nominative:"იანვარი_თებერვალი_მარტი_აპრილი_მაისი_ივნისი_ივლისი_აგვისტო_სექტემბერი_ოქტომბერი_ნოემბერი_დეკემბერი".split("_"),accusative:"იანვარს_თებერვალს_მარტს_აპრილის_მაისს_ივნისს_ივლისს_აგვისტს_სექტემბერს_ოქტომბერს_ნოემბერს_დეკემბერს".split("_")},d=/D[oD] *MMMM?/.test(b)?"accusative":"nominative";return c[d][a.month()]}function c(a,b){var c={nominative:"კვირა_ორშაბათი_სამშაბათი_ოთხშაბათი_ხუთშაბათი_პარასკევი_შაბათი".split("_"),accusative:"კვირას_ორშაბათს_სამშაბათს_ოთხშაბათს_ხუთშაბათს_პარასკევს_შაბათს".split("_")},d=/(წინა|შემდეგ)/.test(b)?"accusative":"nominative";return c[d][a.day()]}return a.defineLocale("ka",{months:b,monthsShort:"იან_თებ_მარ_აპრ_მაი_ივნ_ივლ_აგვ_სექ_ოქტ_ნოე_დეკ".split("_"),weekdays:c,weekdaysShort:"კვი_ორშ_სამ_ოთხ_ხუთ_პარ_შაბ".split("_"),weekdaysMin:"კვ_ორ_სა_ოთ_ხუ_პა_შა".split("_"),longDateFormat:{LT:"h:mm A",LTS:"h:mm:ss A",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendar:{sameDay:"[დღეს] LT[-ზე]",nextDay:"[ხვალ] LT[-ზე]",lastDay:"[გუშინ] LT[-ზე]",nextWeek:"[შემდეგ] dddd LT[-ზე]",lastWeek:"[წინა] dddd LT-ზე",sameElse:"L"},relativeTime:{future:function(a){return/(წამი|წუთი|საათი|წელი)/.test(a)?a.replace(/ი$/,"ში"):a+"ში"},past:function(a){return/(წამი|წუთი|საათი|დღე|თვე)/.test(a)?a.replace(/(ი|ე)$/,"ის წინ"):/წელი/.test(a)?a.replace(/წელი$/,"წლის წინ"):void 0},s:"რამდენიმე წამი",m:"წუთი",mm:"%d წუთი",h:"საათი",hh:"%d საათი",d:"დღე",dd:"%d დღე",M:"თვე",MM:"%d თვე",y:"წელი",yy:"%d წელი"},ordinalParse:/0|1-ლი|მე-\d{1,2}|\d{1,2}-ე/,ordinal:function(a){return 0===a?a:1===a?a+"-ლი":20>a||100>=a&&a%20===0||a%100===0?"მე-"+a:a+"-ე"},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){return a.defineLocale("km",{months:"មករា_កុម្ភៈ_មិនា_មេសា_ឧសភា_មិថុនា_កក្កដា_សីហា_កញ្ញា_តុលា_វិច្ឆិកា_ធ្នូ".split("_"),monthsShort:"មករា_កុម្ភៈ_មិនា_មេសា_ឧសភា_មិថុនា_កក្កដា_សីហា_កញ្ញា_តុលា_វិច្ឆិកា_ធ្នូ".split("_"),weekdays:"អាទិត្យ_ច័ន្ទ_អង្គារ_ពុធ_ព្រហស្បតិ៍_សុក្រ_សៅរ៍".split("_"),weekdaysShort:"អាទិត្យ_ច័ន្ទ_អង្គារ_ពុធ_ព្រហស្បតិ៍_សុក្រ_សៅរ៍".split("_"),weekdaysMin:"អាទិត្យ_ច័ន្ទ_អង្គារ_ពុធ_ព្រហស្បតិ៍_សុក្រ_សៅរ៍".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendar:{sameDay:"[ថ្ងៃនៈ ម៉ោង] LT",nextDay:"[ស្អែក ម៉ោង] LT",nextWeek:"dddd [ម៉ោង] LT",lastDay:"[ម្សិលមិញ ម៉ោង] LT",lastWeek:"dddd [សប្តាហ៍មុន] [ម៉ោង] LT",sameElse:"L"},relativeTime:{future:"%sទៀត",past:"%sមុន",s:"ប៉ុន្មានវិនាទី",m:"មួយនាទី",mm:"%d នាទី",h:"មួយម៉ោង",hh:"%d ម៉ោង",d:"មួយថ្ងៃ",dd:"%d ថ្ងៃ",M:"មួយខែ",MM:"%d ខែ",y:"មួយឆ្នាំ",yy:"%d ឆ្នាំ"},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("ko",{months:"1월_2월_3월_4월_5월_6월_7월_8월_9월_10월_11월_12월".split("_"),monthsShort:"1월_2월_3월_4월_5월_6월_7월_8월_9월_10월_11월_12월".split("_"),weekdays:"일요일_월요일_화요일_수요일_목요일_금요일_토요일".split("_"),weekdaysShort:"일_월_화_수_목_금_토".split("_"),weekdaysMin:"일_월_화_수_목_금_토".split("_"),longDateFormat:{LT:"A h시 m분",LTS:"A h시 m분 s초",L:"YYYY.MM.DD",LL:"YYYY년 MMMM D일",LLL:"YYYY년 MMMM D일 LT",LLLL:"YYYY년 MMMM D일 dddd LT"},calendar:{sameDay:"오늘 LT",nextDay:"내일 LT",nextWeek:"dddd LT",lastDay:"어제 LT",lastWeek:"지난주 dddd LT",sameElse:"L"},relativeTime:{future:"%s 후",past:"%s 전",s:"몇초",ss:"%d초",m:"일분",mm:"%d분",h:"한시간",hh:"%d시간",d:"하루",dd:"%d일",M:"한달",MM:"%d달",y:"일년",yy:"%d년"},ordinalParse:/\d{1,2}일/,ordinal:"%d일",meridiemParse:/오전|오후/,isPM:function(a){return"오후"===a},meridiem:function(a){return 12>a?"오전":"오후"}})}),function(a){a(va)}(function(a){function b(a,b,c){var d={m:["eng Minutt","enger Minutt"],h:["eng Stonn","enger Stonn"],d:["een Dag","engem Dag"],M:["ee Mount","engem Mount"],y:["ee Joer","engem Joer"]};return b?d[c][0]:d[c][1]}function c(a){var b=a.substr(0,a.indexOf(" "));return e(b)?"a "+a:"an "+a}function d(a){var b=a.substr(0,a.indexOf(" "));return e(b)?"viru "+a:"virun "+a}function e(a){if(a=parseInt(a,10),isNaN(a))return!1;if(0>a)return!0;if(10>a)return a>=4&&7>=a?!0:!1;if(100>a){var b=a%10,c=a/10;return e(0===b?c:b)}if(1e4>a){for(;a>=10;)a/=10;return e(a)}return a/=1e3,e(a)}return a.defineLocale("lb",{months:"Januar_Februar_Mäerz_Abrëll_Mee_Juni_Juli_August_September_Oktober_November_Dezember".split("_"),monthsShort:"Jan._Febr._Mrz._Abr._Mee_Jun._Jul._Aug._Sept._Okt._Nov._Dez.".split("_"),weekdays:"Sonndeg_Méindeg_Dënschdeg_Mëttwoch_Donneschdeg_Freideg_Samschdeg".split("_"),weekdaysShort:"So._Mé._Dë._Më._Do._Fr._Sa.".split("_"),weekdaysMin:"So_Mé_Dë_Më_Do_Fr_Sa".split("_"),longDateFormat:{LT:"H:mm [Auer]",LTS:"H:mm:ss [Auer]",L:"DD.MM.YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY LT",LLLL:"dddd, D. MMMM YYYY LT"},calendar:{
 sameDay:"[Haut um] LT",sameElse:"L",nextDay:"[Muer um] LT",nextWeek:"dddd [um] LT",lastDay:"[Gëschter um] LT",lastWeek:function(){switch(this.day()){case 2:case 4:return"[Leschten] dddd [um] LT";default:return"[Leschte] dddd [um] LT"}}},relativeTime:{future:c,past:d,s:"e puer Sekonnen",m:b,mm:"%d Minutten",h:b,hh:"%d Stonnen",d:b,dd:"%d Deeg",M:b,MM:"%d Méint",y:b,yy:"%d Joer"},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){function b(a,b,c,d){return b?"kelios sekundės":d?"kelių sekundžių":"kelias sekundes"}function c(a,b,c,d){return b?e(c)[0]:d?e(c)[1]:e(c)[2]}function d(a){return a%10===0||a>10&&20>a}function e(a){return h[a].split("_")}function f(a,b,f,g){var h=a+" ";return 1===a?h+c(a,b,f[0],g):b?h+(d(a)?e(f)[1]:e(f)[0]):g?h+e(f)[1]:h+(d(a)?e(f)[1]:e(f)[2])}function g(a,b){var c=-1===b.indexOf("dddd HH:mm"),d=i[a.day()];return c?d:d.substring(0,d.length-2)+"į"}var h={m:"minutė_minutės_minutę",mm:"minutės_minučių_minutes",h:"valanda_valandos_valandą",hh:"valandos_valandų_valandas",d:"diena_dienos_dieną",dd:"dienos_dienų_dienas",M:"mėnuo_mėnesio_mėnesį",MM:"mėnesiai_mėnesių_mėnesius",y:"metai_metų_metus",yy:"metai_metų_metus"},i="sekmadienis_pirmadienis_antradienis_trečiadienis_ketvirtadienis_penktadienis_šeštadienis".split("_");return a.defineLocale("lt",{months:"sausio_vasario_kovo_balandžio_gegužės_birželio_liepos_rugpjūčio_rugsėjo_spalio_lapkričio_gruodžio".split("_"),monthsShort:"sau_vas_kov_bal_geg_bir_lie_rgp_rgs_spa_lap_grd".split("_"),weekdays:g,weekdaysShort:"Sek_Pir_Ant_Tre_Ket_Pen_Šeš".split("_"),weekdaysMin:"S_P_A_T_K_Pn_Š".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"YYYY-MM-DD",LL:"YYYY [m.] MMMM D [d.]",LLL:"YYYY [m.] MMMM D [d.], LT [val.]",LLLL:"YYYY [m.] MMMM D [d.], dddd, LT [val.]",l:"YYYY-MM-DD",ll:"YYYY [m.] MMMM D [d.]",lll:"YYYY [m.] MMMM D [d.], LT [val.]",llll:"YYYY [m.] MMMM D [d.], ddd, LT [val.]"},calendar:{sameDay:"[Šiandien] LT",nextDay:"[Rytoj] LT",nextWeek:"dddd LT",lastDay:"[Vakar] LT",lastWeek:"[Praėjusį] dddd LT",sameElse:"L"},relativeTime:{future:"po %s",past:"prieš %s",s:b,m:c,mm:f,h:c,hh:f,d:c,dd:f,M:c,MM:f,y:c,yy:f},ordinalParse:/\d{1,2}-oji/,ordinal:function(a){return a+"-oji"},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){function b(a,b,c){var d=a.split("_");return c?b%10===1&&11!==b?d[2]:d[3]:b%10===1&&11!==b?d[0]:d[1]}function c(a,c,e){return a+" "+b(d[e],a,c)}var d={mm:"minūti_minūtes_minūte_minūtes",hh:"stundu_stundas_stunda_stundas",dd:"dienu_dienas_diena_dienas",MM:"mēnesi_mēnešus_mēnesis_mēneši",yy:"gadu_gadus_gads_gadi"};return a.defineLocale("lv",{months:"janvāris_februāris_marts_aprīlis_maijs_jūnijs_jūlijs_augusts_septembris_oktobris_novembris_decembris".split("_"),monthsShort:"jan_feb_mar_apr_mai_jūn_jūl_aug_sep_okt_nov_dec".split("_"),weekdays:"svētdiena_pirmdiena_otrdiena_trešdiena_ceturtdiena_piektdiena_sestdiena".split("_"),weekdaysShort:"Sv_P_O_T_C_Pk_S".split("_"),weekdaysMin:"Sv_P_O_T_C_Pk_S".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD.MM.YYYY",LL:"YYYY. [gada] D. MMMM",LLL:"YYYY. [gada] D. MMMM, LT",LLLL:"YYYY. [gada] D. MMMM, dddd, LT"},calendar:{sameDay:"[Šodien pulksten] LT",nextDay:"[Rīt pulksten] LT",nextWeek:"dddd [pulksten] LT",lastDay:"[Vakar pulksten] LT",lastWeek:"[Pagājušā] dddd [pulksten] LT",sameElse:"L"},relativeTime:{future:"%s vēlāk",past:"%s agrāk",s:"dažas sekundes",m:"minūti",mm:c,h:"stundu",hh:c,d:"dienu",dd:c,M:"mēnesi",MM:c,y:"gadu",yy:c},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("mk",{months:"јануари_февруари_март_април_мај_јуни_јули_август_септември_октомври_ноември_декември".split("_"),monthsShort:"јан_фев_мар_апр_мај_јун_јул_авг_сеп_окт_ное_дек".split("_"),weekdays:"недела_понеделник_вторник_среда_четврток_петок_сабота".split("_"),weekdaysShort:"нед_пон_вто_сре_чет_пет_саб".split("_"),weekdaysMin:"нe_пo_вт_ср_че_пе_сa".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"D.MM.YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendar:{sameDay:"[Денес во] LT",nextDay:"[Утре во] LT",nextWeek:"dddd [во] LT",lastDay:"[Вчера во] LT",lastWeek:function(){switch(this.day()){case 0:case 3:case 6:return"[Во изминатата] dddd [во] LT";case 1:case 2:case 4:case 5:return"[Во изминатиот] dddd [во] LT"}},sameElse:"L"},relativeTime:{future:"после %s",past:"пред %s",s:"неколку секунди",m:"минута",mm:"%d минути",h:"час",hh:"%d часа",d:"ден",dd:"%d дена",M:"месец",MM:"%d месеци",y:"година",yy:"%d години"},ordinalParse:/\d{1,2}-(ев|ен|ти|ви|ри|ми)/,ordinal:function(a){var b=a%10,c=a%100;return 0===a?a+"-ев":0===c?a+"-ен":c>10&&20>c?a+"-ти":1===b?a+"-ви":2===b?a+"-ри":7===b||8===b?a+"-ми":a+"-ти"},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){return a.defineLocale("ml",{months:"ജനുവരി_ഫെബ്രുവരി_മാർച്ച്_ഏപ്രിൽ_മേയ്_ജൂൺ_ജൂലൈ_ഓഗസ്റ്റ്_സെപ്റ്റംബർ_ഒക്ടോബർ_നവംബർ_ഡിസംബർ".split("_"),monthsShort:"ജനു._ഫെബ്രു._മാർ._ഏപ്രി._മേയ്_ജൂൺ_ജൂലൈ._ഓഗ._സെപ്റ്റ._ഒക്ടോ._നവം._ഡിസം.".split("_"),weekdays:"ഞായറാഴ്ച_തിങ്കളാഴ്ച_ചൊവ്വാഴ്ച_ബുധനാഴ്ച_വ്യാഴാഴ്ച_വെള്ളിയാഴ്ച_ശനിയാഴ്ച".split("_"),weekdaysShort:"ഞായർ_തിങ്കൾ_ചൊവ്വ_ബുധൻ_വ്യാഴം_വെള്ളി_ശനി".split("_"),weekdaysMin:"ഞാ_തി_ചൊ_ബു_വ്യാ_വെ_ശ".split("_"),longDateFormat:{LT:"A h:mm -നു",LTS:"A h:mm:ss -നു",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY, LT",LLLL:"dddd, D MMMM YYYY, LT"},calendar:{sameDay:"[ഇന്ന്] LT",nextDay:"[നാളെ] LT",nextWeek:"dddd, LT",lastDay:"[ഇന്നലെ] LT",lastWeek:"[കഴിഞ്ഞ] dddd, LT",sameElse:"L"},relativeTime:{future:"%s കഴിഞ്ഞ്",past:"%s മുൻപ്",s:"അൽപ നിമിഷങ്ങൾ",m:"ഒരു മിനിറ്റ്",mm:"%d മിനിറ്റ്",h:"ഒരു മണിക്കൂർ",hh:"%d മണിക്കൂർ",d:"ഒരു ദിവസം",dd:"%d ദിവസം",M:"ഒരു മാസം",MM:"%d മാസം",y:"ഒരു വർഷം",yy:"%d വർഷം"},meridiemParse:/രാത്രി|രാവിലെ|ഉച്ച കഴിഞ്ഞ്|വൈകുന്നേരം|രാത്രി/i,isPM:function(a){return/^(ഉച്ച കഴിഞ്ഞ്|വൈകുന്നേരം|രാത്രി)$/.test(a)},meridiem:function(a){return 4>a?"രാത്രി":12>a?"രാവിലെ":17>a?"ഉച്ച കഴിഞ്ഞ്":20>a?"വൈകുന്നേരം":"രാത്രി"}})}),function(a){a(va)}(function(a){var b={1:"१",2:"२",3:"३",4:"४",5:"५",6:"६",7:"७",8:"८",9:"९",0:"०"},c={"१":"1","२":"2","३":"3","४":"4","५":"5","६":"6","७":"7","८":"8","९":"9","०":"0"};return a.defineLocale("mr",{months:"जानेवारी_फेब्रुवारी_मार्च_एप्रिल_मे_जून_जुलै_ऑगस्ट_सप्टेंबर_ऑक्टोबर_नोव्हेंबर_डिसेंबर".split("_"),monthsShort:"जाने._फेब्रु._मार्च._एप्रि._मे._जून._जुलै._ऑग._सप्टें._ऑक्टो._नोव्हें._डिसें.".split("_"),weekdays:"रविवार_सोमवार_मंगळवार_बुधवार_गुरूवार_शुक्रवार_शनिवार".split("_"),weekdaysShort:"रवि_सोम_मंगळ_बुध_गुरू_शुक्र_शनि".split("_"),weekdaysMin:"र_सो_मं_बु_गु_शु_श".split("_"),longDateFormat:{LT:"A h:mm वाजता",LTS:"A h:mm:ss वाजता",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY, LT",LLLL:"dddd, D MMMM YYYY, LT"},calendar:{sameDay:"[आज] LT",nextDay:"[उद्या] LT",nextWeek:"dddd, LT",lastDay:"[काल] LT",lastWeek:"[मागील] dddd, LT",sameElse:"L"},relativeTime:{future:"%s नंतर",past:"%s पूर्वी",s:"सेकंद",m:"एक मिनिट",mm:"%d मिनिटे",h:"एक तास",hh:"%d तास",d:"एक दिवस",dd:"%d दिवस",M:"एक महिना",MM:"%d महिने",y:"एक वर्ष",yy:"%d वर्षे"},preparse:function(a){return a.replace(/[१२३४५६७८९०]/g,function(a){return c[a]})},postformat:function(a){return a.replace(/\d/g,function(a){return b[a]})},meridiemParse:/रात्री|सकाळी|दुपारी|सायंकाळी/,meridiemHour:function(a,b){return 12===a&&(a=0),"रात्री"===b?4>a?a:a+12:"सकाळी"===b?a:"दुपारी"===b?a>=10?a:a+12:"सायंकाळी"===b?a+12:void 0},meridiem:function(a){return 4>a?"रात्री":10>a?"सकाळी":17>a?"दुपारी":20>a?"सायंकाळी":"रात्री"},week:{dow:0,doy:6}})}),function(a){a(va)}(function(a){return a.defineLocale("ms-my",{months:"Januari_Februari_Mac_April_Mei_Jun_Julai_Ogos_September_Oktober_November_Disember".split("_"),monthsShort:"Jan_Feb_Mac_Apr_Mei_Jun_Jul_Ogs_Sep_Okt_Nov_Dis".split("_"),weekdays:"Ahad_Isnin_Selasa_Rabu_Khamis_Jumaat_Sabtu".split("_"),weekdaysShort:"Ahd_Isn_Sel_Rab_Kha_Jum_Sab".split("_"),weekdaysMin:"Ah_Is_Sl_Rb_Km_Jm_Sb".split("_"),longDateFormat:{LT:"HH.mm",LTS:"LT.ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY [pukul] LT",LLLL:"dddd, D MMMM YYYY [pukul] LT"},meridiemParse:/pagi|tengahari|petang|malam/,meridiemHour:function(a,b){return 12===a&&(a=0),"pagi"===b?a:"tengahari"===b?a>=11?a:a+12:"petang"===b||"malam"===b?a+12:void 0},meridiem:function(a){return 11>a?"pagi":15>a?"tengahari":19>a?"petang":"malam"},calendar:{sameDay:"[Hari ini pukul] LT",nextDay:"[Esok pukul] LT",nextWeek:"dddd [pukul] LT",lastDay:"[Kelmarin pukul] LT",lastWeek:"dddd [lepas pukul] LT",sameElse:"L"},relativeTime:{future:"dalam %s",past:"%s yang lepas",s:"beberapa saat",m:"seminit",mm:"%d minit",h:"sejam",hh:"%d jam",d:"sehari",dd:"%d hari",M:"sebulan",MM:"%d bulan",y:"setahun",yy:"%d tahun"},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){var b={1:"၁",2:"၂",3:"၃",4:"၄",5:"၅",6:"၆",7:"၇",8:"၈",9:"၉",0:"၀"},c={"၁":"1","၂":"2","၃":"3","၄":"4","၅":"5","၆":"6","၇":"7","၈":"8","၉":"9","၀":"0"};return a.defineLocale("my",{months:"ဇန်နဝါရီ_ဖေဖော်ဝါရီ_မတ်_ဧပြီ_မေ_ဇွန်_ဇူလိုင်_သြဂုတ်_စက်တင်ဘာ_အောက်တိုဘာ_နိုဝင်ဘာ_ဒီဇင်ဘာ".split("_"),monthsShort:"ဇန်_ဖေ_မတ်_ပြီ_မေ_ဇွန်_လိုင်_သြ_စက်_အောက်_နို_ဒီ".split("_"),weekdays:"တနင်္ဂနွေ_တနင်္လာ_အင်္ဂါ_ဗုဒ္ဓဟူး_ကြာသပတေး_သောကြာ_စနေ".split("_"),weekdaysShort:"နွေ_လာ_င်္ဂါ_ဟူး_ကြာ_သော_နေ".split("_"),weekdaysMin:"နွေ_လာ_င်္ဂါ_ဟူး_ကြာ_သော_နေ".split("_"),longDateFormat:{LT:"HH:mm",LTS:"HH:mm:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},calendar:{sameDay:"[ယနေ.] LT [မှာ]",nextDay:"[မနက်ဖြန်] LT [မှာ]",nextWeek:"dddd LT [မှာ]",lastDay:"[မနေ.က] LT [မှာ]",lastWeek:"[ပြီးခဲ့သော] dddd LT [မှာ]",sameElse:"L"},relativeTime:{future:"လာမည့် %s မှာ",past:"လွန်ခဲ့သော %s က",s:"စက္ကန်.အနည်းငယ်",m:"တစ်မိနစ်",mm:"%d မိနစ်",h:"တစ်နာရီ",hh:"%d နာရီ",d:"တစ်ရက်",dd:"%d ရက်",M:"တစ်လ",MM:"%d လ",y:"တစ်နှစ်",yy:"%d နှစ်"},preparse:function(a){return a.replace(/[၁၂၃၄၅၆၇၈၉၀]/g,function(a){return c[a]})},postformat:function(a){return a.replace(/\d/g,function(a){return b[a]})},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("nb",{months:"januar_februar_mars_april_mai_juni_juli_august_september_oktober_november_desember".split("_"),monthsShort:"jan_feb_mar_apr_mai_jun_jul_aug_sep_okt_nov_des".split("_"),weekdays:"søndag_mandag_tirsdag_onsdag_torsdag_fredag_lørdag".split("_"),weekdaysShort:"søn_man_tirs_ons_tors_fre_lør".split("_"),weekdaysMin:"sø_ma_ti_on_to_fr_lø".split("_"),longDateFormat:{LT:"H.mm",LTS:"LT.ss",L:"DD.MM.YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY [kl.] LT",LLLL:"dddd D. MMMM YYYY [kl.] LT"},calendar:{sameDay:"[i dag kl.] LT",nextDay:"[i morgen kl.] LT",nextWeek:"dddd [kl.] LT",lastDay:"[i går kl.] LT",lastWeek:"[forrige] dddd [kl.] LT",sameElse:"L"},relativeTime:{future:"om %s",past:"for %s siden",s:"noen sekunder",m:"ett minutt",mm:"%d minutter",h:"en time",hh:"%d timer",d:"en dag",dd:"%d dager",M:"en måned",MM:"%d måneder",y:"ett år",yy:"%d år"},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){var b={1:"१",2:"२",3:"३",4:"४",5:"५",6:"६",7:"७",8:"८",9:"९",0:"०"},c={"१":"1","२":"2","३":"3","४":"4","५":"5","६":"6","७":"7","८":"8","९":"9","०":"0"};return a.defineLocale("ne",{months:"जनवरी_फेब्रुवरी_मार्च_अप्रिल_मई_जुन_जुलाई_अगष्ट_सेप्टेम्बर_अक्टोबर_नोभेम्बर_डिसेम्बर".split("_"),monthsShort:"जन._फेब्रु._मार्च_अप्रि._मई_जुन_जुलाई._अग._सेप्ट._अक्टो._नोभे._डिसे.".split("_"),weekdays:"आइतबार_सोमबार_मङ्गलबार_बुधबार_बिहिबार_शुक्रबार_शनिबार".split("_"),weekdaysShort:"आइत._सोम._मङ्गल._बुध._बिहि._शुक्र._शनि.".split("_"),weekdaysMin:"आइ._सो._मङ्_बु._बि._शु._श.".split("_"),longDateFormat:{LT:"Aको h:mm बजे",LTS:"Aको h:mm:ss बजे",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY, LT",LLLL:"dddd, D MMMM YYYY, LT"},preparse:function(a){return a.replace(/[१२३४५६७८९०]/g,function(a){return c[a]})},postformat:function(a){return a.replace(/\d/g,function(a){return b[a]})},meridiemParse:/राती|बिहान|दिउँसो|बेलुका|साँझ|राती/,meridiemHour:function(a,b){return 12===a&&(a=0),"राती"===b?3>a?a:a+12:"बिहान"===b?a:"दिउँसो"===b?a>=10?a:a+12:"बेलुका"===b||"साँझ"===b?a+12:void 0},meridiem:function(a){return 3>a?"राती":10>a?"बिहान":15>a?"दिउँसो":18>a?"बेलुका":20>a?"साँझ":"राती"},calendar:{sameDay:"[आज] LT",nextDay:"[भोली] LT",nextWeek:"[आउँदो] dddd[,] LT",lastDay:"[हिजो] LT",lastWeek:"[गएको] dddd[,] LT",sameElse:"L"},relativeTime:{future:"%sमा",past:"%s अगाडी",s:"केही समय",m:"एक मिनेट",mm:"%d मिनेट",h:"एक घण्टा",hh:"%d घण्टा",d:"एक दिन",dd:"%d दिन",M:"एक महिना",MM:"%d महिना",y:"एक बर्ष",yy:"%d बर्ष"},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){var b="jan._feb._mrt._apr._mei_jun._jul._aug._sep._okt._nov._dec.".split("_"),c="jan_feb_mrt_apr_mei_jun_jul_aug_sep_okt_nov_dec".split("_");return a.defineLocale("nl",{months:"januari_februari_maart_april_mei_juni_juli_augustus_september_oktober_november_december".split("_"),monthsShort:function(a,d){return/-MMM-/.test(d)?c[a.month()]:b[a.month()]},weekdays:"zondag_maandag_dinsdag_woensdag_donderdag_vrijdag_zaterdag".split("_"),weekdaysShort:"zo._ma._di._wo._do._vr._za.".split("_"),weekdaysMin:"Zo_Ma_Di_Wo_Do_Vr_Za".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD-MM-YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},calendar:{sameDay:"[vandaag om] LT",nextDay:"[morgen om] LT",nextWeek:"dddd [om] LT",lastDay:"[gisteren om] LT",lastWeek:"[afgelopen] dddd [om] LT",sameElse:"L"},relativeTime:{future:"over %s",past:"%s geleden",s:"een paar seconden",m:"één minuut",mm:"%d minuten",h:"één uur",hh:"%d uur",d:"één dag",dd:"%d dagen",M:"één maand",MM:"%d maanden",y:"één jaar",yy:"%d jaar"},ordinalParse:/\d{1,2}(ste|de)/,ordinal:function(a){return a+(1===a||8===a||a>=20?"ste":"de")},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("nn",{months:"januar_februar_mars_april_mai_juni_juli_august_september_oktober_november_desember".split("_"),monthsShort:"jan_feb_mar_apr_mai_jun_jul_aug_sep_okt_nov_des".split("_"),weekdays:"sundag_måndag_tysdag_onsdag_torsdag_fredag_laurdag".split("_"),weekdaysShort:"sun_mån_tys_ons_tor_fre_lau".split("_"),weekdaysMin:"su_må_ty_on_to_fr_lø".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD.MM.YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},calendar:{sameDay:"[I dag klokka] LT",nextDay:"[I morgon klokka] LT",nextWeek:"dddd [klokka] LT",lastDay:"[I går klokka] LT",lastWeek:"[Føregåande] dddd [klokka] LT",sameElse:"L"},relativeTime:{future:"om %s",past:"for %s sidan",s:"nokre sekund",m:"eit minutt",mm:"%d minutt",h:"ein time",hh:"%d timar",d:"ein dag",dd:"%d dagar",M:"ein månad",MM:"%d månader",y:"eit år",yy:"%d år"},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){function b(a){return 5>a%10&&a%10>1&&~~(a/10)%10!==1}function c(a,c,d){var e=a+" ";switch(d){case"m":return c?"minuta":"minutę";case"mm":return e+(b(a)?"minuty":"minut");case"h":return c?"godzina":"godzinę";case"hh":return e+(b(a)?"godziny":"godzin");case"MM":return e+(b(a)?"miesiące":"miesięcy");case"yy":return e+(b(a)?"lata":"lat")}}var d="styczeń_luty_marzec_kwiecień_maj_czerwiec_lipiec_sierpień_wrzesień_październik_listopad_grudzień".split("_"),e="stycznia_lutego_marca_kwietnia_maja_czerwca_lipca_sierpnia_września_października_listopada_grudnia".split("_");return a.defineLocale("pl",{months:function(a,b){return/D MMMM/.test(b)?e[a.month()]:d[a.month()]},monthsShort:"sty_lut_mar_kwi_maj_cze_lip_sie_wrz_paź_lis_gru".split("_"),weekdays:"niedziela_poniedziałek_wtorek_środa_czwartek_piątek_sobota".split("_"),weekdaysShort:"nie_pon_wt_śr_czw_pt_sb".split("_"),weekdaysMin:"N_Pn_Wt_Śr_Cz_Pt_So".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD.MM.YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendar:{sameDay:"[Dziś o] LT",nextDay:"[Jutro o] LT",nextWeek:"[W] dddd [o] LT",lastDay:"[Wczoraj o] LT",lastWeek:function(){switch(this.day()){case 0:return"[W zeszłą niedzielę o] LT";case 3:return"[W zeszłą środę o] LT";case 6:return"[W zeszłą sobotę o] LT";default:return"[W zeszły] dddd [o] LT"}},sameElse:"L"},relativeTime:{future:"za %s",past:"%s temu",s:"kilka sekund",m:c,mm:c,h:c,hh:c,d:"1 dzień",dd:"%d dni",M:"miesiąc",MM:c,y:"rok",yy:c},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("pt-br",{months:"janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro".split("_"),monthsShort:"jan_fev_mar_abr_mai_jun_jul_ago_set_out_nov_dez".split("_"),weekdays:"domingo_segunda-feira_terça-feira_quarta-feira_quinta-feira_sexta-feira_sábado".split("_"),weekdaysShort:"dom_seg_ter_qua_qui_sex_sáb".split("_"),weekdaysMin:"dom_2ª_3ª_4ª_5ª_6ª_sáb".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D [de] MMMM [de] YYYY",LLL:"D [de] MMMM [de] YYYY [às] LT",LLLL:"dddd, D [de] MMMM [de] YYYY [às] LT"},calendar:{sameDay:"[Hoje às] LT",nextDay:"[Amanhã às] LT",nextWeek:"dddd [às] LT",lastDay:"[Ontem às] LT",lastWeek:function(){return 0===this.day()||6===this.day()?"[Último] dddd [às] LT":"[Última] dddd [às] LT"},sameElse:"L"},relativeTime:{future:"em %s",past:"%s atrás",s:"segundos",m:"um minuto",mm:"%d minutos",h:"uma hora",hh:"%d horas",d:"um dia",dd:"%d dias",M:"um mês",MM:"%d meses",y:"um ano",yy:"%d anos"},ordinalParse:/\d{1,2}º/,ordinal:"%dº"})}),function(a){a(va)}(function(a){return a.defineLocale("pt",{months:"janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro".split("_"),monthsShort:"jan_fev_mar_abr_mai_jun_jul_ago_set_out_nov_dez".split("_"),weekdays:"domingo_segunda-feira_terça-feira_quarta-feira_quinta-feira_sexta-feira_sábado".split("_"),weekdaysShort:"dom_seg_ter_qua_qui_sex_sáb".split("_"),weekdaysMin:"dom_2ª_3ª_4ª_5ª_6ª_sáb".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D [de] MMMM [de] YYYY",LLL:"D [de] MMMM [de] YYYY LT",LLLL:"dddd, D [de] MMMM [de] YYYY LT"},calendar:{sameDay:"[Hoje às] LT",nextDay:"[Amanhã às] LT",nextWeek:"dddd [às] LT",lastDay:"[Ontem às] LT",lastWeek:function(){return 0===this.day()||6===this.day()?"[Último] dddd [às] LT":"[Última] dddd [às] LT"},sameElse:"L"},relativeTime:{future:"em %s",past:"há %s",s:"segundos",m:"um minuto",mm:"%d minutos",h:"uma hora",hh:"%d horas",d:"um dia",dd:"%d dias",M:"um mês",MM:"%d meses",y:"um ano",yy:"%d anos"},ordinalParse:/\d{1,2}º/,ordinal:"%dº",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){function b(a,b,c){var d={mm:"minute",hh:"ore",dd:"zile",MM:"luni",yy:"ani"},e=" ";return(a%100>=20||a>=100&&a%100===0)&&(e=" de "),a+e+d[c]}return a.defineLocale("ro",{months:"ianuarie_februarie_martie_aprilie_mai_iunie_iulie_august_septembrie_octombrie_noiembrie_decembrie".split("_"),monthsShort:"ian._febr._mart._apr._mai_iun._iul._aug._sept._oct._nov._dec.".split("_"),weekdays:"duminică_luni_marți_miercuri_joi_vineri_sâmbătă".split("_"),weekdaysShort:"Dum_Lun_Mar_Mie_Joi_Vin_Sâm".split("_"),weekdaysMin:"Du_Lu_Ma_Mi_Jo_Vi_Sâ".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"DD.MM.YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY H:mm",LLLL:"dddd, D MMMM YYYY H:mm"},calendar:{sameDay:"[azi la] LT",nextDay:"[mâine la] LT",nextWeek:"dddd [la] LT",lastDay:"[ieri la] LT",lastWeek:"[fosta] dddd [la] LT",sameElse:"L"},relativeTime:{future:"peste %s",past:"%s în urmă",s:"câteva secunde",m:"un minut",mm:b,h:"o oră",hh:b,d:"o zi",dd:b,M:"o lună",MM:b,y:"un an",yy:b},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){function b(a,b){var c=a.split("_");return b%10===1&&b%100!==11?c[0]:b%10>=2&&4>=b%10&&(10>b%100||b%100>=20)?c[1]:c[2]}function c(a,c,d){var e={mm:c?"минута_минуты_минут":"минуту_минуты_минут",hh:"час_часа_часов",dd:"день_дня_дней",MM:"месяц_месяца_месяцев",yy:"год_года_лет"};return"m"===d?c?"минута":"минуту":a+" "+b(e[d],+a)}function d(a,b){var c={nominative:"январь_февраль_март_апрель_май_июнь_июль_август_сентябрь_октябрь_ноябрь_декабрь".split("_"),accusative:"января_февраля_марта_апреля_мая_июня_июля_августа_сентября_октября_ноября_декабря".split("_")},d=/D[oD]?(\[[^\[\]]*\]|\s+)+MMMM?/.test(b)?"accusative":"nominative";return c[d][a.month()]}function e(a,b){var c={nominative:"янв_фев_март_апр_май_июнь_июль_авг_сен_окт_ноя_дек".split("_"),accusative:"янв_фев_мар_апр_мая_июня_июля_авг_сен_окт_ноя_дек".split("_")},d=/D[oD]?(\[[^\[\]]*\]|\s+)+MMMM?/.test(b)?"accusative":"nominative";return c[d][a.month()]}function f(a,b){var c={nominative:"воскресенье_понедельник_вторник_среда_четверг_пятница_суббота".split("_"),accusative:"воскресенье_понедельник_вторник_среду_четверг_пятницу_субботу".split("_")},d=/\[ ?[Вв] ?(?:прошлую|следующую|эту)? ?\] ?dddd/.test(b)?"accusative":"nominative";return c[d][a.day()]}return a.defineLocale("ru",{months:d,monthsShort:e,weekdays:f,weekdaysShort:"вс_пн_вт_ср_чт_пт_сб".split("_"),weekdaysMin:"вс_пн_вт_ср_чт_пт_сб".split("_"),monthsParse:[/^янв/i,/^фев/i,/^мар/i,/^апр/i,/^ма[й|я]/i,/^июн/i,/^июл/i,/^авг/i,/^сен/i,/^окт/i,/^ноя/i,/^дек/i],longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD.MM.YYYY",LL:"D MMMM YYYY г.",LLL:"D MMMM YYYY г., LT",LLLL:"dddd, D MMMM YYYY г., LT"},calendar:{sameDay:"[Сегодня в] LT",nextDay:"[Завтра в] LT",lastDay:"[Вчера в] LT",nextWeek:function(){return 2===this.day()?"[Во] dddd [в] LT":"[В] dddd [в] LT"},lastWeek:function(a){if(a.week()===this.week())return 2===this.day()?"[Во] dddd [в] LT":"[В] dddd [в] LT";switch(this.day()){case 0:return"[В прошлое] dddd [в] LT";case 1:case 2:case 4:return"[В прошлый] dddd [в] LT";case 3:case 5:case 6:return"[В прошлую] dddd [в] LT"}},sameElse:"L"},relativeTime:{future:"через %s",past:"%s назад",s:"несколько секунд",m:c,mm:c,h:"час",hh:c,d:"день",dd:c,M:"месяц",MM:c,y:"год",yy:c},meridiemParse:/ночи|утра|дня|вечера/i,isPM:function(a){return/^(дня|вечера)$/.test(a)},meridiem:function(a){return 4>a?"ночи":12>a?"утра":17>a?"дня":"вечера"},ordinalParse:/\d{1,2}-(й|го|я)/,ordinal:function(a,b){switch(b){case"M":case"d":case"DDD":return a+"-й";case"D":return a+"-го";case"w":case"W":return a+"-я";default:return a}},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){function b(a){return a>1&&5>a}function c(a,c,d,e){var f=a+" ";switch(d){case"s":return c||e?"pár sekúnd":"pár sekundami";case"m":return c?"minúta":e?"minútu":"minútou";case"mm":return c||e?f+(b(a)?"minúty":"minút"):f+"minútami";case"h":return c?"hodina":e?"hodinu":"hodinou";case"hh":return c||e?f+(b(a)?"hodiny":"hodín"):f+"hodinami";case"d":return c||e?"deň":"dňom";case"dd":return c||e?f+(b(a)?"dni":"dní"):f+"dňami";case"M":return c||e?"mesiac":"mesiacom";case"MM":return c||e?f+(b(a)?"mesiace":"mesiacov"):f+"mesiacmi";case"y":return c||e?"rok":"rokom";case"yy":return c||e?f+(b(a)?"roky":"rokov"):f+"rokmi"}}var d="január_február_marec_apríl_máj_jún_júl_august_september_október_november_december".split("_"),e="jan_feb_mar_apr_máj_jún_júl_aug_sep_okt_nov_dec".split("_");return a.defineLocale("sk",{months:d,monthsShort:e,monthsParse:function(a,b){var c,d=[];for(c=0;12>c;c++)d[c]=new RegExp("^"+a[c]+"$|^"+b[c]+"$","i");return d}(d,e),weekdays:"nedeľa_pondelok_utorok_streda_štvrtok_piatok_sobota".split("_"),weekdaysShort:"ne_po_ut_st_št_pi_so".split("_"),weekdaysMin:"ne_po_ut_st_št_pi_so".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"DD.MM.YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY LT",LLLL:"dddd D. MMMM YYYY LT"},calendar:{sameDay:"[dnes o] LT",nextDay:"[zajtra o] LT",nextWeek:function(){switch(this.day()){case 0:return"[v nedeľu o] LT";case 1:case 2:return"[v] dddd [o] LT";case 3:return"[v stredu o] LT";case 4:return"[vo štvrtok o] LT";case 5:return"[v piatok o] LT";case 6:return"[v sobotu o] LT"}},lastDay:"[včera o] LT",lastWeek:function(){switch(this.day()){case 0:return"[minulú nedeľu o] LT";case 1:case 2:return"[minulý] dddd [o] LT";case 3:return"[minulú stredu o] LT";case 4:case 5:return"[minulý] dddd [o] LT";case 6:return"[minulú sobotu o] LT"}},sameElse:"L"},relativeTime:{future:"za %s",past:"pred %s",s:c,m:c,mm:c,h:c,hh:c,d:c,dd:c,M:c,MM:c,y:c,yy:c},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){function b(a,b,c){var d=a+" ";switch(c){case"m":return b?"ena minuta":"eno minuto";case"mm":return d+=1===a?"minuta":2===a?"minuti":3===a||4===a?"minute":"minut";case"h":return b?"ena ura":"eno uro";case"hh":return d+=1===a?"ura":2===a?"uri":3===a||4===a?"ure":"ur";case"dd":return d+=1===a?"dan":"dni";case"MM":return d+=1===a?"mesec":2===a?"meseca":3===a||4===a?"mesece":"mesecev";case"yy":return d+=1===a?"leto":2===a?"leti":3===a||4===a?"leta":"let"}}return a.defineLocale("sl",{months:"januar_februar_marec_april_maj_junij_julij_avgust_september_oktober_november_december".split("_"),monthsShort:"jan._feb._mar._apr._maj._jun._jul._avg._sep._okt._nov._dec.".split("_"),weekdays:"nedelja_ponedeljek_torek_sreda_četrtek_petek_sobota".split("_"),weekdaysShort:"ned._pon._tor._sre._čet._pet._sob.".split("_"),weekdaysMin:"ne_po_to_sr_če_pe_so".split("_"),longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"DD. MM. YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY LT",LLLL:"dddd, D. MMMM YYYY LT"},calendar:{sameDay:"[danes ob] LT",nextDay:"[jutri ob] LT",nextWeek:function(){switch(this.day()){case 0:return"[v] [nedeljo] [ob] LT";case 3:return"[v] [sredo] [ob] LT";case 6:return"[v] [soboto] [ob] LT";case 1:case 2:case 4:case 5:return"[v] dddd [ob] LT"}},lastDay:"[včeraj ob] LT",lastWeek:function(){switch(this.day()){case 0:case 3:case 6:return"[prejšnja] dddd [ob] LT";case 1:case 2:case 4:case 5:return"[prejšnji] dddd [ob] LT"}},sameElse:"L"},relativeTime:{future:"čez %s",past:"%s nazaj",s:"nekaj sekund",m:b,mm:b,h:b,hh:b,d:"en dan",dd:b,M:"en mesec",MM:b,y:"eno leto",yy:b},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){return a.defineLocale("sq",{months:"Janar_Shkurt_Mars_Prill_Maj_Qershor_Korrik_Gusht_Shtator_Tetor_Nëntor_Dhjetor".split("_"),monthsShort:"Jan_Shk_Mar_Pri_Maj_Qer_Kor_Gus_Sht_Tet_Nën_Dhj".split("_"),weekdays:"E Diel_E Hënë_E Martë_E Mërkurë_E Enjte_E Premte_E Shtunë".split("_"),weekdaysShort:"Die_Hën_Mar_Mër_Enj_Pre_Sht".split("_"),weekdaysMin:"D_H_Ma_Më_E_P_Sh".split("_"),meridiemParse:/PD|MD/,isPM:function(a){return"M"===a.charAt(0)},meridiem:function(a){return 12>a?"PD":"MD"},longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendar:{sameDay:"[Sot në] LT",nextDay:"[Nesër në] LT",nextWeek:"dddd [në] LT",lastDay:"[Dje në] LT",lastWeek:"dddd [e kaluar në] LT",sameElse:"L"},relativeTime:{future:"në %s",past:"%s më parë",s:"disa sekonda",m:"një minutë",mm:"%d minuta",h:"një orë",hh:"%d orë",d:"një ditë",dd:"%d ditë",M:"një muaj",MM:"%d muaj",y:"një vit",yy:"%d vite"},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){var b={words:{m:["један минут","једне минуте"],mm:["минут","минуте","минута"],h:["један сат","једног сата"],hh:["сат","сата","сати"],dd:["дан","дана","дана"],MM:["месец","месеца","месеци"],yy:["година","године","година"]},correctGrammaticalCase:function(a,b){return 1===a?b[0]:a>=2&&4>=a?b[1]:b[2]},translate:function(a,c,d){var e=b.words[d];return 1===d.length?c?e[0]:e[1]:a+" "+b.correctGrammaticalCase(a,e)}};return a.defineLocale("sr-cyrl",{months:["јануар","фебруар","март","април","мај","јун","јул","август","септембар","октобар","новембар","децембар"],monthsShort:["јан.","феб.","мар.","апр.","мај","јун","јул","авг.","сеп.","окт.","нов.","дец."],weekdays:["недеља","понедељак","уторак","среда","четвртак","петак","субота"],weekdaysShort:["нед.","пон.","уто.","сре.","чет.","пет.","суб."],weekdaysMin:["не","по","ут","ср","че","пе","су"],longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"DD. MM. YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY LT",LLLL:"dddd, D. MMMM YYYY LT"},calendar:{sameDay:"[данас у] LT",nextDay:"[сутра у] LT",nextWeek:function(){switch(this.day()){case 0:return"[у] [недељу] [у] LT";case 3:return"[у] [среду] [у] LT";case 6:return"[у] [суботу] [у] LT";case 1:case 2:case 4:case 5:return"[у] dddd [у] LT"}},lastDay:"[јуче у] LT",lastWeek:function(){var a=["[прошле] [недеље] [у] LT","[прошлог] [понедељка] [у] LT","[прошлог] [уторка] [у] LT","[прошле] [среде] [у] LT","[прошлог] [четвртка] [у] LT","[прошлог] [петка] [у] LT","[прошле] [суботе] [у] LT"];return a[this.day()]},sameElse:"L"},relativeTime:{future:"за %s",past:"пре %s",s:"неколико секунди",m:b.translate,mm:b.translate,h:b.translate,hh:b.translate,d:"дан",dd:b.translate,M:"месец",MM:b.translate,y:"годину",yy:b.translate},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){var b={words:{m:["jedan minut","jedne minute"],mm:["minut","minute","minuta"],h:["jedan sat","jednog sata"],hh:["sat","sata","sati"],dd:["dan","dana","dana"],MM:["mesec","meseca","meseci"],yy:["godina","godine","godina"]},correctGrammaticalCase:function(a,b){return 1===a?b[0]:a>=2&&4>=a?b[1]:b[2]},translate:function(a,c,d){var e=b.words[d];return 1===d.length?c?e[0]:e[1]:a+" "+b.correctGrammaticalCase(a,e)}};return a.defineLocale("sr",{months:["januar","februar","mart","april","maj","jun","jul","avgust","septembar","oktobar","novembar","decembar"],monthsShort:["jan.","feb.","mar.","apr.","maj","jun","jul","avg.","sep.","okt.","nov.","dec."],weekdays:["nedelja","ponedeljak","utorak","sreda","četvrtak","petak","subota"],weekdaysShort:["ned.","pon.","uto.","sre.","čet.","pet.","sub."],weekdaysMin:["ne","po","ut","sr","če","pe","su"],longDateFormat:{LT:"H:mm",LTS:"LT:ss",L:"DD. MM. YYYY",LL:"D. MMMM YYYY",LLL:"D. MMMM YYYY LT",LLLL:"dddd, D. MMMM YYYY LT"},calendar:{sameDay:"[danas u] LT",nextDay:"[sutra u] LT",nextWeek:function(){switch(this.day()){case 0:return"[u] [nedelju] [u] LT";case 3:return"[u] [sredu] [u] LT";case 6:return"[u] [subotu] [u] LT";case 1:case 2:case 4:case 5:return"[u] dddd [u] LT"}},lastDay:"[juče u] LT",lastWeek:function(){var a=["[prošle] [nedelje] [u] LT","[prošlog] [ponedeljka] [u] LT","[prošlog] [utorka] [u] LT","[prošle] [srede] [u] LT","[prošlog] [četvrtka] [u] LT","[prošlog] [petka] [u] LT","[prošle] [subote] [u] LT"];return a[this.day()]},sameElse:"L"},relativeTime:{future:"za %s",past:"pre %s",s:"nekoliko sekundi",m:b.translate,mm:b.translate,h:b.translate,hh:b.translate,d:"dan",dd:b.translate,M:"mesec",MM:b.translate,y:"godinu",yy:b.translate},ordinalParse:/\d{1,2}\./,ordinal:"%d.",week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){return a.defineLocale("sv",{months:"januari_februari_mars_april_maj_juni_juli_augusti_september_oktober_november_december".split("_"),monthsShort:"jan_feb_mar_apr_maj_jun_jul_aug_sep_okt_nov_dec".split("_"),weekdays:"söndag_måndag_tisdag_onsdag_torsdag_fredag_lördag".split("_"),weekdaysShort:"sön_mån_tis_ons_tor_fre_lör".split("_"),weekdaysMin:"sö_må_ti_on_to_fr_lö".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"YYYY-MM-DD",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},calendar:{sameDay:"[Idag] LT",nextDay:"[Imorgon] LT",lastDay:"[Igår] LT",nextWeek:"dddd LT",lastWeek:"[Förra] dddd[en] LT",sameElse:"L"},relativeTime:{future:"om %s",past:"för %s sedan",s:"några sekunder",m:"en minut",mm:"%d minuter",h:"en timme",hh:"%d timmar",d:"en dag",dd:"%d dagar",M:"en månad",MM:"%d månader",y:"ett år",yy:"%d år"},ordinalParse:/\d{1,2}(e|a)/,ordinal:function(a){var b=a%10,c=1===~~(a%100/10)?"e":1===b?"a":2===b?"a":"e";return a+c},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("ta",{months:"ஜனவரி_பிப்ரவரி_மார்ச்_ஏப்ரல்_மே_ஜூன்_ஜூலை_ஆகஸ்ட்_செப்டெம்பர்_அக்டோபர்_நவம்பர்_டிசம்பர்".split("_"),monthsShort:"ஜனவரி_பிப்ரவரி_மார்ச்_ஏப்ரல்_மே_ஜூன்_ஜூலை_ஆகஸ்ட்_செப்டெம்பர்_அக்டோபர்_நவம்பர்_டிசம்பர்".split("_"),weekdays:"ஞாயிற்றுக்கிழமை_திங்கட்கிழமை_செவ்வாய்கிழமை_புதன்கிழமை_வியாழக்கிழமை_வெள்ளிக்கிழமை_சனிக்கிழமை".split("_"),weekdaysShort:"ஞாயிறு_திங்கள்_செவ்வாய்_புதன்_வியாழன்_வெள்ளி_சனி".split("_"),weekdaysMin:"ஞா_தி_செ_பு_வி_வெ_ச".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY, LT",LLLL:"dddd, D MMMM YYYY, LT"},calendar:{sameDay:"[இன்று] LT",nextDay:"[நாளை] LT",nextWeek:"dddd, LT",lastDay:"[நேற்று] LT",lastWeek:"[கடந்த வாரம்] dddd, LT",sameElse:"L"},relativeTime:{future:"%s இல்",past:"%s முன்",s:"ஒரு சில விநாடிகள்",
 m:"ஒரு நிமிடம்",mm:"%d நிமிடங்கள்",h:"ஒரு மணி நேரம்",hh:"%d மணி நேரம்",d:"ஒரு நாள்",dd:"%d நாட்கள்",M:"ஒரு மாதம்",MM:"%d மாதங்கள்",y:"ஒரு வருடம்",yy:"%d ஆண்டுகள்"},ordinalParse:/\d{1,2}வது/,ordinal:function(a){return a+"வது"},meridiemParse:/யாமம்|வைகறை|காலை|நண்பகல்|எற்பாடு|மாலை/,meridiem:function(a){return 2>a?" யாமம்":6>a?" வைகறை":10>a?" காலை":14>a?" நண்பகல்":18>a?" எற்பாடு":22>a?" மாலை":" யாமம்"},meridiemHour:function(a,b){return 12===a&&(a=0),"யாமம்"===b?2>a?a:a+12:"வைகறை"===b||"காலை"===b?a:"நண்பகல்"===b&&a>=10?a:a+12},week:{dow:0,doy:6}})}),function(a){a(va)}(function(a){return a.defineLocale("th",{months:"มกราคม_กุมภาพันธ์_มีนาคม_เมษายน_พฤษภาคม_มิถุนายน_กรกฎาคม_สิงหาคม_กันยายน_ตุลาคม_พฤศจิกายน_ธันวาคม".split("_"),monthsShort:"มกรา_กุมภา_มีนา_เมษา_พฤษภา_มิถุนา_กรกฎา_สิงหา_กันยา_ตุลา_พฤศจิกา_ธันวา".split("_"),weekdays:"อาทิตย์_จันทร์_อังคาร_พุธ_พฤหัสบดี_ศุกร์_เสาร์".split("_"),weekdaysShort:"อาทิตย์_จันทร์_อังคาร_พุธ_พฤหัส_ศุกร์_เสาร์".split("_"),weekdaysMin:"อา._จ._อ._พ._พฤ._ศ._ส.".split("_"),longDateFormat:{LT:"H นาฬิกา m นาที",LTS:"LT s วินาที",L:"YYYY/MM/DD",LL:"D MMMM YYYY",LLL:"D MMMM YYYY เวลา LT",LLLL:"วันddddที่ D MMMM YYYY เวลา LT"},meridiemParse:/ก่อนเที่ยง|หลังเที่ยง/,isPM:function(a){return"หลังเที่ยง"===a},meridiem:function(a){return 12>a?"ก่อนเที่ยง":"หลังเที่ยง"},calendar:{sameDay:"[วันนี้ เวลา] LT",nextDay:"[พรุ่งนี้ เวลา] LT",nextWeek:"dddd[หน้า เวลา] LT",lastDay:"[เมื่อวานนี้ เวลา] LT",lastWeek:"[วัน]dddd[ที่แล้ว เวลา] LT",sameElse:"L"},relativeTime:{future:"อีก %s",past:"%sที่แล้ว",s:"ไม่กี่วินาที",m:"1 นาที",mm:"%d นาที",h:"1 ชั่วโมง",hh:"%d ชั่วโมง",d:"1 วัน",dd:"%d วัน",M:"1 เดือน",MM:"%d เดือน",y:"1 ปี",yy:"%d ปี"}})}),function(a){a(va)}(function(a){return a.defineLocale("tl-ph",{months:"Enero_Pebrero_Marso_Abril_Mayo_Hunyo_Hulyo_Agosto_Setyembre_Oktubre_Nobyembre_Disyembre".split("_"),monthsShort:"Ene_Peb_Mar_Abr_May_Hun_Hul_Ago_Set_Okt_Nob_Dis".split("_"),weekdays:"Linggo_Lunes_Martes_Miyerkules_Huwebes_Biyernes_Sabado".split("_"),weekdaysShort:"Lin_Lun_Mar_Miy_Huw_Biy_Sab".split("_"),weekdaysMin:"Li_Lu_Ma_Mi_Hu_Bi_Sab".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"MM/D/YYYY",LL:"MMMM D, YYYY",LLL:"MMMM D, YYYY LT",LLLL:"dddd, MMMM DD, YYYY LT"},calendar:{sameDay:"[Ngayon sa] LT",nextDay:"[Bukas sa] LT",nextWeek:"dddd [sa] LT",lastDay:"[Kahapon sa] LT",lastWeek:"dddd [huling linggo] LT",sameElse:"L"},relativeTime:{future:"sa loob ng %s",past:"%s ang nakalipas",s:"ilang segundo",m:"isang minuto",mm:"%d minuto",h:"isang oras",hh:"%d oras",d:"isang araw",dd:"%d araw",M:"isang buwan",MM:"%d buwan",y:"isang taon",yy:"%d taon"},ordinalParse:/\d{1,2}/,ordinal:function(a){return a},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){var b={1:"'inci",5:"'inci",8:"'inci",70:"'inci",80:"'inci",2:"'nci",7:"'nci",20:"'nci",50:"'nci",3:"'üncü",4:"'üncü",100:"'üncü",6:"'ncı",9:"'uncu",10:"'uncu",30:"'uncu",60:"'ıncı",90:"'ıncı"};return a.defineLocale("tr",{months:"Ocak_Şubat_Mart_Nisan_Mayıs_Haziran_Temmuz_Ağustos_Eylül_Ekim_Kasım_Aralık".split("_"),monthsShort:"Oca_Şub_Mar_Nis_May_Haz_Tem_Ağu_Eyl_Eki_Kas_Ara".split("_"),weekdays:"Pazar_Pazartesi_Salı_Çarşamba_Perşembe_Cuma_Cumartesi".split("_"),weekdaysShort:"Paz_Pts_Sal_Çar_Per_Cum_Cts".split("_"),weekdaysMin:"Pz_Pt_Sa_Ça_Pe_Cu_Ct".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD.MM.YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd, D MMMM YYYY LT"},calendar:{sameDay:"[bugün saat] LT",nextDay:"[yarın saat] LT",nextWeek:"[haftaya] dddd [saat] LT",lastDay:"[dün] LT",lastWeek:"[geçen hafta] dddd [saat] LT",sameElse:"L"},relativeTime:{future:"%s sonra",past:"%s önce",s:"birkaç saniye",m:"bir dakika",mm:"%d dakika",h:"bir saat",hh:"%d saat",d:"bir gün",dd:"%d gün",M:"bir ay",MM:"%d ay",y:"bir yıl",yy:"%d yıl"},ordinalParse:/\d{1,2}'(inci|nci|üncü|ncı|uncu|ıncı)/,ordinal:function(a){if(0===a)return a+"'ıncı";var c=a%10,d=a%100-c,e=a>=100?100:null;return a+(b[c]||b[d]||b[e])},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){return a.defineLocale("tzm-latn",{months:"innayr_brˤayrˤ_marˤsˤ_ibrir_mayyw_ywnyw_ywlywz_ɣwšt_šwtanbir_ktˤwbrˤ_nwwanbir_dwjnbir".split("_"),monthsShort:"innayr_brˤayrˤ_marˤsˤ_ibrir_mayyw_ywnyw_ywlywz_ɣwšt_šwtanbir_ktˤwbrˤ_nwwanbir_dwjnbir".split("_"),weekdays:"asamas_aynas_asinas_akras_akwas_asimwas_asiḍyas".split("_"),weekdaysShort:"asamas_aynas_asinas_akras_akwas_asimwas_asiḍyas".split("_"),weekdaysMin:"asamas_aynas_asinas_akras_akwas_asimwas_asiḍyas".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},calendar:{sameDay:"[asdkh g] LT",nextDay:"[aska g] LT",nextWeek:"dddd [g] LT",lastDay:"[assant g] LT",lastWeek:"dddd [g] LT",sameElse:"L"},relativeTime:{future:"dadkh s yan %s",past:"yan %s",s:"imik",m:"minuḍ",mm:"%d minuḍ",h:"saɛa",hh:"%d tassaɛin",d:"ass",dd:"%d ossan",M:"ayowr",MM:"%d iyyirn",y:"asgas",yy:"%d isgasn"},week:{dow:6,doy:12}})}),function(a){a(va)}(function(a){return a.defineLocale("tzm",{months:"ⵉⵏⵏⴰⵢⵔ_ⴱⵕⴰⵢⵕ_ⵎⴰⵕⵚ_ⵉⴱⵔⵉⵔ_ⵎⴰⵢⵢⵓ_ⵢⵓⵏⵢⵓ_ⵢⵓⵍⵢⵓⵣ_ⵖⵓⵛⵜ_ⵛⵓⵜⴰⵏⴱⵉⵔ_ⴽⵟⵓⴱⵕ_ⵏⵓⵡⴰⵏⴱⵉⵔ_ⴷⵓⵊⵏⴱⵉⵔ".split("_"),monthsShort:"ⵉⵏⵏⴰⵢⵔ_ⴱⵕⴰⵢⵕ_ⵎⴰⵕⵚ_ⵉⴱⵔⵉⵔ_ⵎⴰⵢⵢⵓ_ⵢⵓⵏⵢⵓ_ⵢⵓⵍⵢⵓⵣ_ⵖⵓⵛⵜ_ⵛⵓⵜⴰⵏⴱⵉⵔ_ⴽⵟⵓⴱⵕ_ⵏⵓⵡⴰⵏⴱⵉⵔ_ⴷⵓⵊⵏⴱⵉⵔ".split("_"),weekdays:"ⴰⵙⴰⵎⴰⵙ_ⴰⵢⵏⴰⵙ_ⴰⵙⵉⵏⴰⵙ_ⴰⴽⵔⴰⵙ_ⴰⴽⵡⴰⵙ_ⴰⵙⵉⵎⵡⴰⵙ_ⴰⵙⵉⴹⵢⴰⵙ".split("_"),weekdaysShort:"ⴰⵙⴰⵎⴰⵙ_ⴰⵢⵏⴰⵙ_ⴰⵙⵉⵏⴰⵙ_ⴰⴽⵔⴰⵙ_ⴰⴽⵡⴰⵙ_ⴰⵙⵉⵎⵡⴰⵙ_ⴰⵙⵉⴹⵢⴰⵙ".split("_"),weekdaysMin:"ⴰⵙⴰⵎⴰⵙ_ⴰⵢⵏⴰⵙ_ⴰⵙⵉⵏⴰⵙ_ⴰⴽⵔⴰⵙ_ⴰⴽⵡⴰⵙ_ⴰⵙⵉⵎⵡⴰⵙ_ⴰⵙⵉⴹⵢⴰⵙ".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"dddd D MMMM YYYY LT"},calendar:{sameDay:"[ⴰⵙⴷⵅ ⴴ] LT",nextDay:"[ⴰⵙⴽⴰ ⴴ] LT",nextWeek:"dddd [ⴴ] LT",lastDay:"[ⴰⵚⴰⵏⵜ ⴴ] LT",lastWeek:"dddd [ⴴ] LT",sameElse:"L"},relativeTime:{future:"ⴷⴰⴷⵅ ⵙ ⵢⴰⵏ %s",past:"ⵢⴰⵏ %s",s:"ⵉⵎⵉⴽ",m:"ⵎⵉⵏⵓⴺ",mm:"%d ⵎⵉⵏⵓⴺ",h:"ⵙⴰⵄⴰ",hh:"%d ⵜⴰⵙⵙⴰⵄⵉⵏ",d:"ⴰⵙⵙ",dd:"%d oⵙⵙⴰⵏ",M:"ⴰⵢoⵓⵔ",MM:"%d ⵉⵢⵢⵉⵔⵏ",y:"ⴰⵙⴳⴰⵙ",yy:"%d ⵉⵙⴳⴰⵙⵏ"},week:{dow:6,doy:12}})}),function(a){a(va)}(function(a){function b(a,b){var c=a.split("_");return b%10===1&&b%100!==11?c[0]:b%10>=2&&4>=b%10&&(10>b%100||b%100>=20)?c[1]:c[2]}function c(a,c,d){var e={mm:"хвилина_хвилини_хвилин",hh:"година_години_годин",dd:"день_дні_днів",MM:"місяць_місяці_місяців",yy:"рік_роки_років"};return"m"===d?c?"хвилина":"хвилину":"h"===d?c?"година":"годину":a+" "+b(e[d],+a)}function d(a,b){var c={nominative:"січень_лютий_березень_квітень_травень_червень_липень_серпень_вересень_жовтень_листопад_грудень".split("_"),accusative:"січня_лютого_березня_квітня_травня_червня_липня_серпня_вересня_жовтня_листопада_грудня".split("_")},d=/D[oD]? *MMMM?/.test(b)?"accusative":"nominative";return c[d][a.month()]}function e(a,b){var c={nominative:"неділя_понеділок_вівторок_середа_четвер_п’ятниця_субота".split("_"),accusative:"неділю_понеділок_вівторок_середу_четвер_п’ятницю_суботу".split("_"),genitive:"неділі_понеділка_вівторка_середи_четверга_п’ятниці_суботи".split("_")},d=/(\[[ВвУу]\]) ?dddd/.test(b)?"accusative":/\[?(?:минулої|наступної)? ?\] ?dddd/.test(b)?"genitive":"nominative";return c[d][a.day()]}function f(a){return function(){return a+"о"+(11===this.hours()?"б":"")+"] LT"}}return a.defineLocale("uk",{months:d,monthsShort:"січ_лют_бер_квіт_трав_черв_лип_серп_вер_жовт_лист_груд".split("_"),weekdays:e,weekdaysShort:"нд_пн_вт_ср_чт_пт_сб".split("_"),weekdaysMin:"нд_пн_вт_ср_чт_пт_сб".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD.MM.YYYY",LL:"D MMMM YYYY р.",LLL:"D MMMM YYYY р., LT",LLLL:"dddd, D MMMM YYYY р., LT"},calendar:{sameDay:f("[Сьогодні "),nextDay:f("[Завтра "),lastDay:f("[Вчора "),nextWeek:f("[У] dddd ["),lastWeek:function(){switch(this.day()){case 0:case 3:case 5:case 6:return f("[Минулої] dddd [").call(this);case 1:case 2:case 4:return f("[Минулого] dddd [").call(this)}},sameElse:"L"},relativeTime:{future:"за %s",past:"%s тому",s:"декілька секунд",m:c,mm:c,h:"годину",hh:c,d:"день",dd:c,M:"місяць",MM:c,y:"рік",yy:c},meridiemParse:/ночі|ранку|дня|вечора/,isPM:function(a){return/^(дня|вечора)$/.test(a)},meridiem:function(a){return 4>a?"ночі":12>a?"ранку":17>a?"дня":"вечора"},ordinalParse:/\d{1,2}-(й|го)/,ordinal:function(a,b){switch(b){case"M":case"d":case"DDD":case"w":case"W":return a+"-й";case"D":return a+"-го";default:return a}},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){return a.defineLocale("uz",{months:"январь_февраль_март_апрель_май_июнь_июль_август_сентябрь_октябрь_ноябрь_декабрь".split("_"),monthsShort:"янв_фев_мар_апр_май_июн_июл_авг_сен_окт_ноя_дек".split("_"),weekdays:"Якшанба_Душанба_Сешанба_Чоршанба_Пайшанба_Жума_Шанба".split("_"),weekdaysShort:"Якш_Душ_Сеш_Чор_Пай_Жум_Шан".split("_"),weekdaysMin:"Як_Ду_Се_Чо_Па_Жу_Ша".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM YYYY",LLL:"D MMMM YYYY LT",LLLL:"D MMMM YYYY, dddd LT"},calendar:{sameDay:"[Бугун соат] LT [да]",nextDay:"[Эртага] LT [да]",nextWeek:"dddd [куни соат] LT [да]",lastDay:"[Кеча соат] LT [да]",lastWeek:"[Утган] dddd [куни соат] LT [да]",sameElse:"L"},relativeTime:{future:"Якин %s ичида",past:"Бир неча %s олдин",s:"фурсат",m:"бир дакика",mm:"%d дакика",h:"бир соат",hh:"%d соат",d:"бир кун",dd:"%d кун",M:"бир ой",MM:"%d ой",y:"бир йил",yy:"%d йил"},week:{dow:1,doy:7}})}),function(a){a(va)}(function(a){return a.defineLocale("vi",{months:"tháng 1_tháng 2_tháng 3_tháng 4_tháng 5_tháng 6_tháng 7_tháng 8_tháng 9_tháng 10_tháng 11_tháng 12".split("_"),monthsShort:"Th01_Th02_Th03_Th04_Th05_Th06_Th07_Th08_Th09_Th10_Th11_Th12".split("_"),weekdays:"chủ nhật_thứ hai_thứ ba_thứ tư_thứ năm_thứ sáu_thứ bảy".split("_"),weekdaysShort:"CN_T2_T3_T4_T5_T6_T7".split("_"),weekdaysMin:"CN_T2_T3_T4_T5_T6_T7".split("_"),longDateFormat:{LT:"HH:mm",LTS:"LT:ss",L:"DD/MM/YYYY",LL:"D MMMM [năm] YYYY",LLL:"D MMMM [năm] YYYY LT",LLLL:"dddd, D MMMM [năm] YYYY LT",l:"DD/M/YYYY",ll:"D MMM YYYY",lll:"D MMM YYYY LT",llll:"ddd, D MMM YYYY LT"},calendar:{sameDay:"[Hôm nay lúc] LT",nextDay:"[Ngày mai lúc] LT",nextWeek:"dddd [tuần tới lúc] LT",lastDay:"[Hôm qua lúc] LT",lastWeek:"dddd [tuần rồi lúc] LT",sameElse:"L"},relativeTime:{future:"%s tới",past:"%s trước",s:"vài giây",m:"một phút",mm:"%d phút",h:"một giờ",hh:"%d giờ",d:"một ngày",dd:"%d ngày",M:"một tháng",MM:"%d tháng",y:"một năm",yy:"%d năm"},ordinalParse:/\d{1,2}/,ordinal:function(a){return a},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("zh-cn",{months:"一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月".split("_"),monthsShort:"1月_2月_3月_4月_5月_6月_7月_8月_9月_10月_11月_12月".split("_"),weekdays:"星期日_星期一_星期二_星期三_星期四_星期五_星期六".split("_"),weekdaysShort:"周日_周一_周二_周三_周四_周五_周六".split("_"),weekdaysMin:"日_一_二_三_四_五_六".split("_"),longDateFormat:{LT:"Ah点mm",LTS:"Ah点m分s秒",L:"YYYY-MM-DD",LL:"YYYY年MMMD日",LLL:"YYYY年MMMD日LT",LLLL:"YYYY年MMMD日ddddLT",l:"YYYY-MM-DD",ll:"YYYY年MMMD日",lll:"YYYY年MMMD日LT",llll:"YYYY年MMMD日ddddLT"},meridiemParse:/凌晨|早上|上午|中午|下午|晚上/,meridiemHour:function(a,b){return 12===a&&(a=0),"凌晨"===b||"早上"===b||"上午"===b?a:"下午"===b||"晚上"===b?a+12:a>=11?a:a+12},meridiem:function(a,b){var c=100*a+b;return 600>c?"凌晨":900>c?"早上":1130>c?"上午":1230>c?"中午":1800>c?"下午":"晚上"},calendar:{sameDay:function(){return 0===this.minutes()?"[今天]Ah[点整]":"[今天]LT"},nextDay:function(){return 0===this.minutes()?"[明天]Ah[点整]":"[明天]LT"},lastDay:function(){return 0===this.minutes()?"[昨天]Ah[点整]":"[昨天]LT"},nextWeek:function(){var b,c;return b=a().startOf("week"),c=this.unix()-b.unix()>=604800?"[下]":"[本]",0===this.minutes()?c+"dddAh点整":c+"dddAh点mm"},lastWeek:function(){var b,c;return b=a().startOf("week"),c=this.unix()<b.unix()?"[上]":"[本]",0===this.minutes()?c+"dddAh点整":c+"dddAh点mm"},sameElse:"LL"},ordinalParse:/\d{1,2}(日|月|周)/,ordinal:function(a,b){switch(b){case"d":case"D":case"DDD":return a+"日";case"M":return a+"月";case"w":case"W":return a+"周";default:return a}},relativeTime:{future:"%s内",past:"%s前",s:"几秒",m:"1分钟",mm:"%d分钟",h:"1小时",hh:"%d小时",d:"1天",dd:"%d天",M:"1个月",MM:"%d个月",y:"1年",yy:"%d年"},week:{dow:1,doy:4}})}),function(a){a(va)}(function(a){return a.defineLocale("zh-tw",{months:"一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月".split("_"),monthsShort:"1月_2月_3月_4月_5月_6月_7月_8月_9月_10月_11月_12月".split("_"),weekdays:"星期日_星期一_星期二_星期三_星期四_星期五_星期六".split("_"),weekdaysShort:"週日_週一_週二_週三_週四_週五_週六".split("_"),weekdaysMin:"日_一_二_三_四_五_六".split("_"),longDateFormat:{LT:"Ah點mm",LTS:"Ah點m分s秒",L:"YYYY年MMMD日",LL:"YYYY年MMMD日",LLL:"YYYY年MMMD日LT",LLLL:"YYYY年MMMD日ddddLT",l:"YYYY年MMMD日",ll:"YYYY年MMMD日",lll:"YYYY年MMMD日LT",llll:"YYYY年MMMD日ddddLT"},meridiemParse:/早上|上午|中午|下午|晚上/,meridiemHour:function(a,b){return 12===a&&(a=0),"早上"===b||"上午"===b?a:"中午"===b?a>=11?a:a+12:"下午"===b||"晚上"===b?a+12:void 0},meridiem:function(a,b){var c=100*a+b;return 900>c?"早上":1130>c?"上午":1230>c?"中午":1800>c?"下午":"晚上"},calendar:{sameDay:"[今天]LT",nextDay:"[明天]LT",nextWeek:"[下]ddddLT",lastDay:"[昨天]LT",lastWeek:"[上]ddddLT",sameElse:"L"},ordinalParse:/\d{1,2}(日|月|週)/,ordinal:function(a,b){switch(b){case"d":case"D":case"DDD":return a+"日";case"M":return a+"月";case"w":case"W":return a+"週";default:return a}},relativeTime:{future:"%s內",past:"%s前",s:"幾秒",m:"一分鐘",mm:"%d分鐘",h:"一小時",hh:"%d小時",d:"一天",dd:"%d天",M:"一個月",MM:"%d個月",y:"一年",yy:"%d年"}})}),va.locale("en"),La?module.exports=va:"function"==typeof define&&define.amd?(define(function(a,b,c){return c.config&&c.config()&&c.config().noGlobal===!0&&(za.moment=wa),va}),ua(!0)):ua()}.call(this),/*! clndr.min.js v1.2.7 2015-01-21 */
-!function(a){"function"==typeof define&&define.amd?define(["jquery","moment"],a):"object"==typeof exports?a(require("jquery"),require("moment")):a(jQuery,moment)}(function(a,b){function c(c,d){if(this.element=c,this.options=a.extend(!0,{},f,d),this.options.events.length&&(this.options.events=this.options.multiDayEvents?this.addMultiDayMomentObjectsToEvents(this.options.events):this.addMomentObjectToEvents(this.options.events)),this.month=this.options.startWithMonth?b(this.options.startWithMonth).startOf("month"):b().startOf("month"),this.options.constraints){if(this.options.constraints.startDate){var g=b(this.options.constraints.startDate);this.month.isBefore(g,"month")&&(this.month.set("month",g.month()),this.month.set("year",g.year()))}if(this.options.constraints.endDate){var h=b(this.options.constraints.endDate);this.month.isAfter(h,"month")&&this.month.set("month",h.month()).set("year",h.year())}}this._defaults=f,this._name=e,this.init()}var d="<div class='clndr-controls'><div class='clndr-control-button'><span class='clndr-previous-button'>previous</span></div><div class='month'><%= month %> <%= year %></div><div class='clndr-control-button rightalign'><span class='clndr-next-button'>next</span></div></div><table class='clndr-table' border='0' cellspacing='0' cellpadding='0'><thead><tr class='header-days'><% for(var i = 0; i < daysOfTheWeek.length; i++) { %><td class='header-day'><%= daysOfTheWeek[i] %></td><% } %></tr></thead><tbody><% for(var i = 0; i < numberOfRows; i++){ %><tr><% for(var j = 0; j < 7; j++){ %><% var d = j + i * 7; %><td class='<%= days[d].classes %>'><div class='day-contents'><%= days[d].day %></div></td><% } %></tr><% } %></tbody></table>",e="clndr",f={template:d,weekOffset:0,startWithMonth:null,clickEvents:{click:null,nextMonth:null,previousMonth:null,nextYear:null,previousYear:null,today:null,onMonthChange:null,onYearChange:null},targets:{nextButton:"clndr-next-button",previousButton:"clndr-previous-button",nextYearButton:"clndr-next-year-button",previousYearButton:"clndr-previous-year-button",todayButton:"clndr-today-button",day:"day",empty:"empty"},classes:{today:"today",event:"event",past:"past",lastMonth:"last-month",nextMonth:"next-month",adjacentMonth:"adjacent-month",inactive:"inactive"},events:[],extras:null,dateParameter:"date",multiDayEvents:null,doneRendering:null,render:null,daysOfTheWeek:null,showAdjacentMonths:!0,adjacentDaysChangeMonth:!1,ready:null,constraints:null,forceSixRows:null};c.prototype.init=function(){if(this.daysOfTheWeek=this.options.daysOfTheWeek||[],!this.options.daysOfTheWeek){this.daysOfTheWeek=[];for(var c=0;7>c;c++)this.daysOfTheWeek.push(b().weekday(c).format("dd").charAt(0))}if(this.options.weekOffset&&(this.daysOfTheWeek=this.shiftWeekdayLabels(this.options.weekOffset)),!a.isFunction(this.options.render)){if(this.options.render=null,"undefined"==typeof _)throw new Error("Underscore was not found. Please include underscore.js OR provide a custom render function.");this.compiledClndrTemplate=_.template(this.options.template)}a(this.element).html("<div class='clndr'></div>"),this.calendarContainer=a(".clndr",this.element),this.bindEvents(),this.render(),this.options.ready&&this.options.ready.apply(this,[])},c.prototype.shiftWeekdayLabels=function(a){for(var b=this.daysOfTheWeek,c=0;a>c;c++)b.push(b.shift());return b},c.prototype.createDaysObject=function(c){daysArray=[];var d=c.startOf("month");if(this.eventsLastMonth=[],this.eventsThisMonth=[],this.eventsNextMonth=[],this.options.events.length)if(this.options.multiDayEvents){if(this.eventsThisMonth=a(this.options.events).filter(function(){return this._clndrStartDateObject.format("YYYY-MM")===c.format("YYYY-MM")||this._clndrEndDateObject.format("YYYY-MM")===c.format("YYYY-MM")?!0:this._clndrStartDateObject.format("YYYY-MM")<=c.format("YYYY-MM")&&this._clndrEndDateObject.format("YYYY-MM")>=c.format("YYYY-MM")?!0:!1}).toArray(),this.options.showAdjacentMonths){var e=c.clone().subtract(1,"months"),f=c.clone().add(1,"months");this.eventsLastMonth=a(this.options.events).filter(function(){return this._clndrStartDateObject.format("YYYY-MM")===e.format("YYYY-MM")||this._clndrEndDateObject.format("YYYY-MM")===e.format("YYYY-MM")?!0:this._clndrStartDateObject.format("YYYY-MM")<=e.format("YYYY-MM")&&this._clndrEndDateObject.format("YYYY-MM")>=e.format("YYYY-MM")?!0:!1}).toArray(),this.eventsNextMonth=a(this.options.events).filter(function(){return this._clndrStartDateObject.format("YYYY-MM")===f.format("YYYY-MM")||this._clndrEndDateObject.format("YYYY-MM")===f.format("YYYY-MM")?!0:this._clndrStartDateObject.format("YYYY-MM")<=f.format("YYYY-MM")&&this._clndrEndDateObject.format("YYYY-MM")>=f.format("YYYY-MM")?!0:!1}).toArray()}}else if(this.eventsThisMonth=a(this.options.events).filter(function(){return this._clndrDateObject.format("YYYY-MM")==c.format("YYYY-MM")}).toArray(),this.options.showAdjacentMonths){var e=c.clone().subtract(1,"months"),f=c.clone().add(1,"months");this.eventsLastMonth=a(this.options.events).filter(function(){return this._clndrDateObject.format("YYYY-MM")==e.format("YYYY-MM")}).toArray(),this.eventsNextMonth=a(this.options.events).filter(function(){return this._clndrDateObject.format("YYYY-MM")==f.format("YYYY-MM")}).toArray()}var g=d.weekday()-this.options.weekOffset;if(0>g&&(g+=7),this.options.showAdjacentMonths)for(var h=0;g>h;h++){var i=b([c.year(),c.month(),h-g+1]);daysArray.push(this.createDayObject(i,this.eventsLastMonth))}else for(var h=0;g>h;h++)daysArray.push(this.calendarDay({classes:this.options.targets.empty+" "+this.options.classes.lastMonth}));for(var j=d.daysInMonth(),h=1;j>=h;h++){var i=b([c.year(),c.month(),h]);daysArray.push(this.createDayObject(i,this.eventsThisMonth))}for(var h=1;daysArray.length%7!==0;){if(this.options.showAdjacentMonths){var i=b([c.year(),c.month(),j+h]);daysArray.push(this.createDayObject(i,this.eventsNextMonth))}else daysArray.push(this.calendarDay({classes:this.options.targets.empty+" "+this.options.classes.nextMonth}));h++}if(this.options.forceSixRows&&42!==daysArray.length)for(var k=b(daysArray[daysArray.length-1].date).add(1,"days");daysArray.length<42;)this.options.showAdjacentMonths?(daysArray.push(this.createDayObject(b(k),this.eventsNextMonth)),k.add(1,"days")):daysArray.push(this.calendarDay({classes:this.options.targets.empty+" "+this.options.classes.nextMonth}));return daysArray},c.prototype.createDayObject=function(a,c){var d=[],e=b(),f=this,g=0,h=c.length;for(g;h>g;g++)if(f.options.multiDayEvents){var i=c[g]._clndrStartDateObject,j=c[g]._clndrEndDateObject;(a.isSame(i,"day")||a.isAfter(i,"day"))&&(a.isSame(j,"day")||a.isBefore(j,"day"))&&d.push(c[g])}else c[g]._clndrDateObject.date()==a.date()&&d.push(c[g]);var k="";return e.format("YYYY-MM-DD")==a.format("YYYY-MM-DD")&&(k+=" "+this.options.classes.today),a.isBefore(e,"day")&&(k+=" "+this.options.classes.past),d.length&&(k+=" "+this.options.classes.event),this.month.month()>a.month()?(k+=" "+this.options.classes.adjacentMonth,k+=this.month.year()===a.year()?" "+this.options.classes.lastMonth:" "+this.options.classes.nextMonth):this.month.month()<a.month()&&(k+=" "+this.options.classes.adjacentMonth,k+=this.month.year()===a.year()?" "+this.options.classes.nextMonth:" "+this.options.classes.lastMonth),this.options.constraints&&(this.options.constraints.startDate&&a.isBefore(b(this.options.constraints.startDate))&&(k+=" "+this.options.classes.inactive),this.options.constraints.endDate&&a.isAfter(b(this.options.constraints.endDate))&&(k+=" "+this.options.classes.inactive)),!a.isValid()&&a.hasOwnProperty("_d")&&void 0!=a._d&&(a=b(a._d)),k+=" calendar-day-"+a.format("YYYY-MM-DD"),k+=" calendar-dow-"+a.weekday(),this.calendarDay({day:a.date(),classes:this.options.targets.day+k,events:d,date:a})},c.prototype.render=function(){this.calendarContainer.children().remove();var a=this.createDaysObject(this.month),c=(this.month,{daysOfTheWeek:this.daysOfTheWeek,numberOfRows:Math.ceil(a.length/7),days:a,month:this.month.format("MMMM"),year:this.month.year(),eventsThisMonth:this.eventsThisMonth,eventsLastMonth:this.eventsLastMonth,eventsNextMonth:this.eventsNextMonth,extras:this.options.extras});if(this.calendarContainer.html(this.options.render?this.options.render.apply(this,[c]):this.compiledClndrTemplate(c)),this.options.constraints){for(var d in this.options.targets)d!=this.options.targets.day&&this.element.find("."+this.options.targets[d]).toggleClass(this.options.classes.inactive,!1);var e=null,f=null;this.options.constraints.startDate&&(e=b(this.options.constraints.startDate)),this.options.constraints.endDate&&(f=b(this.options.constraints.endDate)),e&&this.month.isSame(e,"month")&&this.element.find("."+this.options.targets.previousButton).toggleClass(this.options.classes.inactive,!0),f&&this.month.isSame(f,"month")&&this.element.find("."+this.options.targets.nextButton).toggleClass(this.options.classes.inactive,!0),e&&b(e).subtract(1,"years").isBefore(b(this.month).subtract(1,"years"))&&this.element.find("."+this.options.targets.previousYearButton).toggleClass(this.options.classes.inactive,!0),f&&b(f).add(1,"years").isAfter(b(this.month).add(1,"years"))&&this.element.find("."+this.options.targets.nextYearButton).toggleClass(this.options.classes.inactive,!0),(e&&e.isAfter(b(),"month")||f&&f.isBefore(b(),"month"))&&this.element.find("."+this.options.targets.today).toggleClass(this.options.classes.inactive,!0)}this.options.doneRendering&&this.options.doneRendering.apply(this,[])},c.prototype.bindEvents=function(){var b=a(this.element),c=this;b.on("click","."+this.options.targets.day,function(b){if(c.options.clickEvents.click){var d=c.buildTargetObject(b.currentTarget,!0);c.options.clickEvents.click.apply(c,[d])}c.options.adjacentDaysChangeMonth&&(a(b.currentTarget).is("."+c.options.classes.lastMonth)?c.backActionWithContext(c):a(b.currentTarget).is("."+c.options.classes.nextMonth)&&c.forwardActionWithContext(c))}),b.on("click","."+this.options.targets.empty,function(b){if(c.options.clickEvents.click){var d=c.buildTargetObject(b.currentTarget,!1);c.options.clickEvents.click.apply(c,[d])}c.options.adjacentDaysChangeMonth&&(a(b.currentTarget).is("."+c.options.classes.lastMonth)?c.backActionWithContext(c):a(b.currentTarget).is("."+c.options.classes.nextMonth)&&c.forwardActionWithContext(c))}),b.on("click","."+this.options.targets.previousButton,{context:this},this.backAction).on("click","."+this.options.targets.nextButton,{context:this},this.forwardAction).on("click","."+this.options.targets.todayButton,{context:this},this.todayAction).on("click","."+this.options.targets.nextYearButton,{context:this},this.nextYearAction).on("click","."+this.options.targets.previousYearButton,{context:this},this.previousYearAction)},c.prototype.buildTargetObject=function(c,d){var e={element:c,events:[],date:null};if(d){var f,g=c.className.indexOf("calendar-day-");0!==g?(f=c.className.substring(g+13,g+23),e.date=b(f)):e.date=null,this.options.events&&(e.events=a.makeArray(a(this.options.events).filter(this.options.multiDayEvents?function(){return(e.date.isSame(this._clndrStartDateObject,"day")||e.date.isAfter(this._clndrStartDateObject,"day"))&&(e.date.isSame(this._clndrEndDateObject,"day")||e.date.isBefore(this._clndrEndDateObject,"day"))}:function(){return this._clndrDateObject.format("YYYY-MM-DD")==f})))}return e},c.prototype.forwardAction=function(a){var b=a.data.context;b.forwardActionWithContext(b)},c.prototype.backAction=function(a){var b=a.data.context;b.backActionWithContext(b)},c.prototype.backActionWithContext=function(a){if(!a.element.find("."+a.options.targets.previousButton).hasClass("inactive")){var c=!a.month.isSame(b(a.month).subtract(1,"months"),"year");a.month.subtract(1,"months"),a.render(),a.options.clickEvents.previousMonth&&a.options.clickEvents.previousMonth.apply(a,[b(a.month)]),a.options.clickEvents.onMonthChange&&a.options.clickEvents.onMonthChange.apply(a,[b(a.month)]),c&&a.options.clickEvents.onYearChange&&a.options.clickEvents.onYearChange.apply(a,[b(a.month)])}},c.prototype.forwardActionWithContext=function(a){if(!a.element.find("."+a.options.targets.nextButton).hasClass("inactive")){var c=!a.month.isSame(b(a.month).add(1,"months"),"year");a.month.add(1,"months"),a.render(),a.options.clickEvents.nextMonth&&a.options.clickEvents.nextMonth.apply(a,[b(a.month)]),a.options.clickEvents.onMonthChange&&a.options.clickEvents.onMonthChange.apply(a,[b(a.month)]),c&&a.options.clickEvents.onYearChange&&a.options.clickEvents.onYearChange.apply(a,[b(a.month)])}},c.prototype.todayAction=function(a){var c=a.data.context,d=!c.month.isSame(b(),"month"),e=!c.month.isSame(b(),"year");c.month=b().startOf("month"),c.options.clickEvents.today&&c.options.clickEvents.today.apply(c,[b(c.month)]),d&&(c.render(),c.month=b(),c.options.clickEvents.onMonthChange&&c.options.clickEvents.onMonthChange.apply(c,[b(c.month)]),e&&c.options.clickEvents.onYearChange&&c.options.clickEvents.onYearChange.apply(c,[b(c.month)]))},c.prototype.nextYearAction=function(a){var c=a.data.context;c.element.find("."+c.options.targets.nextYearButton).hasClass("inactive")||(c.month.add(1,"years"),c.render(),c.options.clickEvents.nextYear&&c.options.clickEvents.nextYear.apply(c,[b(c.month)]),c.options.clickEvents.onMonthChange&&c.options.clickEvents.onMonthChange.apply(c,[b(c.month)]),c.options.clickEvents.onYearChange&&c.options.clickEvents.onYearChange.apply(c,[b(c.month)]))},c.prototype.previousYearAction=function(a){var c=a.data.context;c.element.find("."+c.options.targets.previousYear).hasClass("inactive")||(c.month.subtract(1,"years"),c.render(),c.options.clickEvents.previousYear&&c.options.clickEvents.previousYear.apply(c,[b(c.month)]),c.options.clickEvents.onMonthChange&&c.options.clickEvents.onMonthChange.apply(c,[b(c.month)]),c.options.clickEvents.onYearChange&&c.options.clickEvents.onYearChange.apply(c,[b(c.month)]))},c.prototype.forward=function(a){return this.month.add(1,"months"),this.render(),a&&a.withCallbacks&&(this.options.clickEvents.onMonthChange&&this.options.clickEvents.onMonthChange.apply(this,[b(this.month)]),0===this.month.month()&&this.options.clickEvents.onYearChange&&this.options.clickEvents.onYearChange.apply(this,[b(this.month)])),this},c.prototype.back=function(a){return this.month.subtract(1,"months"),this.render(),a&&a.withCallbacks&&(this.options.clickEvents.onMonthChange&&this.options.clickEvents.onMonthChange.apply(this,[b(this.month)]),11===this.month.month()&&this.options.clickEvents.onYearChange&&this.options.clickEvents.onYearChange.apply(this,[b(this.month)])),this},c.prototype.next=function(a){return this.forward(a),this},c.prototype.previous=function(a){return this.back(a),this},c.prototype.setMonth=function(a,c){return this.month.month(a),this.render(),c&&c.withCallbacks&&this.options.clickEvents.onMonthChange&&this.options.clickEvents.onMonthChange.apply(this,[b(this.month)]),this},c.prototype.nextYear=function(a){return this.month.add(1,"year"),this.render(),a&&a.withCallbacks&&this.options.clickEvents.onYearChange&&this.options.clickEvents.onYearChange.apply(this,[b(this.month)]),this},c.prototype.previousYear=function(a){return this.month.subtract(1,"year"),this.render(),a&&a.withCallbacks&&this.options.clickEvents.onYearChange&&this.options.clickEvents.onYearChange.apply(this,[b(this.month)]),this},c.prototype.setYear=function(a,c){return this.month.year(a),this.render(),c&&c.withCallbacks&&this.options.clickEvents.onYearChange&&this.options.clickEvents.onYearChange.apply(this,[b(this.month)]),this},c.prototype.setEvents=function(a){return this.options.events=this.options.multiDayEvents?this.addMultiDayMomentObjectsToEvents(a):this.addMomentObjectToEvents(a),this.render(),this},c.prototype.addEvents=function(b){return this.options.events=this.options.multiDayEvents?a.merge(this.options.events,this.addMultiDayMomentObjectsToEvents(b)):a.merge(this.options.events,this.addMomentObjectToEvents(b)),this.render(),this},c.prototype.removeEvents=function(a){for(var b=this.options.events.length-1;b>=0;b--)1==a(this.options.events[b])&&this.options.events.splice(b,1);return this.render(),this},c.prototype.addMomentObjectToEvents=function(a){var c=this,d=0,e=a.length;for(d;e>d;d++)a[d]._clndrDateObject=b(a[d][c.options.dateParameter]);return a},c.prototype.addMultiDayMomentObjectsToEvents=function(a){var c=this,d=0,e=a.length;for(d;e>d;d++)a[d][c.options.multiDayEvents.endDate]||a[d][c.options.multiDayEvents.startDate]?(a[d]._clndrEndDateObject=b(a[d][c.options.multiDayEvents.endDate]||a[d][c.options.multiDayEvents.startDate]),a[d]._clndrStartDateObject=b(a[d][c.options.multiDayEvents.startDate]||a[d][c.options.multiDayEvents.endDate])):(a[d]._clndrEndDateObject=b(a[d][c.options.multiDayEvents.singleDay]),a[d]._clndrStartDateObject=b(a[d][c.options.multiDayEvents.singleDay]));return a},c.prototype.calendarDay=function(b){var c={day:"",classes:this.options.targets.empty,events:[],date:null};return a.extend({},c,b)},a.fn.clndr=function(a){if(1===this.length){if(!this.data("plugin_clndr")){var b=new c(this,a);return this.data("plugin_clndr",b),b}}else if(this.length>1)throw new Error("CLNDR does not support multiple elements yet. Make sure your clndr selector returns only one element.")}});/*!
+!function(a){"function"==typeof define&&define.amd?define(["jquery","moment"],a):"object"==typeof exports?a(require("jquery"),require("moment")):a(jQuery,moment)}(function(a,b){function c(c,d){if(this.element=c,this.options=a.extend(!0,{},f,d),this.options.events.length&&(this.options.events=this.options.multiDayEvents?this.addMultiDayMomentObjectsToEvents(this.options.events):this.addMomentObjectToEvents(this.options.events)),this.month=this.options.startWithMonth?b(this.options.startWithMonth).startOf("month"):b().startOf("month"),this.options.constraints){if(this.options.constraints.startDate){var g=b(this.options.constraints.startDate);this.month.isBefore(g,"month")&&(this.month.set("month",g.month()),this.month.set("year",g.year()))}if(this.options.constraints.endDate){var h=b(this.options.constraints.endDate);this.month.isAfter(h,"month")&&this.month.set("month",h.month()).set("year",h.year())}}this._defaults=f,this._name=e,this.init()}var d="<div class='clndr-controls'><div class='clndr-control-button'><span class='clndr-previous-button'>previous</span></div><div class='month'><%= month %> <%= year %></div><div class='clndr-control-button rightalign'><span class='clndr-next-button'>next</span></div></div><table class='clndr-table' border='0' cellspacing='0' cellpadding='0'><thead><tr class='header-days'><% for(var i = 0; i < daysOfTheWeek.length; i++) { %><td class='header-day'><%= daysOfTheWeek[i] %></td><% } %></tr></thead><tbody><% for(var i = 0; i < numberOfRows; i++){ %><tr><% for(var j = 0; j < 7; j++){ %><% var d = j + i * 7; %><td class='<%= days[d].classes %>'><div class='day-contents'><%= days[d].day %></div></td><% } %></tr><% } %></tbody></table>",e="clndr",f={template:d,weekOffset:0,startWithMonth:null,clickEvents:{click:null,nextMonth:null,previousMonth:null,nextYear:null,previousYear:null,today:null,onMonthChange:null,onYearChange:null},targets:{nextButton:"clndr-next-button",previousButton:"clndr-previous-button",nextYearButton:"clndr-next-year-button",previousYearButton:"clndr-previous-year-button",todayButton:"clndr-today-button",day:"day",empty:"empty"},classes:{today:"today",event:"event",past:"past",lastMonth:"last-month",nextMonth:"next-month",adjacentMonth:"adjacent-month",inactive:"inactive"},events:[],extras:null,dateParameter:"date",multiDayEvents:null,doneRendering:null,render:null,daysOfTheWeek:null,showAdjacentMonths:!0,adjacentDaysChangeMonth:!1,ready:null,constraints:null,forceSixRows:null};c.prototype.init=function(){if(this.daysOfTheWeek=this.options.daysOfTheWeek||[],!this.options.daysOfTheWeek){this.daysOfTheWeek=[];for(var c=0;7>c;c++)this.daysOfTheWeek.push(b().weekday(c).format("dd").charAt(0))}if(this.options.weekOffset&&(this.daysOfTheWeek=this.shiftWeekdayLabels(this.options.weekOffset)),!a.isFunction(this.options.render)){if(this.options.render=null,"undefined"==typeof _)throw new Error("Underscore was not found. Please include underscore.js OR provide a custom render function.");this.compiledClndrTemplate=_.template(this.options.template)}a(this.element).html("<div class='clndr'></div>"),this.calendarContainer=a(".clndr",this.element),this.bindEvents(),this.render(),this.options.ready&&this.options.ready.apply(this,[])},c.prototype.shiftWeekdayLabels=function(a){for(var b=this.daysOfTheWeek,c=0;a>c;c++)b.push(b.shift());return b},c.prototype.createDaysObject=function(c){daysArray=[];var d=c.startOf("month");if(this.eventsLastMonth=[],this.eventsThisMonth=[],this.eventsNextMonth=[],this.options.events.length)if(this.options.multiDayEvents){if(this.eventsThisMonth=a(this.options.events).filter(function(){return this._clndrStartDateObject.format("YYYY-MM")===c.format("YYYY-MM")||this._clndrEndDateObject.format("YYYY-MM")===c.format("YYYY-MM")?!0:this._clndrStartDateObject.format("YYYY-MM")<=c.format("YYYY-MM")&&this._clndrEndDateObject.format("YYYY-MM")>=c.format("YYYY-MM")?!0:!1}).toArray(),this.options.showAdjacentMonths){var e=c.clone().subtract(1,"months"),f=c.clone().add(1,"months");this.eventsLastMonth=a(this.options.events).filter(function(){return this._clndrStartDateObject.format("YYYY-MM")===e.format("YYYY-MM")||this._clndrEndDateObject.format("YYYY-MM")===e.format("YYYY-MM")?!0:this._clndrStartDateObject.format("YYYY-MM")<=e.format("YYYY-MM")&&this._clndrEndDateObject.format("YYYY-MM")>=e.format("YYYY-MM")?!0:!1}).toArray(),this.eventsNextMonth=a(this.options.events).filter(function(){return this._clndrStartDateObject.format("YYYY-MM")===f.format("YYYY-MM")||this._clndrEndDateObject.format("YYYY-MM")===f.format("YYYY-MM")?!0:this._clndrStartDateObject.format("YYYY-MM")<=f.format("YYYY-MM")&&this._clndrEndDateObject.format("YYYY-MM")>=f.format("YYYY-MM")?!0:!1}).toArray()}}else if(this.eventsThisMonth=a(this.options.events).filter(function(){return this._clndrDateObject.format("YYYY-MM")==c.format("YYYY-MM")}).toArray(),this.options.showAdjacentMonths){var e=c.clone().subtract(1,"months"),f=c.clone().add(1,"months");this.eventsLastMonth=a(this.options.events).filter(function(){return this._clndrDateObject.format("YYYY-MM")==e.format("YYYY-MM")}).toArray(),this.eventsNextMonth=a(this.options.events).filter(function(){return this._clndrDateObject.format("YYYY-MM")==f.format("YYYY-MM")}).toArray()}var g=d.weekday()-this.options.weekOffset;if(0>g&&(g+=7),this.options.showAdjacentMonths)for(var h=0;g>h;h++){var i=b([c.year(),c.month(),h-g+1]);daysArray.push(this.createDayObject(i,this.eventsLastMonth))}else for(var h=0;g>h;h++)daysArray.push(this.calendarDay({classes:this.options.targets.empty+" "+this.options.classes.lastMonth}));for(var j=d.daysInMonth(),h=1;j>=h;h++){var i=b([c.year(),c.month(),h]);daysArray.push(this.createDayObject(i,this.eventsThisMonth))}for(var h=1;daysArray.length%7!==0;){if(this.options.showAdjacentMonths){var i=b([c.year(),c.month(),j+h]);daysArray.push(this.createDayObject(i,this.eventsNextMonth))}else daysArray.push(this.calendarDay({classes:this.options.targets.empty+" "+this.options.classes.nextMonth}));h++}if(this.options.forceSixRows&&42!==daysArray.length)for(var k=b(daysArray[daysArray.length-1].date).add(1,"days");daysArray.length<42;)this.options.showAdjacentMonths?(daysArray.push(this.createDayObject(b(k),this.eventsNextMonth)),k.add(1,"days")):daysArray.push(this.calendarDay({classes:this.options.targets.empty+" "+this.options.classes.nextMonth}));return daysArray},c.prototype.createDayObject=function(a,c){var d=[],e=b(),f=this,g=0,h=c.length;for(g;h>g;g++)if(f.options.multiDayEvents){var i=c[g]._clndrStartDateObject,j=c[g]._clndrEndDateObject;(a.isSame(i,"day")||a.isAfter(i,"day"))&&(a.isSame(j,"day")||a.isBefore(j,"day"))&&d.push(c[g])}else c[g]._clndrDateObject.date()==a.date()&&d.push(c[g]);var k="";return e.format("YYYY-MM-DD")==a.format("YYYY-MM-DD")&&(k+=" "+this.options.classes.today),a.isBefore(e,"day")&&(k+=" "+this.options.classes.past),d.length&&(k+=" "+this.options.classes.event),this.month.month()>a.month()?(k+=" "+this.options.classes.adjacentMonth,k+=this.month.year()===a.year()?" "+this.options.classes.lastMonth:" "+this.options.classes.nextMonth):this.month.month()<a.month()&&(k+=" "+this.options.classes.adjacentMonth,k+=this.month.year()===a.year()?" "+this.options.classes.nextMonth:" "+this.options.classes.lastMonth),this.options.constraints&&(this.options.constraints.startDate&&a.isBefore(b(this.options.constraints.startDate))&&(k+=" "+this.options.classes.inactive),this.options.constraints.endDate&&a.isAfter(b(this.options.constraints.endDate))&&(k+=" "+this.options.classes.inactive)),!a.isValid()&&a.hasOwnProperty("_d")&&void 0!=a._d&&(a=b(a._d)),k+=" calendar-day-"+a.format("YYYY-MM-DD"),k+=" calendar-dow-"+a.weekday(),this.calendarDay({day:a.date(),classes:this.options.targets.day+k,events:d,date:a})},c.prototype.render=function(){this.calendarContainer.children().remove();var a=this.createDaysObject(this.month),c=(this.month,{daysOfTheWeek:this.daysOfTheWeek,numberOfRows:Math.ceil(a.length/7),days:a,month:this.month.format("MMMM"),year:this.month.year(),eventsThisMonth:this.eventsThisMonth,eventsLastMonth:this.eventsLastMonth,eventsNextMonth:this.eventsNextMonth,extras:this.options.extras});if(this.calendarContainer.html(this.options.render?this.options.render.apply(this,[c]):this.compiledClndrTemplate(c)),this.options.constraints){for(var d in this.options.targets)d!=this.options.targets.day&&this.element.find("."+this.options.targets[d]).toggleClass(this.options.classes.inactive,!1);var e=null,f=null;this.options.constraints.startDate&&(e=b(this.options.constraints.startDate)),this.options.constraints.endDate&&(f=b(this.options.constraints.endDate)),e&&this.month.isSame(e,"month")&&this.element.find("."+this.options.targets.previousButton).toggleClass(this.options.classes.inactive,!0),f&&this.month.isSame(f,"month")&&this.element.find("."+this.options.targets.nextButton).toggleClass(this.options.classes.inactive,!0),e&&b(e).subtract(1,"years").isBefore(b(this.month).subtract(1,"years"))&&this.element.find("."+this.options.targets.previousYearButton).toggleClass(this.options.classes.inactive,!0),f&&b(f).add(1,"years").isAfter(b(this.month).add(1,"years"))&&this.element.find("."+this.options.targets.nextYearButton).toggleClass(this.options.classes.inactive,!0),(e&&e.isAfter(b(),"month")||f&&f.isBefore(b(),"month"))&&this.element.find("."+this.options.targets.today).toggleClass(this.options.classes.inactive,!0)}this.options.doneRendering&&this.options.doneRendering.apply(this,[])},c.prototype.bindEvents=function(){var b=a(this.element),c=this;b.on("click","."+this.options.targets.day,function(b){if(c.options.clickEvents.click){var d=c.buildTargetObject(b.currentTarget,!0);c.options.clickEvents.click.apply(c,[d])}c.options.adjacentDaysChangeMonth&&(a(b.currentTarget).is("."+c.options.classes.lastMonth)?c.backActionWithContext(c):a(b.currentTarget).is("."+c.options.classes.nextMonth)&&c.forwardActionWithContext(c))}),b.on("click","."+this.options.targets.empty,function(b){if(c.options.clickEvents.click){var d=c.buildTargetObject(b.currentTarget,!1);c.options.clickEvents.click.apply(c,[d])}c.options.adjacentDaysChangeMonth&&(a(b.currentTarget).is("."+c.options.classes.lastMonth)?c.backActionWithContext(c):a(b.currentTarget).is("."+c.options.classes.nextMonth)&&c.forwardActionWithContext(c))}),b.on("click","."+this.options.targets.previousButton,{context:this},this.backAction).on("click","."+this.options.targets.nextButton,{context:this},this.forwardAction).on("click","."+this.options.targets.todayButton,{context:this},this.todayAction).on("click","."+this.options.targets.nextYearButton,{context:this},this.nextYearAction).on("click","."+this.options.targets.previousYearButton,{context:this},this.previousYearAction)},c.prototype.buildTargetObject=function(c,d){var e={element:c,events:[],date:null};if(d){var f,g=c.className.indexOf("calendar-day-");0!==g?(f=c.className.substring(g+13,g+23),e.date=b(f)):e.date=null,this.options.events&&(e.events=a.makeArray(this.options.multiDayEvents?a(this.options.events).filter(function(){return(e.date.isSame(this._clndrStartDateObject,"day")||e.date.isAfter(this._clndrStartDateObject,"day"))&&(e.date.isSame(this._clndrEndDateObject,"day")||e.date.isBefore(this._clndrEndDateObject,"day"))}):a(this.options.events).filter(function(){return this._clndrDateObject.format("YYYY-MM-DD")==f})))}return e},c.prototype.forwardAction=function(a){var b=a.data.context;b.forwardActionWithContext(b)},c.prototype.backAction=function(a){var b=a.data.context;b.backActionWithContext(b)},c.prototype.backActionWithContext=function(a){if(!a.element.find("."+a.options.targets.previousButton).hasClass("inactive")){var c=!a.month.isSame(b(a.month).subtract(1,"months"),"year");a.month.subtract(1,"months"),a.render(),a.options.clickEvents.previousMonth&&a.options.clickEvents.previousMonth.apply(a,[b(a.month)]),a.options.clickEvents.onMonthChange&&a.options.clickEvents.onMonthChange.apply(a,[b(a.month)]),c&&a.options.clickEvents.onYearChange&&a.options.clickEvents.onYearChange.apply(a,[b(a.month)])}},c.prototype.forwardActionWithContext=function(a){if(!a.element.find("."+a.options.targets.nextButton).hasClass("inactive")){var c=!a.month.isSame(b(a.month).add(1,"months"),"year");a.month.add(1,"months"),a.render(),a.options.clickEvents.nextMonth&&a.options.clickEvents.nextMonth.apply(a,[b(a.month)]),a.options.clickEvents.onMonthChange&&a.options.clickEvents.onMonthChange.apply(a,[b(a.month)]),c&&a.options.clickEvents.onYearChange&&a.options.clickEvents.onYearChange.apply(a,[b(a.month)])}},c.prototype.todayAction=function(a){var c=a.data.context,d=!c.month.isSame(b(),"month"),e=!c.month.isSame(b(),"year");c.month=b().startOf("month"),c.options.clickEvents.today&&c.options.clickEvents.today.apply(c,[b(c.month)]),d&&(c.render(),c.month=b(),c.options.clickEvents.onMonthChange&&c.options.clickEvents.onMonthChange.apply(c,[b(c.month)]),e&&c.options.clickEvents.onYearChange&&c.options.clickEvents.onYearChange.apply(c,[b(c.month)]))},c.prototype.nextYearAction=function(a){var c=a.data.context;c.element.find("."+c.options.targets.nextYearButton).hasClass("inactive")||(c.month.add(1,"years"),c.render(),c.options.clickEvents.nextYear&&c.options.clickEvents.nextYear.apply(c,[b(c.month)]),c.options.clickEvents.onMonthChange&&c.options.clickEvents.onMonthChange.apply(c,[b(c.month)]),c.options.clickEvents.onYearChange&&c.options.clickEvents.onYearChange.apply(c,[b(c.month)]))},c.prototype.previousYearAction=function(a){var c=a.data.context;c.element.find("."+c.options.targets.previousYear).hasClass("inactive")||(c.month.subtract(1,"years"),c.render(),c.options.clickEvents.previousYear&&c.options.clickEvents.previousYear.apply(c,[b(c.month)]),c.options.clickEvents.onMonthChange&&c.options.clickEvents.onMonthChange.apply(c,[b(c.month)]),c.options.clickEvents.onYearChange&&c.options.clickEvents.onYearChange.apply(c,[b(c.month)]))},c.prototype.forward=function(a){return this.month.add(1,"months"),this.render(),a&&a.withCallbacks&&(this.options.clickEvents.onMonthChange&&this.options.clickEvents.onMonthChange.apply(this,[b(this.month)]),0===this.month.month()&&this.options.clickEvents.onYearChange&&this.options.clickEvents.onYearChange.apply(this,[b(this.month)])),this},c.prototype.back=function(a){return this.month.subtract(1,"months"),this.render(),a&&a.withCallbacks&&(this.options.clickEvents.onMonthChange&&this.options.clickEvents.onMonthChange.apply(this,[b(this.month)]),11===this.month.month()&&this.options.clickEvents.onYearChange&&this.options.clickEvents.onYearChange.apply(this,[b(this.month)])),this},c.prototype.next=function(a){return this.forward(a),this},c.prototype.previous=function(a){return this.back(a),this},c.prototype.setMonth=function(a,c){return this.month.month(a),this.render(),c&&c.withCallbacks&&this.options.clickEvents.onMonthChange&&this.options.clickEvents.onMonthChange.apply(this,[b(this.month)]),this},c.prototype.nextYear=function(a){return this.month.add(1,"year"),this.render(),a&&a.withCallbacks&&this.options.clickEvents.onYearChange&&this.options.clickEvents.onYearChange.apply(this,[b(this.month)]),this},c.prototype.previousYear=function(a){return this.month.subtract(1,"year"),this.render(),a&&a.withCallbacks&&this.options.clickEvents.onYearChange&&this.options.clickEvents.onYearChange.apply(this,[b(this.month)]),this},c.prototype.setYear=function(a,c){return this.month.year(a),this.render(),c&&c.withCallbacks&&this.options.clickEvents.onYearChange&&this.options.clickEvents.onYearChange.apply(this,[b(this.month)]),this},c.prototype.setEvents=function(a){return this.options.events=this.options.multiDayEvents?this.addMultiDayMomentObjectsToEvents(a):this.addMomentObjectToEvents(a),this.render(),this},c.prototype.addEvents=function(b){return this.options.events=this.options.multiDayEvents?a.merge(this.options.events,this.addMultiDayMomentObjectsToEvents(b)):a.merge(this.options.events,this.addMomentObjectToEvents(b)),this.render(),this},c.prototype.removeEvents=function(a){for(var b=this.options.events.length-1;b>=0;b--)1==a(this.options.events[b])&&this.options.events.splice(b,1);return this.render(),this},c.prototype.addMomentObjectToEvents=function(a){var c=this,d=0,e=a.length;for(d;e>d;d++)a[d]._clndrDateObject=b(a[d][c.options.dateParameter]);return a},c.prototype.addMultiDayMomentObjectsToEvents=function(a){var c=this,d=0,e=a.length;for(d;e>d;d++)a[d][c.options.multiDayEvents.endDate]||a[d][c.options.multiDayEvents.startDate]?(a[d]._clndrEndDateObject=b(a[d][c.options.multiDayEvents.endDate]||a[d][c.options.multiDayEvents.startDate]),a[d]._clndrStartDateObject=b(a[d][c.options.multiDayEvents.startDate]||a[d][c.options.multiDayEvents.endDate])):(a[d]._clndrEndDateObject=b(a[d][c.options.multiDayEvents.singleDay]),a[d]._clndrStartDateObject=b(a[d][c.options.multiDayEvents.singleDay]));return a},c.prototype.calendarDay=function(b){var c={day:"",classes:this.options.targets.empty,events:[],date:null};return a.extend({},c,b)},a.fn.clndr=function(a){if(1===this.length){if(!this.data("plugin_clndr")){var b=new c(this,a);return this.data("plugin_clndr",b),b}}else if(this.length>1)throw new Error("CLNDR does not support multiple elements yet. Make sure your clndr selector returns only one element.")}});/*!
  * Symphony 2.6.x, http://getsymphony.com, MIT license
  */
-var Symphony=function(a,b){function c(b,c){return"string"===a.type(b)&&"object"===a.type(c)&&a.each(c,function(a,c){b=b.replace("{$"+a+"}",c)}),b}function d(b){var c=Symphony.Context.get("env");if(c){var d=a.trim(c["page-namespace"]),f={strings:b};"string"===a.type(d)&&""!==d&&(f.namespace=d),a.ajax({async:!1,type:"GET",url:Symphony.Context.get("symphony")+"/ajax/translate/",data:f,dataType:"json",success:function(b){a.extend(!0,e.Dictionary,b)},error:function(c,d,f){a.extend(!0,e.Dictionary,b)}})}}var e={Context:{},Dictionary:{},Support:{}},f=window.requestAnimationFrame||window.mozRequestAnimationFrame||window.webkitRequestAnimationFrame||window.msRequestAnimationFrame||window.oRequestAnimationFrame||function(a){return window.setTimeout(a,.016)},g=window.cancelAnimationFrame||window.webkitCancelRequestAnimationFrame||window.mozCancelRequestAnimationFrame||window.oCancelRequestAnimationFrame||window.msCancelRequestAnimationFrame||function(a){window.clearTimeout(a)};try{e.Support.localStorage=!!localStorage.getItem}catch(h){e.Support.localStorage=!1}return a.extend(!0,e.Support,a.support),{View:{add:function(a,c,d,e){var f;return a=Symphony.Context.get("path")+a,f=b.addRoute(a,c,d),e!==!1&&(f.greedy=!0),f},render:function(a,c){a||(a=Symphony.Context.get("path")+Symphony.Context.get("route")),c===!1&&(b.greedyEnabled=!1),b.parse(a)}},Elements:{window:null,html:null,body:null,wrapper:null,header:null,nav:null,session:null,context:null,contents:null},Context:{add:function(b,c){return b||"object"!==a.type(c)?e.Context[b]&&"string"!==a.type(c)?a.extend(e.Context[b],c):e.Context[b]=c:a.extend(e.Context,c),!0},get:function(a){return a?void 0===typeof e.Context[a]?!1:e.Context[a]:e.Context}},Language:{add:function(b){"en"===Symphony.Context.get("lang")?a.extend(!0,e.Dictionary,b):(a.each(b,function(a,c){c in e.Dictionary&&delete b[c]}),a.isEmptyObject(b)||d(b))},get:function(b,d){var f=e.Dictionary[b];return"string"===a.type(f)&&(b=f),b=c(b,d)}},Support:e.Support,Interface:{},Extensions:{},Utilities:{inSight:function(b){var c=window.innerHeight,d=a();return b.each(function(){var a=this.getBoundingClientRect();if(a.top>=0&&a.top<=c||a.bottom>=0&&a.bottom<=c||a.top<=0&&a.bottom>=c)d=d.add(this);else if(d.length>0)return!1}),d},getXSRF:function(a){var b=Symphony.Elements.contents.find("input[name=xsrf]").val();return a===!0?"xsrf="+encodeURIComponent(b):b},requestAnimationFrame:function(a){return f.call(window,a)},cancelAnimationFrame:function(a){return g.call(window,a)}}}}(window.jQuery,window.crossroads);!function(a,b){"use strict";var c=a(),d=0;a.fn.symphonyAffix=function(b){var d=a(this),e={container:null,top:0,freespace:0,bottom:0,height:0,maxtop:0};return a.extend(e,b),d.each(function(){var b=a.extend({},e),d=a(this),f=function(){b.top=b.container.offset().top,b.freespace=b.container.height(),b.bottom=b.top+b.freespace,b.height=d.height(),b.maxtop=b.freespace-b.height+"px"};b.container?b.container=a(b.container):b.container=d.parent(),f(),d.on("updatesettings.affix",f),d.addClass("js-affix"),d.data("affix-settings",b),c=c.add(d)}),a(window).triggerHandler("scroll"),d},a(window).scroll(function(e){d=a(this).scrollTop(),b.Utilities.requestAnimationFrame(function(){c.each(function(){var b=a(this),c=b.data("affix-settings"),e="js-affix-scroll",f="";d<c.top?e="js-affix-top":d>c.bottom&&(e="js-affix-bottom",f=c.maxtop),b.hasClass(e)||b.removeClass("js-affix-scroll js-affix-top js-affix-bottom").addClass(e).css({top:f})})})})}(window.jQuery,window.Symphony),function(a,b){var c=function(a,b){try{window.localStorage[a]=b}catch(c){window.onerror(c.message)}};a.fn.symphonyCollapsible=function(d){var e=this,f={items:".instance",handles:".frame-header",content:".content",ignore:".ignore",save_state:!0,storage:"symphony.collapsible."+b.Context.get("context-id"),delay:250};return a.extend(f,d),e.each(function(d){var e=a(this),g=f.storage+"."+d+".collapsed",h=function(b){return a.isNumeric(b)?b:f.delay},i=function(a,b){var c=0;a.trigger("collapsebefore.collapsible",f),c=a.data("heightMin"),0!==b&&(a.addClass("js-animate"),a.trigger("collapsestart.collapsible")),a.addClass("collapsed"),a.css("max-height",c),0!==b&&setTimeout(function(){a.trigger("animationend.collapsible"),a.trigger("animationend.duplicator")},b)};e.on("collapse.collapsible",f.items,function(b,c){var d=a(this);i(d,h(c))}),e.on("collapseall.collapsible",function(c){for(var d=e.find(f.items+":not(.collapsed)"),g=b.Utilities.inSight(d),h=a(),j=a(window).scrollTop(),k=g.eq(0).index(),l=0;k<d.length&&l<window.innerHeight;){var m=d.eq(k);g=g.add(m),l+=m.data("heightMin"),k++}g.each(function(){i(a(this),f.delay)}),setTimeout(function(){var b=g.eq(0),c=b.offset().top;h=d.not(g),h.each(function(){i(a(this),0)}),c>0&&j>e.offset().top&&a(window).scrollTop(j+(b.offset().top-c)),h.trigger("animationend.collapsible")},f.delay+100)});var j=function(a,b){var c=0;a.trigger("expandbefore.collapsible",f),c=a.data("heightMax"),0!==b&&(a.addClass("js-animate"),a.trigger("expandstart.collapsible")),a.removeClass("collapsed"),a.css("max-height",c),0!==b&&setTimeout(function(){a.trigger("animationend.collapsible")},b)};e.on("expand.collapsible",f.items,function(b,c){var d=a(this);j(d,h(c))}),e.on("expandall.collapsible",function(c){var d=e.find(f.items+".collapsed"),g=b.Utilities.inSight(d).filter("*:lt(4)"),h=d.not(g),i=a(window).scrollTop();g.addClass("js-animate-all"),g.each(function(){j(a(this),f.delay)}),setTimeout(function(){var b=g.eq(0),c=b.offset().top;h.addClass("js-animate-all"),h.each(function(){j(a(this),0)}),h.trigger("animationend.collapsible"),c>0&&i>e.offset().top&&a(window).scrollTop(i+(b.offset().top-c))},f.delay+100)}),e.on("animationend.collapsible",f.items,function(b){var c=a(this);c.trigger(c.is(".collapsed")?"collapsestop.collapsible":"expandstop.collapsible"),c.removeClass("js-animate js-animate-all")}),e.on("click.collapsible",f.handles,function(b){var c=a(this),d=c.closest(f.items);c.is(f.ignore)||a(b.target).is(f.ignore)||d.is(".locked")||(d.is(".collapsed")?j(d,f.delay):i(d,f.delay))});var k=0;e.on("collapsestop.collapsible expandstop.collapsible store.collapsible",f.items,function(d){f.save_state===!0&&b.Support.localStorage===!0&&(clearTimeout(k),k=setTimeout(function(){var b=e.find(f.items).map(function(b){return a(this).is(".collapsed")?b:void 0}).get().join(",");c(g,b)},f.delay))}),e.on("restore.collapsible",function(c){f.save_state===!0&&b.Support.localStorage===!0&&window.localStorage[g]&&a.each(window.localStorage[g].split(","),function(a,b){var c=e.find(f.items).eq(b);0==c.has(".invalid").length&&i(c,0)})}),e.on("orderstop.orderable",function(a){e.find(f.items).trigger("store.collapsible")}),e.on("destructstop.duplicator",f.items,function(){a(this).trigger("store.collapsible")}),e.on("updatesize.collapsible",f.items,function(){var b=a(this),c=b.find(f.handles).outerHeight(!0),d=c+b.find(f.content).outerHeight(!0);b.data("heightMin",c),b.data("heightMax",d)}),e.on("setsize.collapsible",f.items,function(){var b=a(this),c=b.data("heightMin"),d=b.data("heightMax");b.css({"min-height":c,"max-height":d})}),e.addClass("collapsible").find(f.items).each(function(){var b=a(this);b.addClass("instance"),b.trigger("updatesize.collapsible"),b.trigger("setsize.collapsible")}),e.trigger("restore.collapsible")}),e}}(window.jQuery,window.Symphony),function(a,b){a.fn.symphonyOrderable=function(c){var d=this,e={items:"li",handles:"*",ignore:"input, textarea, select, a",delay:250};return a.extend(e,c),d.on("mousedown.orderable",e.items+" "+e.handles,function(b){var c=a(this),d=c.parents(e.items),f=c.parents(".orderable");a(b.target).is("input, textarea")||b.preventDefault(),c.is(e.ignore)||a(b.target).is(e.ignore)||(f.data("ordering",1),f.is(".selectable, .collapsible")?setTimeout(function(){1==f.data("ordering")&&(f.trigger("orderstart.orderable",[d]),d.addClass("ordering"))},e.delay):(f.trigger("orderstart.orderable",[d]),d.addClass("ordering")))}),d.on("mouseup.orderable mouseleave.orderable",function(b){var c,d=a(this);1==d.data("ordering")&&(c=d.find(".ordering"),c.removeClass("ordering"),d.data("ordering",0),d.trigger("orderstop.orderable",[c]),d.trigger("orderstoplock.orderable",[c]),c.addClass("locked"),setTimeout(function(){c.removeClass("locked"),d.trigger("orderstopunlock.orderable",[c])},e.delay))}),a(document).on("mousemove.orderable",".orderable:has(.ordering)",function(c){var d=a(this);if(1==d.data("ordering")){var f=c.pageY;b.Utilities.requestAnimationFrame(function(){var a=d.find(".ordering");if(a.length){var b,c,g=a.offset().top,h=g+a.outerHeight();window.getSelection&&window.getSelection().removeAllRanges(),g>f?(b=a.prev(e.items),b.length>0&&(a.insertBefore(b),d.trigger("orderchange",[a]))):f>h&&(c=a.next(e.items),c.length>0&&(a.insertAfter(c),d.trigger("orderchange",[a])))}})}}),d.addClass("orderable"),d}}(window.jQuery,window.Symphony),function(a,b){a.fn.symphonySelectable=function(b){var c=this,d={items:"tbody tr:has(input)",ignore:"a",mode:"single"};return a.extend(d,b),c.on("click.selectable",d.items,function(b){var c,e,f,g,h=a(this),i=h.siblings().addBack(),j=a(b.liveFired),k=a(b.target);return k.is(d.ignore)?!0:(window.getSelection&&window.getSelection().removeAllRanges(),void(b.shiftKey&&i.filter(".selected").length>0&&!j.is(".single")?(h.prevAll().filter(".selected").length>0?(f=i.filter(".selected:first").index(),g=h.index()+1):(f=h.index(),g=i.filter(".selected:last").index()+1),c=i.slice(f,g),e=i.filter(".selected").not(c).removeClass("selected").trigger("deselect.selectable"),e.find('input[type="checkbox"]:hidden:first').prop("checked",!1),c.addClass("selected").trigger("select.selectable"),c.find('input[type="checkbox"]:hidden:first').prop("checked",!0)):((!b.metaKey&&!b.ctrlKey&&"additive"!=d.mode&&!k.is("input")||j.is(".single"))&&(e=i.not(h).filter(".selected").removeClass("selected").trigger("deselect.selectable"),e.find('input[type="checkbox"]:hidden:first').prop("checked",!1)),h.is(".selected")?(h.removeClass("selected").trigger("deselect.selectable"),h.find('input[type="checkbox"]:hidden:first').prop("checked",!1)):(h.addClass("selected").trigger("select.selectable"),h.find('input[type="checkbox"]:hidden:first').prop("checked",!0)))))}),a("body").bind("dblclick.selectable",function(){c.find(d.items).removeClass("selected").trigger("deselect.selectable")}),c.addClass("selectable"),c}}(window.jQuery,window.Symphony),function(a,b){a.fn.symphonyDuplicator=function(c){var d=this,e={instances:"> li:not(.template)",templates:"> li.template",headers:"> :first-child",preselect:!1,orderable:!1,collapsible:!1,constructable:!0,destructable:!0,save_state:!0,minimum:0,maximum:1e3,delay:250};return a.extend(e,c),b.Language.add({"Add item":!1,"Remove item":!1}),d.each(function(){var c,d,f,g,h=a(this),i=h.find("> ol"),j=a('<fieldset class="apply" />'),k=a("<select />"),l=a('<button type="button" class="constructor" />');h.addClass("duplicator").addClass("empty"),c=i.find(e.instances).addClass("instance"),d=i.find(e.templates).addClass("template"),f=c.add(d),g=f.find(e.headers).addClass("frame-header"),l.text(i.attr("data-add")||b.Language.get("Add item")),j.on("click.duplicator",".constructor:not(.disabled)",function(b,c){var f=d.filter('[data-type="'+a(this).parent().find("select").val()+'"]').clone(!0);b.preventDefault(),f.trigger("constructstart.duplicator").appendTo(i),h.removeClass("empty"),f.trigger("constructshow.duplicator"),f.trigger("updatesize.collapsible"),f.trigger("setsize.collapsible"),setTimeout(function(){f.trigger("animationend.duplicator")},e.delay)}),h.on("click.duplicator",".destructor:not(.disabled)",function(b){var c=a(this).closest(".instance");c.trigger("collapse.collapsible").trigger("destructstart.duplicator").addClass("destructed"),setTimeout(function(){c.trigger("animationend.duplicator")},e.delay)}),h.on("animationend.duplicator",".instance",function(){var b=a(this).removeClass("js-animate");b.is(".destructed")?(b.remove(),0==h.find(".instance").length&&h.addClass("empty"),b.trigger("destructstop.duplicator"),h.trigger("destructstop.duplicator",[b])):b.trigger("constructstop.duplicator"),e.collapsible&&b.trigger("store.collapsible")}),h.on("constructstop.duplicator",".instance",function(){h.find(".instance").length>=e.maximum&&l.addClass("disabled")}),h.on("destructstart.duplicator",".instance",function(){h.find(".instance").length<=e.maximum&&l.removeClass("disabled")}),h.on("destructstart.duplicator",".instance",function(){h.find(".instance").length-1==e.minimum&&h.find("a.destructor").addClass("disabled")}),h.on("constructstop.duplicator",".instance",function(){h.find(".instance").length>e.minimum&&h.find("a.destructor").removeClass("disabled")}),h.on("constructstop.duplicator",".instance",function(b){var c=a(this);c.is(".unique")&&(k.find('option[value="'+c.attr("data-type")+'"]').attr("disabled",!0),k.find("option").prop("selected",!1).filter(":not(:disabled):first").prop("selected",!0),0==k.find("option:not(:disabled)").length&&k.attr("disabled","disabled"))}),h.on("destructstart.duplicator",".instance",function(b){var c,d=a(this);d.is(".unique")&&(c=k.attr("disabled",!1).find('option[value="'+d.attr("data-type")+'"]').attr("disabled",!1),1==k.find("option:not(:disabled)").length&&c.prop("selected",!0))}),h.on("constructstop.duplicator refresh.duplicator",".instance",function(b){var c=a(this),d=h.find(".instance").index(c);c.find("*[name]").each(function(){var b=a(this),c=/\[\-?[0-9]+\]/,e=b.attr("name");c.test(e)&&b.attr("name",e.replace(c,"["+d+"]"))})}),h.on("orderstop.orderable",function(a){h.find(".instance").trigger("refresh.duplicator")}),g.each(function(){var b=a(this);b.next(".content").length||b.nextAll().wrapAll(a("<div />").attr("class","content"))}),e.constructable===!0&&(h.addClass("constructable"),j.append(a("<div />").append(k)).append(l),j.appendTo(h),d.detach().each(function(){var b=a(this),c=a.trim(b.find(e.headers).attr("data-name"))||a.trim(b.find(e.headers).text()),d=a.trim(b.attr("data-type"));b.trigger("constructstart.duplicator"),d||(d=c,b.attr("data-type",d)),a("<option />",{text:c,value:d}).appendTo(k),b.trigger("constructstop.duplicator")}).removeClass("template").addClass("instance")),0!=e.preselect&&k.find('option[value="'+e.preselect+'"]').prop("selected",!0),d.length<=1&&(j.addClass("single"),d.is(".unique")&&(0==c.length&&l.trigger("click.duplicator",[0]),j.hide())),e.destructable===!0&&(h.addClass("destructable"),g.append(a("<a />").attr("class","destructor").text(i.attr("data-remove")||b.Language.get("Remove item")))),e.collapsible&&h.symphonyCollapsible({items:".instance",handles:".frame-header",ignore:".destructor",save_state:e.save_state,delay:e.delay}),e.orderable&&h.symphonyOrderable({items:".instance",handles:".frame-header"}),c.filter(":has(.invalid)").addClass("conflict"),c.trigger("constructstop.duplicator"),c.find('input[name*="[label]"]').trigger("keyup.duplicator"),c.length>0&&h.removeClass("empty")}),d}}(window.jQuery,window.Symphony),function(a,b){a.fn.symphonyTags=function(b){var c=this,d={items:"li"};return a.extend(d,b),c.on("click.tags",d.items,function(b){var c=a(this),d=c.parent(),e=d.prev().find("input, textarea"),f=e.val(),g=c.attr("class")||c.data("value")||c.text();if(d.is(".singular"))e.val(g);else if(d.is(".inline")){var h=e[0].selectionStart,i=e[0].selectionEnd,j=0;h>0?(e.val(f.substring(0,h)+g+f.substring(i,f.length)),j=h+g.length):(e.val(f+g),j=f.length+g.length),e[0].selectionStart=j,e[0].selectionEnd=j}else{var k=(new RegExp("^"+g.replace(/[-[\]{}()*+?.,\\^$|#\s]/g,"\\$&")+"$","i"),f.split(/,\s*/)),l=!1;for(var m in k)k[m]==g?(k.splice(m,1),l=!0):""==k[m]&&k.splice(m,1);l===!1&&k.push(g),e.val(k.join(", "))}e.trigger("change",{tag:c})}),c}}(window.jQuery,window.Symphony),function(a,b){a.fn.symphonyPickable=function(b){var c=a(this),d={content:"#contents",pickables:".pickable"};a.extend(d,b),c.on("change.pickable",function(b){var c,f,g=a(this),h=g.val(),i=g.attr("id")||g.attr("name"),j=a(d.pickables+'[data-relation="'+i+'"]');a.isNumeric(h)===!0&&(h="choice"+h),g.trigger("pickstart.pickable"),j.hide(),c=a("#"+h),c.length>0?(c.show().trigger("pick.pickable"),g.trigger("pickstop.pickable")):(f=g.data("request"),f&&a.ajax({type:"GET",url:f,data:{choice:h},dataType:"html",success:function(a){e.append(a),a.trigger("pick.pickable"),g.trigger("pickstop.pickable")}}))});var e=a(d.content);return c.each(function(){var b=a(this),c=b.attr("id")||b.attr("name");b.find("option").each(function(){a("#"+a(this).val()).attr("data-relation",c)})}),c.trigger("change.pickable"),c}}(window.jQuery,window.Symphony),function(a,b){a.fn.symphonyTimeAgo=function(c){function d(b){var c,d=b.data("timestamp");return a.isNumeric(d)?d:(c=b.attr(g.timestamp),d=c?new Date(1e3*c):(new Date).getTime(),b.data("timestamp",d),d)}function e(a,c){var d=c-a,e=Math.floor(d/6e4);return 1>e?b.Language.get("just now"):2>e?b.Language.get("a minute ago"):45>e?b.Language.get("{$minutes} minutes ago",{minutes:e}):90>e?b.Language.get("about 1 hour ago"):!g.max||e<g.max?b.Language.get("about {$hours} hours ago",{hours:Math.floor(e/60)}):void 0}var f=this,g={items:"time",timestamp:"utc",max:0};return a.extend(g,c),b.Language.add({"just now":!1,"a minute ago":!1,"{$minutes} minutes ago":!1,"about 1 hour ago":!1,"about {$hours} hours ago":!1}),f.find(g.items).each(function(){var b=a(this),c=d(b),f=new Date,g=e(c,f);g&&b.text(g)}),f}}(window.jQuery,window.Symphony),function(a,b){"use strict";a.fn.symphonyNotify=function(c){var d=this,e={items:"p.notice",storage:"symphony.notify."+b.Context.get("root").replace("http://","")};return a.extend(e,c),b.Language.add({"Ignore?":!1,next:!1,at:!1}),d.on("attach.notify",function(c,d,f){var g,h,i=a(this),j=i.find("div.notifier"),k=j.find(e.items);j.trigger("attachstart.notify"),g=a("<p />",{"class":f}).html(d.replace(b.Language.get("at")+" ","")).addClass("notice active").symphonyTimeAgo(),g.is(".error")||g.is(".success")||g.is(".protected")||g.html(g.html()+' <a class="ignore">'+b.Language.get("Ignore?")+"</a>"),a("<nav />",{text:b.Language.get("next")}).hide().appendTo(g),b.Support.localStorage===!0&&(h=window.localStorage[e.storage]?a.parseJSON(window.localStorage[e.storage]):[]),f&&~f.indexOf("success")&&setTimeout(function(){g.addClass("dimmed")},1e4),-1==a.inArray(g.text(),h)?(k.removeClass("active"),g.addClass("active").prependTo(j),j.scrollTop(0),j.trigger("attachstop.notify",[g])):j.trigger("attachcancel.notify",[g])}),d.on("detach.notify",e.items,function(b){var c=a(this),d=c.parents("div.notifier");d.trigger("detachstart.notify",[c]),d.one("movestop.notify",function(b){var d=a(this),e=d.scrollTop();e>0&&d.scrollTop(e-c.outerHeight()),c.remove(),d.trigger("detachstop.notify",[c])}),c.animate({opacity:0},"normal",function(){0==c.siblings().length?d.trigger("resize.notify",[a("<div />")]):d.trigger("move.notify"),c.remove(),d.trigger("detachstop.notify",[c])})}),d.on("resize.notify attachstop.notify","div.notifier",function(b,c){var d=a(this);if(!d.hasClass("constructing")){var e=c||d.find(".active:not(:animated)");d.show().animate({height:e.innerHeight()||0},100)}}),d.on("attachstop.notify detachstop.notify","div.notifier",function(b){var c=a(this),d=c.find(e.items);1==d.length?d.find("nav").hide():d.find("nav").show()}),d.on("click","nav",function(b){var c=(a(this),a(this).closest("div.notifier"));c.trigger("move.notify")}),d.on("move.notify","div.notifier",function(b){var c,d=a(this),f=d.find(".active"),g=f.next(e.items),h=f.outerHeight();d.trigger("movestart.notify"),f.removeClass("active"),g.length>0?(g.addClass("active"),c=d.scrollTop()+h):(g=d.find(e.items).first().addClass("active"),c=0),g.outerHeight()!==h&&d.trigger("resize.notify"),d.animate({scrollTop:c},"fast",function(){d.trigger("movestop.notify")})}),d.on("click","a.ignore",function(c){var d,f=a(this),g=f.parents(e.items),h=(g.parents("div.notifier"),g.text());if(b.Support.localStorage===!0)try{d=window.localStorage[e.storage]?a.parseJSON(window.localStorage[e.storage]):[],d.push(h),window.localStorage[e.storage]=JSON.stringify(d)}catch(i){window.onerror(i.message)}g.trigger("detach.notify")}),d.each(function(){var b=a(this),c=a('<div class="notifier" />').hide().prependTo(b),d=a(b.find(e.items).get().reverse());c.addClass("constructing"),c.height(d.last().innerHeight()),d.each(function(){var c=a(this).remove(),d=c.html(),e=c.attr("class");b.trigger("attach.notify",[d,e])}),c.find(e.items).length>0&&c.removeClass("constructing").trigger("resize.notify"),c.removeClass("constructing"),setInterval(function(){a("header p.notice").symphonyTimeAgo()},6e4)}),d}}(window.jQuery,window.Symphony),function(a,b){a.fn.symphonyDrawer=function(c){var d=this,e=a("#wrapper"),f=a("#contents"),g=f.find("> form"),h={verticalWidth:300,speed:"fast"};a.extend(h,c),d.on("expand.drawer",function(c,d,f){var j=a(this),k=j.data("position"),l=a(".button.drawer"),m=l.filter('[href="#'+j.attr("id")+'"]'),n=l.filter("."+k),o=j.data("context")?"."+j.data("context"):"",p=i();if(j.trigger("expandstart.drawer"),d="undefined"==typeof d?h.speed:d,f="undefined"==typeof f?!1:!0,n.removeClass("selected"),a(".drawer."+k).filter(function(b){return a(this).data("open")}).trigger("collapse.drawer",[d,!0]),"vertical-left"===k?j.css({width:0,height:p,display:"block"}).animate({width:h.verticalWidth},{duration:d,step:function(a,b){g.css("margin-left",a+1)},complete:function(){g.css("margin-left",h.verticalWidth+1),j.trigger("expandstop.drawer")}}):"vertical-right"===k?j.css({width:0,height:p,display:"block"}).animate({width:h.verticalWidth},{duration:d,step:function(a,b){g.css("margin-right",a+1)},complete:function(){g.css("margin-right",h.verticalWidth+1),j.trigger("expandstop.drawer")}}):"horizontal"===k&&j.animate({height:"show"},{duration:d,complete:function(){j.trigger("expandstop.drawer")}}),m.addClass("selected"),b.Support.localStorage===!0)try{window.localStorage["symphony.drawer."+j.attr("id")+o]="opened"}catch(q){window.onerror(q.message)}e.addClass("drawer-"+k),j.data("open",!0)}),d.on("collapse.drawer",function(c,d,f){var i=a(this),j=i.data("position"),k=a(".button.drawer"),l=k.filter('[href="#'+i.attr("id")+'"]'),m=i.data("context")?"."+i.data("context"):"";if(i.trigger("collapsestart.drawer"),d="undefined"==typeof d?h.speed:d,f="undefined"==typeof f?!1:!0,l.removeClass("selected"),"vertical-left"===j?i.animate({width:0},{duration:d,step:function(a,b){f||g.css("margin-left",a)},complete:function(){i.css({display:"none"}).trigger("collapsestop.drawer")}}):"vertical-right"===j?i.animate({width:0},{duration:d,step:function(a,b){f||g.css("margin-right",a)},complete:function(){i.css({display:"none"}).trigger("collapsestop.drawer")}}):"horizontal"===j&&i.animate({height:"hide"},{duration:d,complete:function(){i.trigger("collapsestop.drawer")}}),b.Support.localStorage===!0)try{window.localStorage["symphony.drawer."+i.attr("id")+m]="closed"}catch(n){window.onerror(n.message)}e.removeClass("drawer-"+j),i.data("open",!1)}),a(window).on("resize.drawer load.drawer",function(){var a=i();d.filter(".vertical-left, .vertical-right").css("height",a)});var i=function(){var a=Math.max(window.innerHeight-f[0].offsetTop-1,f[0].clientHeight);return a};return d.each(function(){var c,d=a(this),e=(d.data("position"),a('.button.drawer[href="#'+d.attr("id")+'"]')),f=d.data("context")?"."+d.data("context"):"";"opened"===d.data("default-state")&&d.data("open",!0),b.Support.localStorage===!0&&(c=window.localStorage["symphony.drawer."+d.attr("id")+f],"opened"===c?d.data("open",!0):"closed"===c&&d.data("open",!1)),e.on("click.drawer",function(a){a.preventDefault(),d.trigger(d.data("open")?"collapse.drawer":"expand.drawer")}),d.data("open")?d.trigger("expand.drawer",[0]):d.trigger("collapse.drawer",[0,!0])}),d}}(window.jQuery,window.Symphony),function(a,b,c){"use strict";b.Interface.Calendar=function(){var d,e,f,g,h,i,j='<div class="calendar"><nav><a class="clndr-previous-button">previous</a><div class="switch"><ul class="months"><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li></ul><ul class="years"><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li></ul></div><a class="clndr-next-button">next</a></nav><table><thead><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr></thead><tbody><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr></tbody></table></div>',k=function(h){return d=a(h),e=d.find(".calendar"),f=d.find("input"),g=e.attr("data-format"),void 0===g?void z(e):(c.locale(b.Elements.html.attr("lang")),x(),y(),q(),e.on("mousedown.calendar","a, .clndr",function(a){a.stopPropagation(),a.preventDefault()}),e.on("mousedown.calendar",".switch",l),e.on("mousedown.calendar",".months li",m),e.on("mousedown.calendar",".years li",n),f.on("focus.calendar",o),void f.on("input.calendar",p))},l=function(c){var d;c.stopPropagation(),c.preventDefault(),d=e.find(".switch"),d.addClass("select"),b.Elements.body.on("click.calendar",function(c){var e=a(c.target);e.parents(".switch").length||(d.removeClass("select"),b.Elements.body.off("click.calendar"))})},m=function(a){a.preventDefault(),i.setMonth(a.target.textContent)},n=function(a){a.preventDefault(),i.setYear(a.target.textContent)},o=function(){i.setMonth(h.get("month")),i.setYear(h.get("year"))},p=function(){x(),o()},q=function(){i=e.clndr({startWithMonth:h,showAdjacentMonths:!0,adjacentDaysChangeMonth:!0,forceSixRows:!0,render:r,clickEvents:{click:w}})},r=function(a){var b=j.clone(),d=c().month(a.month).get("month");return b=s(b,a),b=t(b,a,d),b=u(b,a),b=v(b,a),b.html()},s=function(a,b){return a.find("thead td").each(function(a){this.textContent=b.daysOfTheWeek[a]}),a},t=function(a,b,d){return a.find(".months li").each(function(a){this.textContent=c().month(d-6+a).format("MMMM")}),a},u=function(a,b){return a.find(".years li").each(function(a){this.textContent=b.year-6+a}),a},v=function(a,b){return a.find("tbody td span").each(function(a){var c=b.days[a];this.textContent=c.day,this.setAttribute("class",c.classes),c.date.isSame(h,"day")&&this.classList.add("active")}),a},w=function(a){var b=a.date;h.set("year",b.year()),h.set("month",b.month()),h.set("date",b.date()),f.val(h.format(g)),e.find(".active").removeClass("active"),a.element.classList.add("active")},x=function(){var a=f.val();h=a?c(a,g):c({hour:0,minute:0,seconds:0})},y=function(){j=a(j)},z=function(d){var e=b.Language.get("The Symphony calendar widget has been disabled because your system date format is currently not supported. Try one of the following instead or disable the calendar in the field settings:"),f=b.Context.get("datetime"),g=[];d.addClass("hidden"),a.each(f.formats,function(a,d){var e="";-1!==a.indexOf("j")&&-1!==a.indexOf("n")&&(e=" – "+b.Language.get("no leading zero")),g.push(" - "+a+" ("+c().format(d)+e+")")}),console.info(e+"\n\n"+g.join("\n"))};return{init:k}}}(window.jQuery,window.Symphony,window.moment),function(a,b){"use strict";b.Interface.Filtering=function(){var c,d,e,f=[],g=function(){c=b.Elements.context.find(".filtering"),d=c.find(".filters-duplicator"),e=d.find(".apply"),r(),s(),o(),d.on("constructstop.duplicator destructstart.duplicator",".instance",o),c.on("keyup.filtering",".filter",h),c.on("change.filtering",".filter",h),d.on("destructstop.duplicator",k),d.on("constructstop.duplicator",".instance",j),c.on("change",".comparison",j),c.find(".instance").each(j),b.Interface.Suggestions.init(c,".filter")},h=function(b){var c=a(b.target);(13===b.keyCode||c.is(".apply-filters")||c.is(".updated"))&&(b.preventDefault(),b.stopPropagation(),k())},i=function(a){a.preventDefault(),a.stopPropagation(),m()},j=function(){var b,c=a(this);c.is(".instance")?b=c.find(".comparison").val():(b=c.val(),c=c.parents(".instance")),n(c,b)},k=function(){var a,c,d=l();a=b.Context.get("symphony")+b.Context.get("route"),c=a+(""!==d?"?":"")+d,window.location=c},l=function(){var b=[];return c.find(".instance:not(.template):visible").each(function(){var c,d=a(this),e=a.trim(d.find(".comparison").val()),f=d.find(".filter");e&&(e+=" "),c="filter["+f.attr("name")+"]="+e+a.trim(f.val()),b.push(c)}),b.join("&")},m=function(){window.location=b.Context.get("symphony")+b.Context.get("route")},n=function(a,b){var c=a.find(".suggestions .help");b||(b="is"),c.removeClass("active"),c.filter('[data-comparison="'+b+'"]').addClass("active")},o=function(){d.find(".instance:not(.template)").length?p():q()},p=function(){f.apply.prop("disabled",!1),f.apply.removeAttr("disabled"),f.clear.show()},q=function(){f.apply.prop("disabled",!0),f.clear.hide()},r=function(){f.apply=a("<button/>",{text:b.Language.get("Apply filters"),"class":"apply-filters",click:h}).insertBefore(e)},s=function(){f.clear=a("<button/>",{text:b.Language.get("Clear filters"),"class":"clear-filters delete",click:i}).insertBefore(e)};return{init:g}}()}(window.jQuery,window.Symphony),function(a,b){"use strict";b.Interface.Suggestions=function(){var c,d=function(b,d){c=a(b),c.find(d).each(function(){this.autocomplete="off"}),t(d),c.on("input.suggestions",d,e),c.on("click.suggestions",d,e),c.on("focus.suggestions",d,e),c.on("keyup.suggestions",d,e),c.on("mouseover.suggestions",".suggestions li:not(.help):not(.calendar)",f),c.on("mouseout.suggestions",".suggestions li:not(.help):not(.calendar)",g),c.on("mousedown.suggestions",".suggestions li:not(.help):not(.calendar)",i),c.on("keydown.suggestions",d,h)},e=function(b){var c=a(this),d=c.val(),e=c.next(".suggestions"),f=e.attr("data-search-types"),g=c.attr("data-trigger");-1===jQuery.inArray(b.which,[13,27,38,40])&&(f&&-1!==f.indexOf("date")?n(c):d&&g?j(c,e,d,g):d||f&&-1!==f.indexOf("static")?k(c,d):q(e))},f=function(b){var c=a(b.target);c.siblings("li:not(.help)").removeClass("active"),c.addClass("active")},g=function(b){var c=a(b.target);c.removeClass("active")},h=function(b){var c,d=a(this);40==b.which?(b.preventDefault(),s(d)):38==b.which?(b.preventDefault(),r(d)):27==b.which?(b.preventDefault(),d.blur()):13==b.which&&(b.preventDefault(),c=d.next(".suggestions").find("li:not(.help).active").text(),c&&o(c,d))},i=function(b){var c=a(b.target).parent(".suggestions").prev("input");o(b.target.textContent,c)},j=function(a,b,c,d){var e=a[0].selectionStart||0,f=c.substring(0,e).split(" "),g=c.substr(e).split(" "),h=f[f.length-1],i=f[f.length-1]+g[0];h&&0===h.indexOf(d)?k(a,i):q(b)},k=function(c,d){var e,f,g,h=c.next(".suggestions"),i=h.attr("data-search-types"),j=c.attr("data-trigger"),k=d;j&&(e=j.substr(0,1)),k||(k=c.val()),"{"===e&&(k=k.substr(1)),i&&-1!==i.indexOf("parameters")?(g=b.Context.get("symphony")+"/ajax/parameters/",f={query:k}):(g=b.Context.get("symphony")+"/ajax/query/",f={field_id:h.attr("data-field-id"),query:k,types:i}),c.attr("data-url")&&(g=c.attr("data-url")),k!==h.attr("data-last-query")&&(h.attr("data-last-query",k),a.ajax({type:"GET",url:g,data:f,success:function(a){i&&-1!==i.indexOf("parameters")?l(c,h,a):m(h,a)}}))},l=function(b,c,d){var e,f=c.clone(),g=f.find(".help:first"),h=b.attr("data-trigger");
+/**
+ * @package assets
+ */
+/**
+ * The Symphony object provides language, message and context management.
+ *
+ * @class
+ */
+var Symphony=function(a,b){/*-------------------------------------------------------------------------
+	Functions
+-------------------------------------------------------------------------*/
+// Replace variables in string
+function c(b,c){return"string"===a.type(b)&&"object"===a.type(c)&&a.each(c,function(a,c){b=b.replace("{$"+a+"}",c)}),b}
+// Get localised strings
+function d(b){var c=Symphony.Context.get("env");if(c){var d=a.trim(c["page-namespace"]),f={strings:b};
+// Validate and set namespace
+"string"===a.type(d)&&""!==d&&(f.namespace=d),
+// Request translations
+a.ajax({async:!1,type:"GET",url:Symphony.Context.get("symphony")+"/ajax/translate/",data:f,dataType:"json",
+// Add localised strings
+success:function(b){a.extend(!0,e.Dictionary,b)},
+// Use English strings on error
+error:function(c,d,f){a.extend(!0,e.Dictionary,b)}})}}
+// Internal Symphony storage
+var e={Context:{},Dictionary:{},Support:{}},f=window.requestAnimationFrame||window.mozRequestAnimationFrame||window.webkitRequestAnimationFrame||window.msRequestAnimationFrame||window.oRequestAnimationFrame||function(a){return window.setTimeout(a,.016)},g=window.cancelAnimationFrame||window.webkitCancelRequestAnimationFrame||window.mozCancelRequestAnimationFrame||window.oCancelRequestAnimationFrame||window.msCancelRequestAnimationFrame||function(a){window.clearTimeout(a)};/*-----------------------------------------------------------------------*/
+// Set browser support information
+try{e.Support.localStorage=!!localStorage.getItem}catch(h){e.Support.localStorage=!1}/*-------------------------------------------------------------------------
+	Symphony API
+-------------------------------------------------------------------------*/
+// Deep copy jQuery.support
+return a.extend(!0,e.Support,a.support),{/**
+		 * Symphony backend view using Crossroads
+		 *
+		 * @since Symphony 2.4
+		 */
+View:{/**
+			 * Add function to view
+			 *
+			 * @param {String} pattern
+			 *  Expression to match the view, using the Symphony URL as base
+			 * @param {Function} handler
+			 *  Function that should be applied to a view
+			 * @param {Integer} priority
+			 *  Priority of the function
+			 * @param {Boolean} greedy
+			 *  If set to `false`, only executes the first matched view, defaults to `true`
+			 * @return {Route}
+			 *  Returns a route object
+			 */
+add:function(a,c,d,e){var f;return a=Symphony.Context.get("path")+a,f=b.addRoute(a,c,d),e!==!1&&(f.greedy=!0),f},/**
+			 * Render given URL, defaults to the current backend URL
+			 *
+			 * @param {String} url
+			 *  The URL of the view that should be rendered, optional
+			 * @param {Boolean} greedy
+			 *  Determines, if only the first or all matching views are rendered,
+			 *  defaults to `true (all)
+			 */
+render:function(a,c){a||(a=Symphony.Context.get("path")+Symphony.Context.get("route")),c===!1&&(b.greedyEnabled=!1),b.parse(a)}},/**
+		 * Storage for the main Symphony elements`.
+		 * Symphony automatically adds all main UI areas.
+		 *
+		 * @since Symphony 2.4
+		 */
+Elements:{window:null,html:null,body:null,wrapper:null,header:null,nav:null,session:null,context:null,contents:null},/**
+		 * The Context object contains general information about the system,
+		 * the backend, the current user. It includes an add and a get function.
+		 * This is a private object and can only be accessed via add and get.
+		 *
+		 * @class
+		 */
+Context:{/**
+			 * Add data to the Context object
+			 *
+			 * @param {String} group
+			 *  Name of the data group
+			 * @param {String|Object} values
+			 *  Object or string to be stored
+			 */
+add:function(b,c){
+// Always return
+// Add multiple groups
+return b||"object"!==a.type(c)?e.Context[b]&&"string"!==a.type(c)?a.extend(e.Context[b],c):e.Context[b]=c:a.extend(e.Context,c),!0},/**
+			 * Get data from the Context object
+			 *
+			 * @param {String} group
+			 *  Name of the group to be returned
+			 */
+get:function(a){
+// Return full context, if no group is set
+// Return full context, if no group is set
+// Return false if group does not exist in Storage
+return a?void 0===typeof e.Context[a]?!1:e.Context[a]:e.Context}},/**
+		 * The Language object stores the dictionary with all needed translations.
+		 * It offers public functions to add strings and get their translation and
+		 * it offers private functions to handle variables and get the translations via
+		 * an synchronous AJAX request.
+		 * Since Symphony 2.3, it is also possible to define different translations
+		 * for the same string, by using page namespaces.
+		 * This is a private object
+		 *
+		 * @class
+		 */
+Language:{/**
+			 * Add strings to the Dictionary
+			 *
+			 * @param {Object} strings
+			 *  Object with English string as key, value should be false
+			 */
+add:function(b){
+// English system
+"en"===Symphony.Context.get("lang")?a.extend(!0,e.Dictionary,b):(
+// Check if strings have already been translated
+a.each(b,function(a,c){c in e.Dictionary&&delete b[c]}),
+// Translate strings
+a.isEmptyObject(b)||d(b))},/**
+			 * Get translated string from the Dictionary.
+			 * The function replaces variables like {$name} with the a specified value if
+			 * an object of inserts is passed in the function call.
+			 *
+			 * @param {String} string
+			 *  English string to be translated
+			 * @param {Object} inserts
+			 *  Object with variable name and value pairs
+			 * @return {String}
+			 *  Returns the translated string
+			 */
+get:function(b,d){var f=e.Dictionary[b];
+// Return translated string
+// Validate and set translation
+// Insert variables
+return"string"===a.type(f)&&(b=f),b=c(b,d)}},/**
+		 * A collection of properties that represent the presence of
+		 * different browser features and also contains the test results
+		 * from jQuery.support.
+		 *
+		 * @class
+		 */
+Support:e.Support,/**
+		 * A namespace for core interface components
+		 *
+		 * @since Symphony 2.6
+		 */
+Interface:{},/**
+		 * A namespace for extension to store global functions
+		 *
+		 * @since Symphony 2.3
+		 */
+Extensions:{},/**
+		 * Helper functions
+		 *
+		 * @since Symphony 2.4
+		 */
+Utilities:{/**
+			 * Get a jQuery object of all elements within the current viewport
+			 *
+			 * @since Symphony 2.4
+			 */
+inSight:function(b){var c=window.innerHeight,d=a();return b.each(function(){var a=this.getBoundingClientRect();if(a.top>=0&&a.top<=c||a.bottom>=0&&a.bottom<=c||a.top<=0&&a.bottom>=c)d=d.add(this);else if(d.length>0)return!1}),d},/**
+			 * Returns the XSRF token for the backend
+			 *
+			 * @since Symphony 2.4
+			 * @param boolean $serialised
+			 *  If passed as true, this function will return the string as a serialised
+			 *  form elements, ie. field=value. If omitted, or false, this function
+			 *  will just return the XSRF token.
+			 */
+getXSRF:function(a){var b=Symphony.Elements.contents.find("input[name=xsrf]").val();return a===!0?"xsrf="+encodeURIComponent(b):b},/**
+			 * Cross browser wrapper around requestFrameAnimation
+			 *
+			 * @since Symphony 2.5
+			 * @param function $func
+			 *  The callback to schedule for frame animation
+			 */
+requestAnimationFrame:function(a){return f.call(window,a)},/**
+			 * Cross browser wrapper around cancelAnimationFrame
+			 *
+			 * @since Symphony 2.5
+			 * @param Integer $t
+			 *  The request id
+			 */
+cancelAnimationFrame:function(a){return g.call(window,a)}}}}(window.jQuery,window.crossroads);/**
+ * @package assets
+ */
+!function(a,b){"use strict";
+// holds up all instances
+var c=a(),d=0;/**
+	 * Create affix elements.
+	 * Affix elements follow the scroll and are constrain by their container.
+	 *
+	 * @since Symphony 2.5
+	 *
+	 * @name $.symphonyAffix
+	 * @class
+	 *
+	 * @param {Object} options An object specifying containing the attributes specified below
+	 * @param {String} [options.container=$(this).parent()] Selector to find affix container
+	 *
+	 * @example
 
-h&&(e=h.substr(0,1)),q(f),a.each(d,function(b,c){if("status"!==b){"{"===e&&(c="{"+c+"}");var d=a("<li />",{text:c});g.length?d.insertBefore(g):f.append(d)}}),c.replaceWith(f)},m=function(b,c){var d=b.clone(),e=d.find(".help:first"),f=[];q(d),c.entries&&(a.each(c.entries,function(a,b){f.push(b.value)}),f=f.filter(function(a,b,c){return c.indexOf(a)===b}),a.each(f,function(b,c){var f=a("<li />",{text:c});e?f.insertBefore(e):d.append(f)}),b.replaceWith(d))},n=function(a){var b=a.next(".suggestions"),c=b.find(".calendar");c.length||u(b)},o=function(a,b){var c=b.attr("data-search-types");c&&-1!==c.indexOf("parameters")?p(a,b):(a=a.replace(/,/g,"\\,").replace(/&/g,"%26"),b.val(a),b.addClass("updated"),b.change()),q(b.next(".suggestions"))},p=function(a,b){var c=b.val(),d=b[0].selectionStart||0,e=c.substring(0,d).split(" "),f=c.substr(d).split(" "),g="",h="";e.length>1&&(e.pop(),g=e.join(" ")+" "),f.length>1&&(f.shift(),h=" "+f.join(" ")),b.val(g+a+h);var i=g.length+a.length;b[0].selectionStart=i,b[0].selectionEnd=i,b.focus()},q=function(a){a.removeAttr("data-last-query"),a.find("li:not(.help)").remove()},r=function(a){var b=a.next(".suggestions"),c=b.find("li:not(.help).active").removeClass("active"),d=c.prev("li:not(.help):visible");0===c.length||0===d.length?b.find("li:not(.help)").last().addClass("active"):d.addClass("active"),v(b)},s=function(a){var b=a.next(".suggestions"),c=b.find("li:not(.help).active").removeClass("active"),d=c.next("li:not(.help):visible");0===c.length||0===d.length?b.find("li:not(.help)").first().addClass("active"):d.addClass("active"),v(b)},t=function(b){var d=c.find(b);d.each(function(){var b,c,d=a(this),e=d.next(".suggestions");e.length||(b=a('<ul class="suggestions" />'),c=d.attr("data-search-types"),c&&b.attr("data-search-types",c),b.insertAfter(d))})},u=function(a){var c=new b.Interface.Calendar;a.prepend('<li class="calendar" data-format="YYYY-MM-DD" />'),c.init(a.parents("label"))},v=function(a){var b,c=a.find("li.active");b=c.is(":visible:first")?0:(c.prevAll().length+1)*c.outerHeight()-180,a.animate({scrollTop:b},150)};return{init:d}}(),a.fn.symphonySuggestions=function(c){var d=this,e={trigger:"{$",source:b.Context.get("path")+"/ajax/parameters/"};return a.extend(e,c),d.each(function(){var c=a(this).find('input[type="text"]');c.attr("data-trigger",e.trigger),c.attr("data-url",e.source),c.attr("data-search-types","parameters"),b.Interface.Suggestions.init(this,'input[type="text"]')}),d}}(window.jQuery,window.Symphony),function(a,b){var c=function(){var a=document.getElementById("environment");return a?JSON.parse(a.textContent):{}}();b.Context.add(null,c),b.Language.add({"Are you sure you want to proceed?":!1,"Reordering was unsuccessful.":!1,"Change Password":!1,"Remove File":!1,"Untitled Field":!1,"The field “{$title}” ({$type}) has been removed.":!1,"Undo?":!1,untitled:!1,"Expand all":!1,"Collapse all":!1,"drag to reorder":!1,"Please reset your password":!1,required:!1,"Click to select":!1,"Type to search":!1,Clear:!1,"Search for {$item}":!1,"Add filter":!1,filtered:!1,None:!1,"Clear filters":!1,"Apply filters":!1,"The Symphony calendar widget has been disabled because your system date format is currently not supported. Try one of the following instead or disable the calendar in the field settings:":!1,"no leading zero":!1}),a(document).ready(function(){b.Elements.window=a(window),b.Elements.html=a("html").addClass("js-active"),b.Elements.body=a("body"),b.Elements.wrapper=a("#wrapper"),b.Elements.header=a("#header"),b.Elements.nav=a("#nav"),b.Elements.session=a("#session"),b.Elements.context=a("#context"),b.Elements.breadcrumbs=a("#breadcrumbs"),b.Elements.contents=a("#contents");var c=b.Context.get("path"),d=b.Context.get("route");if(c&&d){var e=(c+d).split("/").filter(function(a){return"edit"!=a&&"new"!=a&&"created"!=a&&"saved"!=a&&""!=a}).join(".");b.Context.add("context-id",e)}b.View.render()})}(window.jQuery,window.Symphony),function(a,b){b.View.add("/:context*:",function(){b.Elements.contents.find("select.picker[data-interactive]").symphonyPickable(),b.Elements.contents.find("ul.orderable[data-interactive]").symphonyOrderable(),b.Elements.contents.find("table.selectable[data-interactive]").symphonySelectable(),b.Elements.wrapper.find(".filters-duplicator[data-interactive]").symphonyDuplicator(),b.Elements.wrapper.find(".tags[data-interactive]").symphonyTags(),b.Elements.wrapper.find("div.drawer").symphonyDrawer(),b.Elements.header.symphonyNotify(),a("select[multiple=multiple]").scrollTop(0),b.Elements.contents.find(".duplicator").on("constructshow.duplicator",".instance",function(){a(this).find(".tags[data-interactive]").symphonyTags()}),b.Elements.window.on("resize.admin nav.admin",function(){var a=b.Elements.nav.find("ul.content"),c=b.Elements.nav.find("ul.structure"),d=a.width()+c.width()+20;d>window.innerWidth?b.Elements.nav.removeClass("wide"):b.Elements.nav.addClass("wide")}).trigger("nav.admin"),b.Elements.nav.on("focus.admin blur.admin","a",function(){a(this).parents("li").eq(1).toggleClass("current")}),b.Elements.window.on("resize.admin",function(){b.Elements.header.find(".notifier").trigger("resize.notify")}),b.Elements.window.on("resize.admin table.admin",function(){var a=b.Elements.contents.find("table:first");a.width()>b.Elements.html.width()?a.addClass("fixed"):a.removeClass("fixed")}).trigger("table.admin");var c=null,d=b.Elements.contents.find("table.orderable[data-interactive]");d=d.filter(function(){return a(this).find("tbody tr").length>1}),d.symphonyOrderable({items:"tr",handles:"td"}).on("orderstart.orderable",function(){c=a(this).find("input").map(function(a){return this.name+"="+(a+1)}).get().join("&")}).on("orderstop.orderable",function(){var e=d.find("input").map(function(a){return this.name+"="+(a+1)}).get().join("&");d.addClass("busy"),null!==c&&e!==c?(d.trigger("orderupdate.admin"),e=e+"&"+b.Utilities.getXSRF(!0),a.ajax({type:"POST",url:b.Context.get("symphony")+"/ajax/reorder"+b.Context.get("route"),data:e,error:function(){b.Message.post(b.Language.get("Reordering was unsuccessful."),"error")},complete:function(){d.removeClass("busy").find("tr").removeClass("selected")}})):d.removeClass("busy")}),d.length&&b.Elements.breadcrumbs.append('<p class="inactive"><span> – '+b.Language.get("drag to reorder")+"</span></p>"),b.Elements.contents.find("fieldset.apply").each(function(){var c=a(this),d=b.Elements.contents.find("table.selectable"),e=c.find("select"),f=c.find("button");d.length>0&&(d.on("select.selectable deselect.selectable check.selectable","tbody tr",function(){d.has(".selected").length>0?(c.removeClass("inactive"),e.removeAttr("disabled")):(c.addClass("inactive"),e.attr("disabled","disabled"))}),d.find("tbody tr:first").trigger("check"),f.on("click.admin",function(){return c.is(".inactive")?!1:void 0}))}),b.Elements.contents.add(b.Elements.context).on("click.admin","button.confirm",function(){var c=a(this).attr("data-message")||b.Language.get("Are you sure you want to proceed?");return confirm(c)}),b.Elements.contents.find("> form").on("submit.admin",function(){var c=a('select[name="with-selected"]'),d=c.find("option:selected"),e=d.attr("data-message")||b.Language.get("Are you sure you want to proceed?");return d.is(".confirm")?confirm(e):void 0}),b.Elements.window.on("error.admin",function(c){a.ajax({type:"POST",url:b.Context.get("symphony")+"/ajax/log/",data:{error:c.originalEvent.message,url:c.originalEvent.filename,line:c.originalEvent.lineno,xsrf:b.Utilities.getXSRF()}})})}),b.View.add("/publish/:context*:",function(){b.Interface.Filtering.init(),b.Elements.contents.find(".page").each(function(){var b,c=a(this),d=c.find("form"),e=d.find("input"),f=e.attr("data-active"),g=e.attr("data-inactive"),h=a("<span />").appendTo(d);b=Math.max(h.text(f).width(),h.text(g).width()),e.width(b+20),h.remove(),e.val(g),d.on("mouseover.admin",function(){d.is(".active")||e.val()!=g||e.val(f)}),d.on("mouseout.admin",function(){d.is(".active")||e.val()!=f||e.val(g)}),e.on("focus.admin",function(){e.val()==f&&e.val(""),d.addClass("active")}),e.on("blur.admin",function(){(d.is(".invalid")||""===e.val())&&(d.removeClass("invalid"),e.val(g)),e.val()==g&&d.removeClass("active")}),d.on("submit.admin",function(){return parseInt(e.val(),10)>parseInt(e.attr("data-max"),10)?(d.addClass("invalid"),!1):void 0})}),a("<em />",{text:b.Language.get("Remove File"),on:{click:function(b){b.preventDefault();var c=a(this).parent(),d=c.find("input").attr("name");c.empty().append('<input name="'+d+'" type="file">')}}}).appendTo("label.file:has(a) span.frame"),a(".field-date").each(function(){var c,d=a(this),e=b.Context.get("datetime");d.attr("data-interactive")&&(c=new b.Interface.Calendar,c.init(this)),moment().utcOffset()!==e["timezone-offset"]&&d.addClass("show-timezone")})}),b.View.add("/:context*:/new",function(){b.Elements.contents.find('input[type="text"], textarea').first().focus()}),b.View.add("/blueprints/pages/:action:/:id:/:status:",function(){}),b.View.add("/blueprints/sections/:action:/:id:/:status:",function(c,d,e){var f,g,h,i=a("#fields-duplicator"),j=a("#fields-legend");if(f=a("<a />",{"class":"expand",text:b.Language.get("Expand all")}),g=a("<a />",{"class":"collapse",text:b.Language.get("Collapse all")}),h=a("<p />",{"class":"help toggle"}),h.append(f).append("<br />").append(g).insertAfter(j),h.on("click.admin","a.expand, a.collapse",function(){i.trigger(a(this).is(".expand")?"expandall.collapsible":"collapseall.collapsible")}),a("fieldset.settings > legend + .help").symphonyAffix(),i.symphonyDuplicator({orderable:!0,collapsible:!0,preselect:"input"}),i.on("constructshow.duplicator",".instance",function(){var c,d=a(this),e=d.find(".js-fetch-sections"),f=e.parent(),g=[];e.length&&(c=e.find("option").each(function(){g.push(this.value),isNaN(this.value)||a(this).remove()}),a.ajax({type:"GET",dataType:"json",url:b.Context.get("symphony")+"/ajax/sections/",success:function(c){e.detach(),c.sections.length&&e.prop("disabled",!1);var d=a();e.attr("data-required")||(d=d.add(a("<option />",{text:b.Language.get("None"),value:""}))),a.each(c.sections,function(b,c){var e=a("<optgroup />",{label:c.name});d=d.add(e),a.each(c.fields,function(b,c){var d=a("<option />",{value:c.id,text:c.name}).appendTo(e);a.inArray(c.id,g)>-1&&d.prop("selected",!0)})}),e.append(d),f.append(e),e.trigger("change.admin")}}))}),i.find(".instance").trigger("constructshow.duplicator"),i.on("constructshow.duplicator expandstop.collapsible",".instance",function(){var b=a(this);b.hasClass("js-animate-all")||a(this).find("input:visible:first").trigger("focus.admin")}),i.on("blur.admin input.admin",'.instance input[name*="[label]"]',function(){var c=a(this),d=c.val();""===d&&(d=b.Language.get("Untitled Field")),c.parents(".instance").find(".frame-header strong").text(d)}),i.on("change.admin",'.instance select[name*="[location]"]',function(){var b=a(this);b.parents(".instance").find(".frame-header").removeClass("main").removeClass("sidebar").addClass(b.val())}),i.on("change.admin",'.instance input[name*="[required]"]',function(){var c=a(this),d=c.parents(".instance").find(".frame-header h4");c.is(":checked")?a("<span />",{"class":"required",text:"— "+b.Language.get("required")}).appendTo(d):d.find(".required").remove()}),i.find('.instance input[name*="[required]"]').trigger("change.admin"),i.on("change.admin",'.instance select[name*="[dynamic_options]"]',function(){a(this).parents(".instance").find("[data-condition=associative]").toggle(a.isNumeric(this.value))}).trigger("change.admin"),i.on("change.admin",'.instance select[name*="[pre_populate_source]"]',function(){var b=a(this).val(),c=!1;b&&(b=jQuery.grep(b,function(a){return"existing"!=a}),c=b.length>0),a(this).parents(".instance").find("[data-condition=associative]").toggle(c)}).trigger("change.admin"),i.on("destructstart.duplicator",function(c){var d=a(c.target),e=d.clone(),f=e.find(".frame-header strong").text(),g=e.find(".frame-header span").text(),h=d.index(),i=(new Date).getTime();b.Elements.header.find("div.notifier").trigger("attach.notify",[b.Language.get("The field “{$title}” ({$type}) has been removed.",{title:f,type:g})+'<a id="'+i+'">'+b.Language.get("Undo?")+"</a>","protected undo"]),a("#"+i).data("field",e).data("preceding",h-1).on("click.admin",function(){var b=a(this),c=b.parent(),d=b.data("field").hide(),e=a("#fields-duplicator");e.parent().removeClass("empty"),d.trigger("constructstart.duplicator"),e.find(".instance:eq("+b.data("preceding")+")").after(d),d.trigger("constructshow.duplicator"),d.slideDown("fast",function(){d.trigger("constructstop.duplicator")}),c.trigger("detach.notify")})}),i.on("orderstop.orderable",function(){b.Elements.header.find(".undo").trigger("detach.notify")}),i.on("orderstart.orderable",function(b,c){var d=a(this),e=c.find(".frame-header"),f=e.is(".main")?"main":"sidebar";d.find("li:has(."+f+")").not(c).addClass("highlight")}),i.on("orderstop.orderable",function(){a(this).find("li.highlight").removeClass("highlight")}),"created"===e){var k=(i.find(".instance"),b.Context.get("context-id"));k=k.split("."),k.pop(),k="symphony.collapsible."+k.join(".")+".0.collapsed",b.Support.localStorage===!0&&window.localStorage[k]&&(a.each(window.localStorage[k].split(","),function(a,b){var c=i.find(".instance").eq(b);0==c.has(".invalid").length&&c.trigger("collapse.collapsible",[0])}),window.localStorage.removeItem(k))}}),b.View.add("/blueprints/datasources/:action:/:id:/:status:/:*:",function(c){if(c){var d=a("#ds-context"),e=a("#ds-source"),f=b.Elements.contents.find('input[name="fields[name]"]').attr("data-updated",0),g=0,h=b.Elements.contents.find('select[name="fields[param][]"]'),i=b.Elements.contents.find(".pagination"),j=i.find("input");f.on("blur.admin input.admin",function(){var c=g+=1,d=f.val();setTimeout(function(c,d,e){c==d&&a.ajax({type:"GET",data:{string:e},dataType:"json",url:b.Context.get("symphony")+"/ajax/handle/",success:function(a){c==d&&(f.data("handle",a.handle),h.trigger("update.admin"))}})},500,g,c,d)}),h.on("update.admin",function(){var c=f.data("handle")||b.Language.get("untitled");0!==parseInt(f.attr("data-updated"))&&h.find("option").each(function(){var b=a(this),d=b.attr("data-handle");b.text("$ds-"+c+"."+d)}),f.attr("data-updated",1)}).trigger("update.admin"),b.Elements.contents.find(".contextual select optgroup").each(function(){var b=a(this),c=b.parents("select"),e=b.attr("data-label"),f=b.remove().find("option").addClass("optgroup");d.on("change.admin",function(){var b=a(this).find("option:selected"),d=b.attr("data-context")||"section-"+b.val();d==e&&(c.find("option.optgroup").remove(),c.append(f.clone(!0)))})}),d.on("change.admin",function(){var a=d.find("option:selected").parent(),c=a.attr("data-label")||a.attr("label"),f=d.find("option:selected").attr("data-context")||"section-"+d.val(),g=b.Elements.contents.find(".contextual");e.val(d.val()),g.addClass("irrelevant"),g.filter("[data-context~="+c+"]").removeClass("irrelevant"),g.filter("[data-context~="+f+"]").removeClass("irrelevant"),b.Elements.contents.find('input[name="fields[name]"]').trigger("blur.admin")}).trigger("change.admin"),b.Elements.contents.find("input[name*=paginate_results]").on("change.admin",function(){var b=!a(this).is(":checked");j.prop("disabled",b)}).trigger("change.admin"),b.Elements.contents.find("> form").on("submit.admin",function(){j.prop("disabled",!1)}),b.Elements.contents.find(".filters-duplicator, .ds-param").each(function(){b.Interface.Suggestions.init(this,'input[type="text"]')}),b.Elements.contents.find(".filters-duplicator").on("input.admin change.admin","input",function(b){var c=a(b.target).parents(".instance"),d=b.target.value,e=c.data("filters"),f=c.find(".help"),g=a.trim(d.search(/:/)?d.split(":")[0]:d);e||(e={},c.find(".tags li").each(function(){var b=a.trim(this.getAttribute("data-value"));b.search(/:/)&&(b=b.slice(0,-1)),e[b]=this.getAttribute("data-help")}),c.data("filters",e)),e[g]&&f.html(e[g])})}}),b.View.add("/blueprints/events/:action:/:name:/:status:/:*:",function(){var c=a("#event-context"),d=a("#event-source"),e=a("#event-filters"),f=(b.Elements.contents.find("> form"),b.Elements.contents.find('input[name="fields[name]"]').attr("data-updated",0)),g=0;f.on("blur.admin input.admin",function(){var a=g+=1;setTimeout(function(a,c){a==c&&b.Elements.contents.trigger("update.admin")},500,g,a)}),c.on("change.admin",function(){d.val(c.val()),b.Elements.contents.trigger("update.admin")}).trigger("change.admin"),e.on("change.admin",function(){b.Elements.contents.trigger("update.admin")}),b.Elements.contents.on("update.admin",function(){""==f.val()?a("#event-documentation").empty():a.ajax({type:"GET",data:{section:c.val(),filters:e.serializeArray(),name:f.val()},dataType:"html",url:b.Context.get("symphony")+"/ajax/eventdocumentation/",success:function(b){a("#event-documentation").replaceWith(b)}})})}),b.View.add("/system/authors/:action:/:id:/:status:",function(c,d,e){var f=a("#password");if(!f.has(".invalid").length&&d&&!e){var g=a('<div class="password" />'),h=a('<span class="frame centered" />'),i=a("<button />",{text:b.Language.get("Change Password"),on:{click:function(a){a.preventDefault(),g.hide()}}}).attr("type","button");h.append(i),g.append(h),g.insertBefore(f)}if("reset-password"==e){var j=b.Elements.contents.find("fieldset"),k=j.eq(0),l=j.eq(1),m=l.find("> legend");k.hide(),l.children().not("legend, #password").hide(),a("<p />",{"class":"help",text:b.Language.get("Please reset your password")}).insertAfter(m)}b.Elements.contents.find("input, select").on("change.admin input.admin",function(){a("#confirmation").addClass("highlight")})}),b.View.add("/system/extensions/:context*:",function(){b.Language.add({Enable:!1,Install:!1,Update:!1}),b.Elements.contents.find(".actions select").on("click.admin focus.admin",function(a){var c=b.Elements.contents.find("tr.selected"),d=c.filter(".extension-can-update").length,e=c.filter(".extension-can-install").length,f=c.length-d-e,g=b.Elements.contents.find('.actions option[value="enable"]'),h=[];f&&h.push(b.Language.get("Enable")),d&&h.push(b.Language.get("Update")),e&&h.push(b.Language.get("Install")),g.text(h.join("/"))})})}(window.jQuery,window.Symphony);
+			var affix = $('#affix').symphonyAffix({
+				container:		'.parent',
+			});
+	 */
+a.fn.symphonyAffix=function(b){var d=a(this),e={
+// public
+container:null,
+// private
+top:0,freespace:0,bottom:0,height:0,maxtop:0};/*---------------------------------------------------------------------
+			Initialisation
+		---------------------------------------------------------------------*/
+// Init
+return a.extend(e,b),d.each(function(){var b=a.extend({},e),d=a(this),f=function(){b.top=b.container.offset().top,b.freespace=b.container.height(),b.bottom=b.top+b.freespace,b.height=d.height(),b.maxtop=b.freespace-b.height+"px"};
+// use parent as default container
+b.container?b.container=a(b.container):b.container=d.parent(),
+// cache cssom values
+f(),d.on("updatesettings.affix",f),d.addClass("js-affix"),
+// save instance settings
+d.data("affix-settings",b),
+// register instance
+c=c.add(d)}),a(window).triggerHandler("scroll"),d},/*-----------------------------------------------------------------------*/
+// One listener for all instances
+a(window).scroll(function(e){d=a(this).scrollTop(),b.Utilities.requestAnimationFrame(function(){c.each(function(){var b=a(this),c=b.data("affix-settings"),e="js-affix-scroll",f="";d<c.top?e="js-affix-top":d>c.bottom&&(e="js-affix-bottom",f=c.maxtop),b.hasClass(e)||b.removeClass("js-affix-scroll js-affix-top js-affix-bottom").addClass(e).css({top:f})})})})}(window.jQuery,window.Symphony),/**
+ * @package assets
+ */
+function(a,b){
+// Saves the value into the local storage at the specified storage key.
+var c=function(a,b){
+// Put in a try/catch in case something goes wrong (no space, privileges etc)
+// Always put try/catches into their own function to prevent callers from
+// going into un-optimized hell
+try{window.localStorage[a]=b}catch(c){window.onerror(c.message)}};/**
+	 * Create collapsible elements.
+	 *
+	 * @name $.symphonyCollapsible
+	 * @class
+	 *
+	 * @param {Object} options An object specifying containing the attributes specified below
+	 * @param {String} [options.items='.instance'] Selector to find collapsible items within the container
+	 * @param {String} [options.handles='.header:first'] Selector to find clickable handles to trigger interaction
+	 * @param {String} [options.content='.content'] Selector to find hideable content area
+	 * @param {Boolean} [options.save_state=true] Stores states of instances using local storage
+	 * @param {String} [options.storage='symphony.collapsible.area.page.id'] Namespace used for local storage
+	 * @param {Integer} [options.delay=250] Time delay for animations
+	 *
+	 * @example
+
+			var collapsible = $('#duplicator').symphonyCollapsible({
+				items:		'.instance',
+				handles:	'.header span'
+			});
+			collapsible.collapseAll();
+	 */
+a.fn.symphonyCollapsible=function(d){var e=this,f={items:".instance",handles:".frame-header",content:".content",ignore:".ignore",save_state:!0,storage:"symphony.collapsible."+b.Context.get("context-id"),delay:250};/*-----------------------------------------------------------------------*/
+/*-----------------------------------------------------------------------*/
+return a.extend(f,d),e.each(function(d){var e=a(this),g=f.storage+"."+d+".collapsed",h=function(b){return a.isNumeric(b)?b:f.delay},i=function(a,b){var c=0;
+// Customization point
+a.trigger("collapsebefore.collapsible",f),c=a.data("heightMin"),0!==b&&(a.addClass("js-animate"),a.trigger("collapsestart.collapsible")),a.addClass("collapsed"),a.css("max-height",c),0!==b&&setTimeout(function(){a.trigger("animationend.collapsible"),a.trigger("animationend.duplicator")},b)};
+// Collapse item
+e.on("collapse.collapsible",f.items,function(b,c){var d=a(this);i(d,h(c))}),
+// Collapse all items
+e.on("collapseall.collapsible",function(c){
+// Find items that will be visible after collapse
+for(var d=e.find(f.items+":not(.collapsed)"),g=b.Utilities.inSight(d),h=a(),j=a(window).scrollTop(),k=g.eq(0).index(),l=0;k<d.length&&l<window.innerHeight;){var m=d.eq(k);g=g.add(m),l+=m.data("heightMin"),k++}g.each(function(){i(a(this),f.delay)}),setTimeout(function(){var b=g.eq(0),c=b.offset().top;h=d.not(g),h.each(function(){i(a(this),0)}),c>0&&j>e.offset().top&&a(window).scrollTop(j+(b.offset().top-c)),h.trigger("animationend.collapsible")},f.delay+100)});
+// Expand item
+var j=function(a,b){var c=0;
+// Customization point
+a.trigger("expandbefore.collapsible",f),c=a.data("heightMax"),0!==b&&(a.addClass("js-animate"),a.trigger("expandstart.collapsible")),a.removeClass("collapsed"),a.css("max-height",c),0!==b&&setTimeout(function(){a.trigger("animationend.collapsible")},b)};e.on("expand.collapsible",f.items,function(b,c){var d=a(this);j(d,h(c))}),
+// Expand all items
+e.on("expandall.collapsible",function(c){var d=e.find(f.items+".collapsed"),g=b.Utilities.inSight(d).filter("*:lt(4)"),h=d.not(g),i=a(window).scrollTop();g.addClass("js-animate-all"),// prevent focus
+g.each(function(){j(a(this),f.delay)}),setTimeout(function(){var b=g.eq(0),c=b.offset().top;h.addClass("js-animate-all"),// prevent focus
+h.each(function(){j(a(this),0)}),h.trigger("animationend.collapsible"),
+// if we are past the first item
+c>0&&i>e.offset().top&&
+// scroll back to where we were,
+// which is last scroll position + delta of first visible item
+a(window).scrollTop(i+(b.offset().top-c))},f.delay+100)}),
+// Finish animations
+e.on("animationend.collapsible",f.items,function(b){var c=a(this);
+// Trigger events
+c.is(".collapsed")?c.trigger("collapsestop.collapsible"):c.trigger("expandstop.collapsible"),
+// clean up
+c.removeClass("js-animate js-animate-all")}),
+// Toggle single item
+e.on("click.collapsible",f.handles,function(b){var c=a(this),d=c.closest(f.items);c.is(f.ignore)||a(b.target).is(f.ignore)||d.is(".locked")||(
+// Expand
+d.is(".collapsed")?j(d,f.delay):i(d,f.delay))});
+// Save states
+var k=0;e.on("collapsestop.collapsible expandstop.collapsible store.collapsible",f.items,function(d){f.save_state===!0&&b.Support.localStorage===!0&&(
+// save it to local storage, delayed, once
+clearTimeout(k),k=setTimeout(function(){var b=e.find(f.items).map(function(b){return a(this).is(".collapsed")?b:void 0}).get().join(",");c(g,b)},f.delay))}),
+// Restore states
+e.on("restore.collapsible",function(c){f.save_state===!0&&b.Support.localStorage===!0&&window.localStorage[g]&&a.each(window.localStorage[g].split(","),function(a,b){var c=e.find(f.items).eq(b);0==c.has(".invalid").length&&i(c,0)})}),
+// Refresh state storage after ordering
+e.on("orderstop.orderable",function(a){e.find(f.items).trigger("store.collapsible")}),
+// Refresh state storage after deleting and instance
+e.on("destructstop.duplicator",f.items,function(){a(this).trigger("store.collapsible")}),
+// Update sizes
+e.on("updatesize.collapsible",f.items,function(){var b=a(this),c=b.find(f.handles).outerHeight(!0),d=c+b.find(f.content).outerHeight(!0);b.data("heightMin",c),b.data("heightMax",d)}),
+// Set sizes
+e.on("setsize.collapsible",f.items,function(){var b=a(this),c=b.data("heightMin"),d=b.data("heightMax");b.css({"min-height":c,"max-height":d})}),/*---------------------------------------------------------------------
+			Initialisation
+		---------------------------------------------------------------------*/
+// Prepare interface
+e.addClass("collapsible").find(f.items).each(function(){var b=a(this);b.addClass("instance"),b.trigger("updatesize.collapsible"),b.trigger("setsize.collapsible")}),
+// Restore states
+e.trigger("restore.collapsible")}),e}}(window.jQuery,window.Symphony),/**
+ * @package assets
+ */
+function(a,b){/**
+	 * Fills the target input/textarea with a value from the source element.
+	 * The plugin cease to change the value when the target is edited by the user and has a value.
+	 *
+	 * @name $.symphonyDefaultValue
+	 * @class
+	 *
+	 * @param {Object} options An object specifying containing the attributes specified below
+	 * @param {String} [options.sourceElement='.js-defaultvalue-source'] Selector to find the default value
+	 * @param {String} [options.sourceEvent='select'] The event that triggers setting the value in the target element
+	 * @param {String} [options.targetEvent='keyup blur'] The event(s) to watch for user interaction
+	 *
+	 * @example
+
+			$('.js-defaultvalue-target').symphonyDefaultValue();
+	 */
+a.fn.symphonyDefaultValue=function(b){var c=this,d=!1,e={sourceElement:".js-defaultvalue-source",sourceEvent:"change",targetEvent:"keyup blur"};a.extend(e,b),
+// append our namespace on the sourceEvent
+e.sourceEvent+=".symphony-defaultvalue";var f=a(e.sourceElement),g=function(){return c.val()},h=function(a){c.val(a)},i=function(){return f.find("option:selected").text()},j=function(a){d&&h(i())},k=function(){d||(f.on(e.sourceEvent,j),d=!0)},l=function(){d&&(a(e.sourceElement).off(e.sourceEvent),d=!1)};/*-----------------------------------------------------------------------*/
+/*-------------------------------------------------------------------------
+		Initialisation
+	-------------------------------------------------------------------------*/
+return c.on(e.targetEvent,function(a){g()?l():k()}),g()||k(),c}}(window.jQuery,window.Symphony),/**
+ * @package assets
+ */
+function(a,b){/**
+	 * Create orderable elements.
+	 *
+	 * @name $.symphonyOrderable
+	 * @class
+	 *
+	 * @param {Object} options An object specifying containing the attributes specified below
+	 * @param {String} [options.items='li'] Selector to find items to be orderable
+	 * @param {String} [options.handles='*'] Selector to find children that can be grabbed to re-order
+	 * @param {String} [options.ignore='input, textarea, select'] Selector to find elements that should not propagate to the handle
+	 * @param {Integer} [options.delay=250] Time used to delay actions
+	 *
+	 * @example
+
+			$('table').symphonyOrderable({
+				items: 'tr',
+				handles: 'td'
+			});
+	 */
+a.fn.symphonyOrderable=function(c){var d=this,e={items:"li",handles:"*",ignore:"input, textarea, select, a",delay:250};/*-----------------------------------------------------------------------*/
+/*-------------------------------------------------------------------------
+		Events
+	-------------------------------------------------------------------------*/
+// Start ordering
+// Stop ordering
+// Order items
+/*-------------------------------------------------------------------------
+		Initialisation
+	-------------------------------------------------------------------------*/
+// Make orderable
+return a.extend(e,c),d.on("mousedown.orderable",e.items+" "+e.handles,function(b){var c=a(this),d=c.parents(e.items),f=c.parents(".orderable");
+// Needed to prevent browsers from selecting texts and focusing textinputs
+a(b.target).is("input, textarea")||b.preventDefault(),c.is(e.ignore)||a(b.target).is(e.ignore)||(f.data("ordering",1),
+// Highlight item
+f.is(".selectable, .collapsible")?
+// Delay ordering to avoid conflicts with scripts bound to the click event
+setTimeout(function(){1==f.data("ordering")&&(f.trigger("orderstart.orderable",[d]),d.addClass("ordering"))},e.delay):(f.trigger("orderstart.orderable",[d]),d.addClass("ordering")))}),d.on("mouseup.orderable mouseleave.orderable",function(b){var c,d=a(this);1==d.data("ordering")&&(c=d.find(".ordering"),c.removeClass("ordering"),d.data("ordering",0),d.trigger("orderstop.orderable",[c]),d.trigger("orderstoplock.orderable",[c]),c.addClass("locked"),setTimeout(function(){c.removeClass("locked"),d.trigger("orderstopunlock.orderable",[c])},e.delay))}),a(document).on("mousemove.orderable",".orderable:has(.ordering)",function(c){var d=a(this);if(1==d.data("ordering")){
+// Only keep what we need from event object
+var f=c.pageY;b.Utilities.requestAnimationFrame(function(){var a=d.find(".ordering");
+// If there is still an ordering item in DOM
+if(a.length){var b,c,g=a.offset().top,h=g+a.outerHeight();
+// Remove text ranges
+window.getSelection&&window.getSelection().removeAllRanges(),
+// Move item up
+g>f?(b=a.prev(e.items),b.length>0&&(a.insertBefore(b),d.trigger("orderchange",[a]))):f>h&&(c=a.next(e.items),c.length>0&&(a.insertAfter(c),d.trigger("orderchange",[a])))}})}}),d.addClass("orderable"),d}}(window.jQuery,window.Symphony),/**
+ * @package assets
+ */
+function(a,b){/**
+	 * Create selectable elements. Clicking an item will select it
+	 * by adding the class <code>.selected</code>. Holding down the shift key
+	 * while clicking multiple items creates a selection range. Holding the meta key
+	 * (which is <code>cmd</code> on a Mac or <code>ctrl</code> on Windows) allows
+	 * the selection of multiple items or the modification of an already selected
+	 * range of items. Doubleclicking outside the selection list will
+	 * remove the selection.
+	 *
+	 * @name $.symphonySelectable
+	 * @class
+	 *
+	 * @param {Object} options An object specifying containing the attributes specified below
+	 * @param {String} [options.items='tbody tr:has(input)'] Selector to find items that are selectable
+	 * item. Needed to properly handle item highlighting when used in connection with the orderable plugin
+	 * @param {String} [options.ignore='a'] Selector to find elements that should not propagate to the handle
+	 * @param {String} [optinos.mode='single'] Either 'default' (click removes other selections) or 'additive' (click adds to exisiting selection)
+	 *
+	 * @example
+
+			var selectable = $('table').symphonySelectable();
+			selectable.find('a').mousedown(function(event) {
+				event.stopPropagation();
+			});
+	 */
+a.fn.symphonySelectable=function(b){var c=this,d={items:"tbody tr:has(input)",ignore:"a",mode:"single"};/*-----------------------------------------------------------------------*/
+/*-------------------------------------------------------------------------
+		Events
+	-------------------------------------------------------------------------*/
+// Select
+// Remove all selections by doubleclicking the body
+/*-------------------------------------------------------------------------
+		Initialisation
+	-------------------------------------------------------------------------*/
+// Make selectable
+return a.extend(d,b),c.on("click.selectable",d.items,function(b){var c,e,f,g,h=a(this),i=h.siblings().addBack(),j=a(b.liveFired),k=a(b.target);
+// Ignored elements
+// Ignored elements
+// Remove text ranges
+// Range selection
+// Select upwards
+// Get selection
+// Deselect items outside the selection range
+// Select range
+// Press meta or ctrl key to adjust current range, otherwise the selection will be removed
+// Toggle selection
+return k.is(d.ignore)?!0:(window.getSelection&&window.getSelection().removeAllRanges(),void(b.shiftKey&&i.filter(".selected").length>0&&!j.is(".single")?(h.prevAll().filter(".selected").length>0?(f=i.filter(".selected:first").index(),g=h.index()+1):(f=h.index(),g=i.filter(".selected:last").index()+1),c=i.slice(f,g),e=i.filter(".selected").not(c).removeClass("selected").trigger("deselect.selectable"),e.find('input[type="checkbox"]:hidden:first').prop("checked",!1),c.addClass("selected").trigger("select.selectable"),c.find('input[type="checkbox"]:hidden:first').prop("checked",!0)):((!b.metaKey&&!b.ctrlKey&&"additive"!=d.mode&&!k.is("input")||j.is(".single"))&&(e=i.not(h).filter(".selected").removeClass("selected").trigger("deselect.selectable"),e.find('input[type="checkbox"]:hidden:first').prop("checked",!1)),h.is(".selected")?(h.removeClass("selected").trigger("deselect.selectable"),h.find('input[type="checkbox"]:hidden:first').prop("checked",!1)):(h.addClass("selected").trigger("select.selectable"),h.find('input[type="checkbox"]:hidden:first').prop("checked",!0)))))}),a("body").bind("dblclick.selectable",function(){c.find(d.items).removeClass("selected").trigger("deselect.selectable")}),c.addClass("selectable"),c}}(window.jQuery,window.Symphony),/**
+ * @package assets
+ */
+function(a,b){/**
+	 * Duplicators are advanced lists used throughout the
+	 * Symphony backend to manage repeatable content.
+	 *
+	 * @name $.symphonyDuplicator
+	 * @class
+	 *
+	 * @param {Object} options An object specifying containing the attributes specified below
+	 * @param {String} [options.instances='> li:not(.template)'] Selector to find children to use as instances
+	 * @param {String} [options.templates='> li.template'] Selector to find children to use as templates
+	 * @param {String} [options.headers='> :first-child'] Selector to find the header part of each instance
+	 * @param {String} [options.perselect=false] Default option for the selector
+	 * @param {Boolean} [options.orderable=false] Can instances be ordered
+	 * @param {Boolean} [options.collapsible=false] Can instances be collapsed
+	 * @param {Boolean} [options.constructable=true] Allow construction of new instances
+	 * @param {Boolean} [options.destructable=true] Allow destruction of instances
+	 * @param {Integer} [optionss.minimum=0] Do not allow instances to be removed below this limit
+	 * @param {Integer} [options.maximum=1000] Do not allow instances to be added above this limit,
+	 * @param {Integer} [options.delay=250'] Time delay for animations
+	 *
+	 * @example
+
+			$('.duplicator').symphonyDuplicator({
+				orderable: true,
+				collapsible: true
+			});
+	 */
+a.fn.symphonyDuplicator=function(c){var d=this,e={instances:"> li:not(.template)",templates:"> li.template",headers:"> :first-child",preselect:!1,orderable:!1,collapsible:!1,constructable:!0,destructable:!0,save_state:!0,minimum:0,maximum:1e3,delay:250};/*-----------------------------------------------------------------------*/
+/*-----------------------------------------------------------------------*/
+// Language strings
+/*-----------------------------------------------------------------------*/
+return a.extend(e,c),b.Language.add({"Add item":!1,"Remove item":!1}),d.each(function(){var c,d,f,g,h=a(this),i=h.find("> ol"),j=a('<fieldset class="apply" />'),k=a("<select />"),l=a('<button type="button" class="constructor" />');
+// Initialise duplicator components
+h.addClass("duplicator").addClass("empty"),c=i.find(e.instances).addClass("instance"),d=i.find(e.templates).addClass("template"),f=c.add(d),g=f.find(e.headers).addClass("frame-header"),l.text(i.attr("data-add")||b.Language.get("Add item")),j.on("click.duplicator",".constructor:not(.disabled)",function(b,c){var f=d.filter('[data-type="'+a(this).parent().find("select").val()+'"]').clone(!0);b.preventDefault(),f.trigger("constructstart.duplicator").appendTo(i),h.removeClass("empty"),f.trigger("constructshow.duplicator"),f.trigger("updatesize.collapsible"),f.trigger("setsize.collapsible"),setTimeout(function(){f.trigger("animationend.duplicator")},e.delay)}),h.on("click.duplicator",".destructor:not(.disabled)",function(b){var c=a(this).closest(".instance");c.trigger("collapse.collapsible").trigger("destructstart.duplicator").addClass("destructed"),setTimeout(function(){c.trigger("animationend.duplicator")},e.delay)}),h.on("animationend.duplicator",".instance",function(){var b=a(this).removeClass("js-animate");b.is(".destructed")?(b.remove(),0==h.find(".instance").length&&h.addClass("empty"),b.trigger("destructstop.duplicator"),h.trigger("destructstop.duplicator",[b])):b.trigger("constructstop.duplicator"),e.collapsible&&b.trigger("store.collapsible")}),h.on("constructstop.duplicator",".instance",function(){h.find(".instance").length>=e.maximum&&l.addClass("disabled")}),h.on("destructstart.duplicator",".instance",function(){h.find(".instance").length<=e.maximum&&l.removeClass("disabled")}),h.on("destructstart.duplicator",".instance",function(){h.find(".instance").length-1==e.minimum&&h.find("a.destructor").addClass("disabled")}),h.on("constructstop.duplicator",".instance",function(){h.find(".instance").length>e.minimum&&h.find("a.destructor").removeClass("disabled")}),h.on("constructstop.duplicator",".instance",function(b){var c=a(this);c.is(".unique")&&(k.find('option[value="'+c.attr("data-type")+'"]').attr("disabled",!0),k.find("option").prop("selected",!1).filter(":not(:disabled):first").prop("selected",!0),0==k.find("option:not(:disabled)").length&&k.attr("disabled","disabled"))}),h.on("destructstart.duplicator",".instance",function(b){var c,d=a(this);d.is(".unique")&&(c=k.attr("disabled",!1).find('option[value="'+d.attr("data-type")+'"]').attr("disabled",!1),1==k.find("option:not(:disabled)").length&&c.prop("selected",!0))}),h.on("constructstop.duplicator refresh.duplicator",".instance",function(b){var c=a(this),d=h.find(".instance").index(c);c.find("*[name]").each(function(){var b=a(this),c=/\[\-?[0-9]+\]/,e=b.attr("name");c.test(e)&&b.attr("name",e.replace(c,"["+d+"]"))})}),h.on("orderstop.orderable",function(a){h.find(".instance").trigger("refresh.duplicator")}),g.each(function(){var b=a(this);b.next(".content").length||b.nextAll().wrapAll(a("<div />").attr("class","content"))}),e.constructable===!0&&(h.addClass("constructable"),j.append(a("<div />").append(k)).append(l),j.appendTo(h),d.detach().each(function(){var b=a(this),c=a.trim(b.find(e.headers).attr("data-name"))||a.trim(b.find(e.headers).text()),d=a.trim(b.attr("data-type"));b.trigger("constructstart.duplicator"),d||(d=c,b.attr("data-type",d)),a("<option />",{text:c,value:d}).appendTo(k),b.trigger("constructstop.duplicator")}).removeClass("template").addClass("instance")),0!=e.preselect&&k.find('option[value="'+e.preselect+'"]').prop("selected",!0),d.length<=1&&(j.addClass("single"),d.is(".unique")&&(0==c.length&&l.trigger("click.duplicator",[0]),j.hide())),e.destructable===!0&&(h.addClass("destructable"),g.append(a("<a />").attr("class","destructor").text(i.attr("data-remove")||b.Language.get("Remove item")))),e.collapsible&&h.symphonyCollapsible({items:".instance",handles:".frame-header",ignore:".destructor",save_state:e.save_state,delay:e.delay}),e.orderable&&h.symphonyOrderable({items:".instance",handles:".frame-header"}),c.filter(":has(.invalid)").addClass("conflict"),c.trigger("constructstop.duplicator"),c.find('input[name*="[label]"]').trigger("keyup.duplicator"),c.length>0&&h.removeClass("empty")}),d}}(window.jQuery,window.Symphony),/**
+ * @package assets
+ */
+function(a,b){/**
+	 * Insert tags from a list into an input field based on three modes:
+	 * singular - allowing only one tag at a time (add a class of .singular)
+	 * multiple - allowing multiple tags, comma separated
+	 * inline - which adds tags at the current cursor position (add a class of .inline)
+	 *
+	 * @name $.symphonyTags
+	 * @class
+	 *
+	 * @param {Object} custom_settings An object specifying containing the attributes specified below
+	 * @param {String} [custom_settings.items='li'] Selector to find collapsible items within the container
+	 *
+	 * @example
+
+			$('.tags').symphonyTags();
+	 */
+a.fn.symphonyTags=function(b){var c=this,d={items:"li"};/*-----------------------------------------------------------------------*/
+/*-------------------------------------------------------------------------
+		Events
+	-------------------------------------------------------------------------*/
+return a.extend(d,b),c.on("click.tags",d.items,function(b){var c=a(this),d=c.parent(),e=d.prev().find("input, textarea"),f=e.val(),g=c.attr("class")||c.data("value")||c.text();
+// Singular
+if(d.is(".singular"))e.val(g);else if(d.is(".inline")){var h=e[0].selectionStart,i=e[0].selectionEnd,j=0;
+// Insert tag
+h>0?(e.val(f.substring(0,h)+g+f.substring(i,f.length)),j=h+g.length):(e.val(f+g),j=f.length+g.length),
+// Reset cursor position
+e[0].selectionStart=j,e[0].selectionEnd=j}else{var k=(new RegExp("^"+g.replace(/[-[\]{}()*+?.,\\^$|#\s]/g,"\\$&")+"$","i"),f.split(/,\s*/)),l=!1;
+// Check existing tags
+for(var m in k)
+// Remove existing tag
+k[m]==g?(k.splice(m,1),l=!0):""==k[m]&&k.splice(m,1);
+// Add new tag
+l===!1&&k.push(g),
+// Save tags
+e.val(k.join(", "))}
+// Include the tag that was just triggered.
+e.trigger("change",{tag:c})}),c}}(window.jQuery,window.Symphony),/**
+ * @package assets
+ */
+function(a,b){/**
+	 * Pickable allows to show and hide elements based on the value of a select box.
+	 *
+	 * Each option is mapped to its associated content by matching the option `value`
+	 * with the content `id`. If the option value is numeric, Pickable prefices it
+	 * with `choice`. Only the content of the currently selected option is
+	 * shown, all other elements associated with the given select box are hidden.
+	 *
+	 * If no content element of the given `id` is found, Pickable checks for a
+	 * `data-request` attribute on the selected option. If a `data-request` URL is set,
+	 * Pickable tries to fetch the content remotely and expects an content element with
+	 * no additional markup in return.
+	 *
+	 * @name $.symphonyPickable
+	 * @class
+	 *
+	 * @param {Object} options An object containing the element selectors specified below
+	 * @param {String} [options.content='#contents'] Selector to find the container that wraps all pickable elements
+	 * @param {String} [options.pickables='.pickable'] Selector used to find pickable elements
+	 *
+	 * @example
+
+			$('.picker').symphonyPickable();
+	 */
+a.fn.symphonyPickable=function(b){var c=a(this),d={content:"#contents",pickables:".pickable"};a.extend(d,b),/*-------------------------------------------------------------------------
+		Events
+	-------------------------------------------------------------------------*/
+// Switch content
+c.on("change.pickable",function(b){var c,f,g=a(this),h=g.val(),i=g.attr("id")||g.attr("name"),j=a(d.pickables+'[data-relation="'+i+'"]');
+// Handle numeric values
+a.isNumeric(h)===!0&&(h="choice"+h),
+// Hide all choices
+g.trigger("pickstart.pickable"),j.hide(),c=a("#"+h),c.length>0?(c.show().trigger("pick.pickable"),g.trigger("pickstop.pickable")):(f=g.data("request"),f&&a.ajax({type:"GET",url:f,data:{choice:h},dataType:"html",success:function(a){e.append(a),a.trigger("pick.pickable"),g.trigger("pickstop.pickable")}}))});/*-------------------------------------------------------------------------
+		Initialisation
+	-------------------------------------------------------------------------*/
+var e=a(d.content);/*-----------------------------------------------------------------------*/
+// Set up relationships
+// Show picked content
+return c.each(function(){var b=a(this),c=b.attr("id")||b.attr("name");b.find("option").each(function(){a("#"+a(this).val()).attr("data-relation",c)})}),c.trigger("change.pickable"),c}}(window.jQuery,window.Symphony),/**
+ * @package assets
+ */
+function(a,b){/**
+	 * Convert absolute to relative dates.
+	 *
+	 * @name $.symphonyTimeAgo
+	 * @class
+	 *
+	 * @param {Object} options An object specifying containing the attributes specified below
+	 * @param {String} [options.items='time'] Selector to find the absolute date
+	 * @param {String} [options.timestamp='utc'] Attribute of `object.items` representing the timestamp of the given date
+	 * @param {Integer} [options.max=0] Plugin will disable when the minutes exceed this value. By default this behaviour is off.
+	 *
+	 * @example
+
+			$('.notifier').symphonyTimeAgo();
+	 */
+a.fn.symphonyTimeAgo=function(c){/*-------------------------------------------------------------------------
+		Functions
+	-------------------------------------------------------------------------*/
+function d(b){var c,d=b.data("timestamp");
+// Fetch stored timestamp
+// Fetch stored timestamp
+// Defined date and time
+// Datetime will be in seconds since Epoch, JS requires
+// millseconds, so multiply by 1000.
+// Store and return timestamp
+return a.isNumeric(d)?d:(c=b.attr(g.timestamp),d=c?new Date(1e3*c):(new Date).getTime(),b.data("timestamp",d),d)}function e(a,c){
+// Calculate time difference
+var d=c-a,
+// Convert time to minutes
+e=Math.floor(d/6e4);
+// Return relative date based on passed time
+// Return relative date based on passed time
+return 1>e?b.Language.get("just now"):2>e?b.Language.get("a minute ago"):45>e?b.Language.get("{$minutes} minutes ago",{minutes:e}):90>e?b.Language.get("about 1 hour ago"):!g.max||e<g.max?b.Language.get("about {$hours} hours ago",{hours:Math.floor(e/60)}):void 0}var f=this,g={items:"time",timestamp:"utc",max:0};/*-----------------------------------------------------------------------*/
+/*-----------------------------------------------------------------------*/
+/*-------------------------------------------------------------------------
+		Initialisation
+	-------------------------------------------------------------------------*/
+return a.extend(g,c),b.Language.add({"just now":!1,"a minute ago":!1,"{$minutes} minutes ago":!1,"about 1 hour ago":!1,"about {$hours} hours ago":!1}),f.find(g.items).each(function(){var b=a(this),c=d(b),f=new Date,g=e(c,f);
+// Set relative time
+g&&b.text(g)}),f}}(window.jQuery,window.Symphony),/**
+ * @package assets
+ */
+function(a,b){"use strict";/**
+	 * Notify combines multiple system messages to an interface that focusses
+	 * on a single message at a time and offers a navigation to move between message.
+	 *
+	 * @name $.symphonyNotify
+	 * @class
+	 *
+	 * @param {Object} options An object specifying containing the attributes specified below
+	 * @param {String} [options.items='p.notice'] Selector to find messages
+	 * @param {String} [options.storage='symphony.notify.root'] Namespace used for local storage
+	 *
+	 * @example
+
+			$('#messages').symphonyNotify();
+	 */
+a.fn.symphonyNotify=function(c){var d=this,e={items:"p.notice",storage:"symphony.notify."+b.Context.get("root").replace("http://","")};/*-----------------------------------------------------------------------*/
+/*-----------------------------------------------------------------------*/
+/*-------------------------------------------------------------------------
+		Events
+	-------------------------------------------------------------------------*/
+// Attach message
+// Detach message
+// Resize notifier
+// Count messages
+// Next message
+// Move messages
+// Ignore message
+/*-------------------------------------------------------------------------
+		Initialisation
+	-------------------------------------------------------------------------*/
+// Build interface
+return a.extend(e,c),b.Language.add({"Ignore?":!1,next:!1,at:!1}),d.on("attach.notify",function(c,d,f){var g,h,i=a(this),j=i.find("div.notifier"),k=j.find(e.items);j.trigger("attachstart.notify"),g=a("<p />",{"class":f}).html(d.replace(b.Language.get("at")+" ","")).addClass("notice active").symphonyTimeAgo(),g.is(".error")||g.is(".success")||g.is(".protected")||g.html(g.html()+' <a class="ignore">'+b.Language.get("Ignore?")+"</a>"),a("<nav />",{text:b.Language.get("next")}).hide().appendTo(g),b.Support.localStorage===!0&&(h=window.localStorage[e.storage]?a.parseJSON(window.localStorage[e.storage]):[]),f&&~f.indexOf("success")&&setTimeout(function(){g.addClass("dimmed")},1e4),-1==a.inArray(g.text(),h)?(k.removeClass("active"),g.addClass("active").prependTo(j),j.scrollTop(0),j.trigger("attachstop.notify",[g])):j.trigger("attachcancel.notify",[g])}),d.on("detach.notify",e.items,function(b){var c=a(this),d=c.parents("div.notifier");d.trigger("detachstart.notify",[c]),
+// Prepare item removal
+d.one("movestop.notify",function(b){var d=a(this),e=d.scrollTop();
+// Adjust offset
+e>0&&d.scrollTop(e-c.outerHeight()),
+// Remove item
+c.remove(),d.trigger("detachstop.notify",[c])}),
+// Fade item
+c.animate({opacity:0},"normal",function(){
+// No other items
+0==c.siblings().length?d.trigger("resize.notify",[a("<div />")]):d.trigger("move.notify"),
+// Remove item
+c.remove(),d.trigger("detachstop.notify",[c])})}),d.on("resize.notify attachstop.notify","div.notifier",function(b,c){var d=a(this);
+// Adjust height
+if(!d.hasClass("constructing")){var e=c||d.find(".active:not(:animated)");d.show().animate({height:e.innerHeight()||0},100)}}),d.on("attachstop.notify detachstop.notify","div.notifier",function(b){var c=a(this),d=c.find(e.items);
+// Hide navigator
+1==d.length?d.find("nav").hide():d.find("nav").show()}),d.on("click","nav",function(b){var c=(a(this),a(this).closest("div.notifier"));
+// Move messages
+c.trigger("move.notify")}),d.on("move.notify","div.notifier",function(b){var c,d=a(this),f=d.find(".active"),g=f.next(e.items),h=f.outerHeight();d.trigger("movestart.notify"),
+// Deactivate current message
+f.removeClass("active"),
+// Activate next message and get offset
+g.length>0?(g.addClass("active"),c=d.scrollTop()+h):(g=d.find(e.items).first().addClass("active"),c=0),
+// If next's height is not the same, resize first
+g.outerHeight()!==h&&d.trigger("resize.notify"),
+// Move to next message
+d.animate({scrollTop:c},"fast",function(){d.trigger("movestop.notify")})}),d.on("click","a.ignore",function(c){var d,f=a(this),g=f.parents(e.items),h=(g.parents("div.notifier"),g.text());
+// Store exclusion rule
+if(b.Support.localStorage===!0)
+// Put in a try/catch incase we exceed storage space
+try{d=window.localStorage[e.storage]?a.parseJSON(window.localStorage[e.storage]):[],d.push(h),window.localStorage[e.storage]=JSON.stringify(d)}catch(i){window.onerror(i.message)}
+// Remove item
+g.trigger("detach.notify")}),d.each(function(){var b=a(this),c=a('<div class="notifier" />').hide().prependTo(b),d=a(b.find(e.items).get().reverse());
+// Construct notifier
+c.addClass("constructing"),c.height(d.last().innerHeight()),d.each(function(){var c=a(this).remove(),d=c.html(),e=c.attr("class");b.trigger("attach.notify",[d,e])}),
+// Resize notifier
+c.find(e.items).length>0&&c.removeClass("constructing").trigger("resize.notify"),c.removeClass("constructing"),
+// Update relative times in system messages
+setInterval(function(){a("header p.notice").symphonyTimeAgo()},6e4)}),d}}(window.jQuery,window.Symphony),/**
+ * @package assets
+ */
+function(a,b){/**
+	 * Drawers are hidden areas in the backend that are used to
+	 * display additional content on request. There are three different
+	 * types of drawers: horizontal, vertical left and vertical right.
+	 *
+	 * @name $.symphonyDrawer
+	 * @class
+	 *
+	 * @param {Object} options An object specifying containing the attributes specified below
+	 * @param {Integer} [options.verticalWidth=300] Width of the vertical drawers
+	 * @param {String} [options.speed='fast'] Animation speed
+	 *
+	 * @example
+
+			$('.drawer').symphonyDrawer();
+	 */
+a.fn.symphonyDrawer=function(c){var d=this,e=a("#wrapper"),f=a("#contents"),g=f.find("> form"),h={verticalWidth:300,speed:"fast"};a.extend(h,c),/*-------------------------------------------------------------------------
+		Events
+	-------------------------------------------------------------------------*/
+// Expand drawer
+d.on("expand.drawer",function(c,d,f){var j=a(this),k=j.data("position"),l=a(".button.drawer"),m=l.filter('[href="#'+j.attr("id")+'"]'),n=l.filter("."+k),o=j.data("context")?"."+j.data("context"):"",p=i();
+// store state
+if(j.trigger("expandstart.drawer"),d="undefined"==typeof d?h.speed:d,f="undefined"==typeof f?!1:!0,n.removeClass("selected"),a(".drawer."+k).filter(function(b){return a(this).data("open")}).trigger("collapse.drawer",[d,!0]),"vertical-left"===k?j.css({width:0,height:p,display:"block"}).animate({width:h.verticalWidth},{duration:d,step:function(a,b){g.css("margin-left",a+1)},complete:function(){g.css("margin-left",h.verticalWidth+1),j.trigger("expandstop.drawer")}}):"vertical-right"===k?j.css({width:0,height:p,display:"block"}).animate({width:h.verticalWidth},{duration:d,step:function(a,b){g.css("margin-right",a+1)},complete:function(){g.css("margin-right",h.verticalWidth+1),j.trigger("expandstop.drawer")}}):"horizontal"===k&&j.animate({height:"show"},{duration:d,complete:function(){j.trigger("expandstop.drawer")}}),m.addClass("selected"),b.Support.localStorage===!0)
+// Put in a try/catch incase we exceed storage space
+try{window.localStorage["symphony.drawer."+j.attr("id")+o]="opened"}catch(q){window.onerror(q.message)}e.addClass("drawer-"+k),j.data("open",!0)}),
+// Collapse drawer
+d.on("collapse.drawer",function(c,d,f){var i=a(this),j=i.data("position"),k=a(".button.drawer"),l=k.filter('[href="#'+i.attr("id")+'"]'),m=i.data("context")?"."+i.data("context"):"";
+// store state
+if(i.trigger("collapsestart.drawer"),d="undefined"==typeof d?h.speed:d,f="undefined"==typeof f?!1:!0,l.removeClass("selected"),"vertical-left"===j?i.animate({width:0},{duration:d,step:function(a,b){f||g.css("margin-left",a)},complete:function(){i.css({display:"none"}).trigger("collapsestop.drawer")}}):"vertical-right"===j?i.animate({width:0},{duration:d,step:function(a,b){f||g.css("margin-right",a)},complete:function(){i.css({display:"none"}).trigger("collapsestop.drawer")}}):"horizontal"===j&&i.animate({height:"hide"},{duration:d,complete:function(){i.trigger("collapsestop.drawer")}}),b.Support.localStorage===!0)
+// Put in a try/catch incase we exceed storage space
+try{window.localStorage["symphony.drawer."+i.attr("id")+m]="closed"}catch(n){window.onerror(n.message)}e.removeClass("drawer-"+j),i.data("open",!1)}),
+// Resize drawers
+a(window).on("resize.drawer load.drawer",function(){var a=i();d.filter(".vertical-left, .vertical-right").css("height",a)});/*-------------------------------------------------------------------------
+		Utilities
+	-------------------------------------------------------------------------*/
+var i=function(){var a=Math.max(window.innerHeight-f[0].offsetTop-1,f[0].clientHeight);return a};/*-----------------------------------------------------------------------*/
+/*-------------------------------------------------------------------------
+		Initialisation
+	-------------------------------------------------------------------------*/
+return d.each(function(){var c,d=a(this),e=(d.data("position"),a('.button.drawer[href="#'+d.attr("id")+'"]')),f=d.data("context")?"."+d.data("context"):"";
+// Initial state
+"opened"===d.data("default-state")&&d.data("open",!0),
+// Restore state
+b.Support.localStorage===!0&&(c=window.localStorage["symphony.drawer."+d.attr("id")+f],"opened"===c?d.data("open",!0):"closed"===c&&d.data("open",!1)),
+// Click event for the related button
+e.on("click.drawer",function(a){a.preventDefault(),d.data("open")?d.trigger("collapse.drawer"):d.trigger("expand.drawer")}),d.data("open")?d.trigger("expand.drawer",[0]):d.trigger("collapse.drawer",[0,!0])}),d}}(window.jQuery,window.Symphony),/**
+ * @package assets
+ */
+function(a,b,c){"use strict";/**
+	 * Symphony calendar interface.
+	 */
+b.Interface.Calendar=function(){var d,e,f,g,h,i,j='<div class="calendar"><nav><a class="clndr-previous-button">previous</a><div class="switch"><ul class="months"><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li></ul><ul class="years"><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li></ul></div><a class="clndr-next-button">next</a></nav><table><thead><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr></thead><tbody><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr><tr><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td><td><span></span></td></tr></tbody></table></div>',k=function(h){
+// Don't continue to build the calendar if we don't have a format
+// to work with. RE: #2306
+// Don't continue to build the calendar if we don't have a format
+// to work with. RE: #2306
+// Set locale
+// Create calendar
+/**
+			 * Events
+			 *
+			 * Use `mousedown` instead of `click` event in order to prevent 
+			 * conflicts with suggestions and other core plugins.
+			 */
+// Switch sheets
+// Handle current date
+return d=a(h),e=d.find(".calendar"),f=d.find("input"),g=e.attr("data-format"),void 0===g?void z(e):(c.locale(b.Elements.html.attr("lang")),x(),y(),q(),e.on("mousedown.calendar","a, .clndr",function(a){a.stopPropagation(),a.preventDefault()}),e.on("mousedown.calendar",".switch",l),e.on("mousedown.calendar",".months li",m),e.on("mousedown.calendar",".years li",n),f.on("focus.calendar",o),void f.on("input.calendar",p))},l=function(c){var d;c.stopPropagation(),c.preventDefault(),d=e.find(".switch"),d.addClass("select"),b.Elements.body.on("click.calendar",function(c){var e=a(c.target);e.parents(".switch").length||(d.removeClass("select"),b.Elements.body.off("click.calendar"))})},m=function(a){a.preventDefault(),i.setMonth(a.target.textContent)},n=function(a){a.preventDefault(),i.setYear(a.target.textContent)},o=function(){i.setMonth(h.get("month")),i.setYear(h.get("year"))},p=function(){x(),o()},q=function(){i=e.clndr({startWithMonth:h,showAdjacentMonths:!0,adjacentDaysChangeMonth:!0,forceSixRows:!0,render:r,clickEvents:{click:w}})},r=function(a){var b=j.clone(),d=c().month(a.month).get("month");return b=s(b,a),b=t(b,a,d),b=u(b,a),b=v(b,a),b.html()},s=function(a,b){return a.find("thead td").each(function(a){this.textContent=b.daysOfTheWeek[a]}),a},t=function(a,b,d){return a.find(".months li").each(function(a){this.textContent=c().month(d-6+a).format("MMMM")}),a},u=function(a,b){return a.find(".years li").each(function(a){this.textContent=b.year-6+a}),a},v=function(a,b){return a.find("tbody td span").each(function(a){var c=b.days[a];this.textContent=c.day,this.setAttribute("class",c.classes),c.date.isSame(h,"day")&&this.classList.add("active")}),a},w=function(a){var b=a.date;h.set("year",b.year()),h.set("month",b.month()),h.set("date",b.date()),f.val(h.format(g)),e.find(".active").removeClass("active"),a.element.classList.add("active")},x=function(){var a=f.val();h=a?c(a,g):c({hour:0,minute:0,seconds:0})},y=function(){j=a(j)},z=function(d){var e=b.Language.get("The Symphony calendar widget has been disabled because your system date format is currently not supported. Try one of the following instead or disable the calendar in the field settings:"),f=b.Context.get("datetime"),g=[];
+// Hide calendar
+d.addClass("hidden"),
+// Suggest supported date formats
+a.each(f.formats,function(a,d){var e="";-1!==a.indexOf("j")&&-1!==a.indexOf("n")&&(e=" – "+b.Language.get("no leading zero")),g.push(" - "+a+" ("+c().format(d)+e+")")}),console.info(e+"\n\n"+g.join("\n"))};
+// API
+return{init:k}}}(window.jQuery,window.Symphony,window.moment),/**
+ * @package assets
+ */
+function(a,b){"use strict";/**
+	 * Filtering interface for the publish area.
+	 */
+b.Interface.Filtering=function(){var c,d,e,f=[],g=function(){c=b.Elements.context.find(".filtering"),d=c.find(".filters-duplicator"),e=d.find(".apply"),r(),s(),o(),d.on("constructstop.duplicator destructstart.duplicator",".instance",o),c.on("keyup.filtering",".filter",h),c.on("change.filtering",".filter",h),d.on("destructstop.duplicator",k),d.on("constructstop.duplicator",".instance",j),c.on("change",".comparison",j),c.find(".instance").each(j),b.Interface.Suggestions.init(c,".filter")},h=function(b){var c=a(b.target);(13===b.keyCode||c.is(".apply-filters")||c.is(".updated"))&&(b.preventDefault(),b.stopPropagation(),k())},i=function(a){a.preventDefault(),a.stopPropagation(),m()},j=function(){var b,c=a(this);
+// Show help contextually
+c.is(".instance")?b=c.find(".comparison").val():(b=c.val(),c=c.parents(".instance")),n(c,b)},k=function(){var a,c,d=l();a=b.Context.get("symphony")+b.Context.get("route"),c=a+(""!==d?"?":"")+d,window.location=c},l=function(){var b=[];return c.find(".instance:not(.template):visible").each(function(){var c,d=a(this),e=a.trim(d.find(".comparison").val()),f=d.find(".filter");e&&(e+=" "),c="filter["+f.attr("name")+"]="+e+a.trim(f.val()),b.push(c)}),b.join("&")},m=function(){window.location=b.Context.get("symphony")+b.Context.get("route")},n=function(a,b){var c=a.find(".suggestions .help");b||(b="is"),c.removeClass("active"),c.filter('[data-comparison="'+b+'"]').addClass("active")},o=function(){d.find(".instance:not(.template)").length?p():q()},p=function(){f.apply.prop("disabled",!1),f.apply.removeAttr("disabled"),f.clear.show()},q=function(){f.apply.prop("disabled",!0),f.clear.hide()},r=function(){f.apply=a("<button/>",{text:b.Language.get("Apply filters"),"class":"apply-filters",click:h}).insertBefore(e)},s=function(){f.clear=a("<button/>",{text:b.Language.get("Clear filters"),"class":"clear-filters delete",click:i}).insertBefore(e)};/*-------------------------------------------------------------------------
+		Public API
+	-------------------------------------------------------------------------*/
+return{init:g}}()}(window.jQuery,window.Symphony),/**
+ * @package assets
+ */
+function(a,b){"use strict";b.Interface.Suggestions=function(){var c,d=function(b,d){c=a(b),c.find(d).each(function(){this.autocomplete="off"}),t(d),c.on("input.suggestions",d,e),c.on("click.suggestions",d,e),c.on("focus.suggestions",d,e),c.on("keyup.suggestions",d,e),c.on("mouseover.suggestions",".suggestions li:not(.help):not(.calendar)",f),c.on("mouseout.suggestions",".suggestions li:not(.help):not(.calendar)",g),c.on("mousedown.suggestions",".suggestions li:not(.help):not(.calendar)",i),c.on("keydown.suggestions",d,h)},e=function(b){var c=a(this),d=c.val(),e=c.next(".suggestions"),f=e.attr("data-search-types"),g=c.attr("data-trigger");
+// Stop when navigating the suggestion list
+-1===jQuery.inArray(b.which,[13,27,38,40])&&(
+// Dates
+f&&-1!==f.indexOf("date")?n(c):d&&g?j(c,e,d,g):d||f&&-1!==f.indexOf("static")?k(c,d):q(e))},f=function(b){var c=a(b.target);c.siblings("li:not(.help)").removeClass("active"),c.addClass("active")},g=function(b){var c=a(b.target);c.removeClass("active")},h=function(b){var c,d=a(this);
+// Down
+40==b.which?(b.preventDefault(),s(d)):38==b.which?(b.preventDefault(),r(d)):27==b.which?(b.preventDefault(),d.blur()):13==b.which&&(b.preventDefault(),c=d.next(".suggestions").find("li:not(.help).active").text(),c&&o(c,d))},i=function(b){var c=a(b.target).parent(".suggestions").prev("input");o(b.target.textContent,c)},j=function(a,b,c,d){var e=a[0].selectionStart||0,f=c.substring(0,e).split(" "),g=c.substr(e).split(" "),h=f[f.length-1],i=f[f.length-1]+g[0];
+// Token found
+h&&0===h.indexOf(d)?k(a,i):q(b)},k=function(c,d){var e,f,g,h=c.next(".suggestions"),i=h.attr("data-search-types"),j=c.attr("data-trigger"),k=d;
+// Prefix
+j&&(e=j.substr(0,1)),
+// Get value
+k||(k=c.val()),"{"===e&&(k=k.substr(1)),
+// Get data
+i&&-1!==i.indexOf("parameters")?(g=b.Context.get("symphony")+"/ajax/parameters/",f={query:k}):(g=b.Context.get("symphony")+"/ajax/query/",f={field_id:h.attr("data-field-id"),query:k,types:i}),
+// Get custom url
+c.attr("data-url")&&(g=c.attr("data-url")),
+// Load suggestions
+k!==h.attr("data-last-query")&&(h.attr("data-last-query",k),a.ajax({type:"GET",url:g,data:f,success:function(a){i&&-1!==i.indexOf("parameters")?l(c,h,a):m(h,a)}}))},l=function(b,c,d){var e,f=c.clone(),g=f.find(".help:first"),h=b.attr("data-trigger");
+// Prefix
+h&&(e=h.substr(0,1)),
+// Clear existing suggestions
+q(f),
+// Add suggestions
+a.each(d,function(b,c){if("status"!==b){"{"===e&&(c="{"+c+"}");var d=a("<li />",{text:c});g.length?d.insertBefore(g):f.append(d)}}),c.replaceWith(f)},m=function(b,c){var d=b.clone(),e=d.find(".help:first"),f=[];
+// Clear existing suggestions
+q(d),
+// Add suggestions
+c.entries&&(a.each(c.entries,function(a,b){f.push(b.value)}),f=f.filter(function(a,b,c){return c.indexOf(a)===b}),a.each(f,function(b,c){var f=a("<li />",{text:c});e?f.insertBefore(e):d.append(f)}),b.replaceWith(d))},n=function(a){var b=a.next(".suggestions"),c=b.find(".calendar");c.length||u(b)},o=function(a,b){var c=b.attr("data-search-types");c&&-1!==c.indexOf("parameters")?p(a,b):(a=a.replace(/,/g,"\\,").replace(/&/g,"%26"),b.val(a),b.addClass("updated"),b.change()),q(b.next(".suggestions"))},p=function(a,b){var c=b.val(),d=b[0].selectionStart||0,e=c.substring(0,d).split(" "),f=c.substr(d).split(" "),g="",h="";
+// Get text before parameter
+e.length>1&&(e.pop(),g=e.join(" ")+" "),
+// Get text after parameter
+f.length>1&&(f.shift(),h=" "+f.join(" ")),
+// Insert suggestion
+b.val(g+a+h);
+// Set cursor
+var i=g.length+a.length;b[0].selectionStart=i,b[0].selectionEnd=i,b.focus()},q=function(a){a.removeAttr("data-last-query"),a.find("li:not(.help)").remove()},r=function(a){var b=a.next(".suggestions"),c=b.find("li:not(.help).active").removeClass("active"),d=c.prev("li:not(.help):visible");
+// First
+0===c.length||0===d.length?b.find("li:not(.help)").last().addClass("active"):d.addClass("active"),v(b)},s=function(a){var b=a.next(".suggestions"),c=b.find("li:not(.help).active").removeClass("active"),d=c.next("li:not(.help):visible");
+// First
+0===c.length||0===d.length?b.find("li:not(.help)").first().addClass("active"):d.addClass("active"),v(b)},t=function(b){var d=c.find(b);d.each(function(){var b,c,d=a(this),e=d.next(".suggestions");e.length||(b=a('<ul class="suggestions" />'),c=d.attr("data-search-types"),c&&b.attr("data-search-types",c),b.insertAfter(d))})},u=function(a){var c=new b.Interface.Calendar;a.prepend('<li class="calendar" data-format="YYYY-MM-DD" />'),c.init(a.parents("label"))},v=function(a){var b,c=a.find("li.active");
+// Get distance
+b=c.is(":visible:first")?0:(c.prevAll().length+1)*c.outerHeight()-180,a.animate({scrollTop:b},150)};/*-------------------------------------------------------------------------
+		API
+	-------------------------------------------------------------------------*/
+return{init:d}}(),/**
+	 * Symphony suggestion plugin for jQuery.
+	 *
+	 * @deprecated As of Symphony 2.6.0 this plugin is deprecated,
+	 *  use `Symphony.Interface.Suggestions` instead. This will be
+	 *  removed in Symphony 3.0
+	 */
+a.fn.symphonySuggestions=function(c){var d=this,e={trigger:"{$",source:b.Context.get("path")+"/ajax/parameters/"};return a.extend(e,c),d.each(function(){var c=a(this).find('input[type="text"]');c.attr("data-trigger",e.trigger),c.attr("data-url",e.source),c.attr("data-search-types","parameters"),b.Interface.Suggestions.init(this,'input[type="text"]')}),d}}(window.jQuery,window.Symphony),/**
+ * Symphony backend initialisation
+ *
+ * @package assets
+ */
+function(a,b){
+// Set environment
+var c=function(){var a=document.getElementById("environment");return a?JSON.parse(a.textContent):{}}();b.Context.add(null,c),
+// Get translations
+b.Language.add({"Are you sure you want to proceed?":!1,"Reordering was unsuccessful.":!1,"Change Password":!1,"Remove File":!1,"Untitled Field":!1,"The field “{$title}” ({$type}) has been removed.":!1,"Undo?":!1,untitled:!1,"Expand all":!1,"Collapse all":!1,"drag to reorder":!1,"Please reset your password":!1,required:!1,"Click to select":!1,"Type to search":!1,Clear:!1,"Search for {$item}":!1,"Add filter":!1,filtered:!1,None:!1,"Clear filters":!1,"Apply filters":!1,"The Symphony calendar widget has been disabled because your system date format is currently not supported. Try one of the following instead or disable the calendar in the field settings:":!1,"no leading zero":!1}),
+// Initialise backend
+a(document).ready(function(){
+// Cache main elements
+b.Elements.window=a(window),b.Elements.html=a("html").addClass("js-active"),b.Elements.body=a("body"),b.Elements.wrapper=a("#wrapper"),b.Elements.header=a("#header"),b.Elements.nav=a("#nav"),b.Elements.session=a("#session"),b.Elements.context=a("#context"),b.Elements.breadcrumbs=a("#breadcrumbs"),b.Elements.contents=a("#contents");
+// Create context id
+var c=b.Context.get("path"),d=b.Context.get("route");if(c&&d){var e=(c+d).split("/").filter(function(a){return"edit"!=a&&"new"!=a&&"created"!=a&&"saved"!=a&&""!=a}).join(".");b.Context.add("context-id",e)}
+// Render view
+b.View.render()})}(window.jQuery,window.Symphony),/**
+ * Symphony backend views
+ *
+ * @package assets
+ */
+function(a,b){/*--------------------------------------------------------------------------
+	General backend view
+--------------------------------------------------------------------------*/
+b.View.add("/:context*:",function(){
+// Initialise core plugins
+b.Elements.contents.find("select.picker[data-interactive]").symphonyPickable(),b.Elements.contents.find("ul.orderable[data-interactive]").symphonyOrderable(),b.Elements.contents.find("table.selectable[data-interactive]").symphonySelectable(),b.Elements.wrapper.find(".filters-duplicator[data-interactive]").symphonyDuplicator(),b.Elements.wrapper.find(".tags[data-interactive]").symphonyTags(),b.Elements.wrapper.find("div.drawer").symphonyDrawer(),b.Elements.header.symphonyNotify(),
+// Fix for Webkit browsers to initially show the options. #2127
+a("select[multiple=multiple]").scrollTop(0),
+// Initialise tag lists inside duplicators
+b.Elements.contents.find(".duplicator").on("constructshow.duplicator",".instance",function(){a(this).find(".tags[data-interactive]").symphonyTags()}),
+// Navigation sizing
+b.Elements.window.on("resize.admin nav.admin",function(){var a=b.Elements.nav.find("ul.content"),c=b.Elements.nav.find("ul.structure"),d=a.width()+c.width()+20;
+// Compact mode
+d>window.innerWidth?b.Elements.nav.removeClass("wide"):b.Elements.nav.addClass("wide")}).trigger("nav.admin"),
+// Accessible navigation
+b.Elements.nav.on("focus.admin blur.admin","a",function(){a(this).parents("li").eq(1).toggleClass("current")}),
+// Notifier sizing
+b.Elements.window.on("resize.admin",function(){b.Elements.header.find(".notifier").trigger("resize.notify")}),
+// Table sizing
+b.Elements.window.on("resize.admin table.admin",function(){var a=b.Elements.contents.find("table:first");
+// Fix table size, if width exceeds the visibile viewport area.
+a.width()>b.Elements.html.width()?a.addClass("fixed"):a.removeClass("fixed")}).trigger("table.admin");
+// Orderable tables
+var c=null,d=b.Elements.contents.find("table.orderable[data-interactive]");d=d.filter(function(){return a(this).find("tbody tr").length>1}),d.symphonyOrderable({items:"tr",handles:"td"}).on("orderstart.orderable",function(){c=a(this).find("input").map(function(a){return this.name+"="+(a+1)}).get().join("&")}).on("orderstop.orderable",function(){var e=d.find("input").map(function(a){return this.name+"="+(a+1)}).get().join("&");d.addClass("busy"),null!==c&&e!==c?(d.trigger("orderupdate.admin"),e=e+"&"+b.Utilities.getXSRF(!0),a.ajax({type:"POST",url:b.Context.get("symphony")+"/ajax/reorder"+b.Context.get("route"),data:e,error:function(){b.Message.post(b.Language.get("Reordering was unsuccessful."),"error")},complete:function(){d.removeClass("busy").find("tr").removeClass("selected")}})):d.removeClass("busy")}),d.length&&b.Elements.breadcrumbs.append('<p class="inactive"><span> – '+b.Language.get("drag to reorder")+"</span></p>"),b.Elements.contents.find("fieldset.apply").each(function(){var c=a(this),d=b.Elements.contents.find("table.selectable"),e=c.find("select"),f=c.find("button");d.length>0&&(d.on("select.selectable deselect.selectable check.selectable","tbody tr",function(){d.has(".selected").length>0?(c.removeClass("inactive"),e.removeAttr("disabled")):(c.addClass("inactive"),e.attr("disabled","disabled"))}),d.find("tbody tr:first").trigger("check"),f.on("click.admin",function(){return c.is(".inactive")?!1:void 0}))}),b.Elements.contents.add(b.Elements.context).on("click.admin","button.confirm",function(){var c=a(this).attr("data-message")||b.Language.get("Are you sure you want to proceed?");return confirm(c)}),b.Elements.contents.find("> form").on("submit.admin",function(){var c=a('select[name="with-selected"]'),d=c.find("option:selected"),e=d.attr("data-message")||b.Language.get("Are you sure you want to proceed?");return d.is(".confirm")?confirm(e):void 0}),b.Elements.window.on("error.admin",function(c){a.ajax({type:"POST",url:b.Context.get("symphony")+"/ajax/log/",data:{error:c.originalEvent.message,url:c.originalEvent.filename,line:c.originalEvent.lineno,xsrf:b.Utilities.getXSRF()}})})}),b.View.add("/publish/:context*:",function(){
+// Filtering
+b.Interface.Filtering.init(),
+// Pagination
+b.Elements.contents.find(".page").each(function(){var b,c=a(this),d=c.find("form"),e=d.find("input"),f=e.attr("data-active"),g=e.attr("data-inactive"),h=a("<span />").appendTo(d);b=Math.max(h.text(f).width(),h.text(g).width()),e.width(b+20),h.remove(),e.val(g),d.on("mouseover.admin",function(){d.is(".active")||e.val()!=g||e.val(f)}),d.on("mouseout.admin",function(){d.is(".active")||e.val()!=f||e.val(g)}),e.on("focus.admin",function(){e.val()==f&&e.val(""),d.addClass("active")}),e.on("blur.admin",function(){(d.is(".invalid")||""===e.val())&&(d.removeClass("invalid"),e.val(g)),e.val()==g&&d.removeClass("active")}),d.on("submit.admin",function(){return parseInt(e.val(),10)>parseInt(e.attr("data-max"),10)?(d.addClass("invalid"),!1):void 0})}),
+// Upload field destructors
+a("<em />",{text:b.Language.get("Remove File"),on:{click:function(b){b.preventDefault();var c=a(this).parent(),d=c.find("input").attr("name");c.empty().append('<input name="'+d+'" type="file">')}}}).appendTo("label.file:has(a) span.frame"),
+// Calendars
+a(".field-date").each(function(){var c,d=a(this),e=b.Context.get("datetime");
+// Add calendar widget
+d.attr("data-interactive")&&(c=new b.Interface.Calendar,c.init(this)),
+// Add timezone offset information
+moment().utcOffset()!==e["timezone-offset"]&&d.addClass("show-timezone")})}),b.View.add("/:context*:/new",function(){b.Elements.contents.find('input[type="text"], textarea').first().focus()}),/*--------------------------------------------------------------------------
+	Blueprints - Pages Editor
+--------------------------------------------------------------------------*/
+b.View.add("/blueprints/pages/:action:/:id:/:status:",function(){}),/*--------------------------------------------------------------------------
+	Blueprints - Sections
+--------------------------------------------------------------------------*/
+b.View.add("/blueprints/sections/:action:/:id:/:status:",function(c,d,e){var f,g,h,i=a("#fields-duplicator"),j=a("#fields-legend");
+// Restore collapsible states for new sections
+if(f=a("<a />",{"class":"expand",text:b.Language.get("Expand all")}),g=a("<a />",{"class":"collapse",text:b.Language.get("Collapse all")}),h=a("<p />",{"class":"help toggle"}),h.append(f).append("<br />").append(g).insertAfter(j),h.on("click.admin","a.expand, a.collapse",function(){a(this).is(".expand")?i.trigger("expandall.collapsible"):i.trigger("collapseall.collapsible")}),a("fieldset.settings > legend + .help").symphonyAffix(),i.symphonyDuplicator({orderable:!0,collapsible:!0,preselect:"input"}),i.on("constructshow.duplicator",".instance",function(){var c,d=a(this),e=d.find(".js-fetch-sections"),f=e.parent(),g=[];e.length&&(c=e.find("option").each(function(){g.push(this.value),isNaN(this.value)||a(this).remove()}),a.ajax({type:"GET",dataType:"json",url:b.Context.get("symphony")+"/ajax/sections/",success:function(c){e.detach(),c.sections.length&&e.prop("disabled",!1);var d=a();e.attr("data-required")||(d=d.add(a("<option />",{text:b.Language.get("None"),value:""}))),a.each(c.sections,function(b,c){var e=a("<optgroup />",{label:c.name});d=d.add(e),a.each(c.fields,function(b,c){var d=a("<option />",{value:c.id,text:c.name}).appendTo(e);a.inArray(c.id,g)>-1&&d.prop("selected",!0)})}),e.append(d),f.append(e),e.trigger("change.admin")}}))}),i.find(".instance").trigger("constructshow.duplicator"),i.on("constructshow.duplicator expandstop.collapsible",".instance",function(){var b=a(this);b.hasClass("js-animate-all")||a(this).find("input:visible:first").trigger("focus.admin")}),i.on("blur.admin input.admin",'.instance input[name*="[label]"]',function(){var c=a(this),d=c.val();""===d&&(d=b.Language.get("Untitled Field")),c.parents(".instance").find(".frame-header strong").text(d)}),i.on("change.admin",'.instance select[name*="[location]"]',function(){var b=a(this);b.parents(".instance").find(".frame-header").removeClass("main").removeClass("sidebar").addClass(b.val())}),i.on("change.admin",'.instance input[name*="[required]"]',function(){var c=a(this),d=c.parents(".instance").find(".frame-header h4");c.is(":checked")?a("<span />",{"class":"required",text:"— "+b.Language.get("required")}).appendTo(d):d.find(".required").remove()}),i.find('.instance input[name*="[required]"]').trigger("change.admin"),i.on("change.admin",'.instance select[name*="[dynamic_options]"]',function(){a(this).parents(".instance").find("[data-condition=associative]").toggle(a.isNumeric(this.value))}).trigger("change.admin"),i.on("change.admin",'.instance select[name*="[pre_populate_source]"]',function(){var b=a(this).val(),c=!1;b&&(b=jQuery.grep(b,function(a){return"existing"!=a}),c=b.length>0),a(this).parents(".instance").find("[data-condition=associative]").toggle(c)}).trigger("change.admin"),i.on("destructstart.duplicator",function(c){var d=a(c.target),e=d.clone(),f=e.find(".frame-header strong").text(),g=e.find(".frame-header span").text(),h=d.index(),i=(new Date).getTime();b.Elements.header.find("div.notifier").trigger("attach.notify",[b.Language.get("The field “{$title}” ({$type}) has been removed.",{title:f,type:g})+'<a id="'+i+'">'+b.Language.get("Undo?")+"</a>","protected undo"]),a("#"+i).data("field",e).data("preceding",h-1).on("click.admin",function(){var b=a(this),c=b.parent(),d=b.data("field").hide(),e=a("#fields-duplicator");e.parent().removeClass("empty"),d.trigger("constructstart.duplicator"),e.find(".instance:eq("+b.data("preceding")+")").after(d),d.trigger("constructshow.duplicator"),d.slideDown("fast",function(){d.trigger("constructstop.duplicator")}),c.trigger("detach.notify")})}),i.on("orderstop.orderable",function(){b.Elements.header.find(".undo").trigger("detach.notify")}),i.on("orderstart.orderable",function(b,c){var d=a(this),e=c.find(".frame-header"),f=e.is(".main")?"main":"sidebar";d.find("li:has(."+f+")").not(c).addClass("highlight")}),i.on("orderstop.orderable",function(){a(this).find("li.highlight").removeClass("highlight")}),"created"===e){var k=(i.find(".instance"),b.Context.get("context-id"));k=k.split("."),k.pop(),k="symphony.collapsible."+k.join(".")+".0.collapsed",b.Support.localStorage===!0&&window.localStorage[k]&&(a.each(window.localStorage[k].split(","),function(a,b){var c=i.find(".instance").eq(b);0==c.has(".invalid").length&&c.trigger("collapse.collapsible",[0])}),window.localStorage.removeItem(k))}}),/*--------------------------------------------------------------------------
+	Blueprints - Datasource Editor
+--------------------------------------------------------------------------*/
+b.View.add("/blueprints/datasources/:action:/:id:/:status:/:*:",function(c){if(c){var d=a("#ds-context"),e=a("#ds-source"),f=b.Elements.contents.find('input[name="fields[name]"]').attr("data-updated",0),g=0,h=b.Elements.contents.find('select[name="fields[param][]"]'),i=b.Elements.contents.find(".pagination"),j=i.find("input");
+// Update data source handle
+f.on("blur.admin input.admin",function(){var c=g+=1,d=f.val();setTimeout(function(c,d,e){c==d&&a.ajax({type:"GET",data:{string:e},dataType:"json",url:b.Context.get("symphony")+"/ajax/handle/",success:function(a){c==d&&(f.data("handle",a.handle),h.trigger("update.admin"))}})},500,g,c,d)}).symphonyDefaultValue({sourceElement:d}),
+// Update output parameters
+h.on("update.admin",function(){var c=f.data("handle")||b.Language.get("untitled");
+// Process parameters
+0!==parseInt(f.attr("data-updated"))&&h.find("option").each(function(){var b=a(this),d=b.attr("data-handle");
+// Set parameter
+b.text("$ds-"+c+"."+d)}),
+// Updated
+f.attr("data-updated",1)}).trigger("update.admin"),
+// Data source manager options
+b.Elements.contents.find(".contextual select optgroup").each(function(){var b=a(this),c=b.parents("select"),e=b.attr("data-label"),f=b.remove().find("option").addClass("optgroup");
+// Show only relevant options based on context
+d.on("change.admin",function(){var b=a(this).find("option:selected"),d=b.attr("data-context")||"section-"+b.val();d==e&&(c.find("option.optgroup").remove(),c.append(f.clone(!0)))})}),
+// Data source manager context
+d.on("change.admin",function(){var a=d.find("option:selected").parent(),c=a.attr("data-label")||a.attr("label"),f=d.find("option:selected").attr("data-context")||"section-"+d.val(),g=b.Elements.contents.find(".contextual");
+// Store context
+e.val(d.val()),
+// Show only relevant interface components based on context
+g.addClass("irrelevant"),g.filter("[data-context~="+c+"]").removeClass("irrelevant"),g.filter("[data-context~="+f+"]").removeClass("irrelevant"),
+// Make sure parameter names are up-to-date
+b.Elements.contents.find('input[name="fields[name]"]').trigger("blur.admin")}).trigger("change.admin"),
+// Toggle pagination
+b.Elements.contents.find("input[name*=paginate_results]").on("change.admin",function(){var b=!a(this).is(":checked");j.prop("disabled",b)}).trigger("change.admin"),
+// Enabled fields on submit
+b.Elements.contents.find("> form").on("submit.admin",function(){j.prop("disabled",!1)}),
+// Enable parameter suggestions
+b.Elements.contents.find(".filters-duplicator, .ds-param").each(function(){b.Interface.Suggestions.init(this,'input[type="text"]')}),
+// Toggle filter help
+b.Elements.contents.find(".filters-duplicator").on("input.admin change.admin","input",function(b){var c=a(b.target).parents(".instance"),d=b.target.value,e=c.data("filters"),f=c.find(".help"),g=d.search(/:/)?a.trim(d.split(":")[0]):a.trim(d);
+// Store filters
+e||(e={},c.find(".tags li").each(function(){var b=a.trim(this.getAttribute("data-value"));b.search(/:/)&&(b=b.slice(0,-1)),e[b]=this.getAttribute("data-help")}),c.data("filters",e)),
+// Filter help
+e[g]&&f.html(e[g])})}}),/*--------------------------------------------------------------------------
+	Blueprints - Event Editor
+--------------------------------------------------------------------------*/
+b.View.add("/blueprints/events/:action:/:name:/:status:/:*:",function(){var c=a("#event-context"),d=a("#event-source"),e=a("#event-filters"),f=(b.Elements.contents.find("> form"),b.Elements.contents.find('input[name="fields[name]"]').attr("data-updated",0)),g=0;
+// Update event handle
+f.on("blur.admin input.admin",function(){var a=g+=1;setTimeout(function(a,c){a==c&&b.Elements.contents.trigger("update.admin")},500,g,a)}).symphonyDefaultValue({sourceElement:c}),
+// Change context
+c.on("change.admin",function(){d.val(c.val()),b.Elements.contents.trigger("update.admin")}).trigger("change.admin"),
+// Change filters
+e.on("change.admin",function(){b.Elements.contents.trigger("update.admin")}),
+// Update documentation
+b.Elements.contents.on("update.admin",function(){""==f.val()?a("#event-documentation").empty():a.ajax({type:"GET",data:{section:c.val(),filters:e.serializeArray(),name:f.val()},dataType:"html",url:b.Context.get("symphony")+"/ajax/eventdocumentation/",success:function(b){a("#event-documentation").replaceWith(b)}})})}),/*--------------------------------------------------------------------------
+	System - Authors
+--------------------------------------------------------------------------*/
+b.View.add("/system/authors/:action:/:id:/:status:",function(c,d,e){var f=a("#password");
+// Add change password overlay
+if(!f.has(".invalid").length&&d&&!e){var g=a('<div class="password" />'),h=a('<span class="frame centered" />'),i=a("<button />",{text:b.Language.get("Change Password"),on:{click:function(a){a.preventDefault(),g.hide()}}}).attr("type","button");h.append(i),g.append(h),g.insertBefore(f)}
+// Focussed UI for password reset
+if("reset-password"==e){var j=b.Elements.contents.find("fieldset"),k=j.eq(0),l=j.eq(1),m=l.find("> legend");k.hide(),l.children().not("legend, #password").hide(),a("<p />",{"class":"help",text:b.Language.get("Please reset your password")}).insertAfter(m)}
+// Highlight confirmation promt
+b.Elements.contents.find("input, select").on("change.admin input.admin",function(){a("#confirmation").addClass("highlight")})}),/*--------------------------------------------------------------------------
+	System - Extensions
+--------------------------------------------------------------------------*/
+b.View.add("/system/extensions/:context*:",function(){b.Language.add({Enable:!1,Install:!1,Update:!1}),
+// Update controls contextually
+b.Elements.contents.find(".actions select").on("click.admin focus.admin",function(a){var c=b.Elements.contents.find("tr.selected"),d=c.filter(".extension-can-update").length,e=c.filter(".extension-can-install").length,f=c.length-d-e,g=b.Elements.contents.find('.actions option[value="enable"]'),h=[];f&&h.push(b.Language.get("Enable")),d&&h.push(b.Language.get("Update")),e&&h.push(b.Language.get("Install")),g.text(h.join("/"))})})}(window.jQuery,window.Symphony);

--- a/symphony/content/content.ajaxquery.php
+++ b/symphony/content/content.ajaxquery.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once(TOOLKIT . '/class.jsonpage.php');
-
 class contentAjaxQuery extends JSONPage
 {
     public function view()

--- a/symphony/content/content.ajaxquery.php
+++ b/symphony/content/content.ajaxquery.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @package content
+ */
+/**
+ * The AjaxQuery returns an JSON array of entries, associations and other
+ * static values, depending on the parameters received.
+ */
 
 class contentAjaxQuery extends JSONPage
 {

--- a/symphony/content/content.ajaxsections.php
+++ b/symphony/content/content.ajaxsections.php
@@ -11,7 +11,11 @@ class contentAjaxSections extends JSONPage
 {
     public function view()
     {
-        $sections = SectionManager::fetch(null, 'ASC', 'sortorder');
+        $sort = General::sanitize($_REQUEST['sort']);
+        if (empty($sort)) {
+            $sort = 'sortorder';
+        }
+        $sections = SectionManager::fetch(null, 'ASC', $sort);
         $options = array();
 
         if (is_array($sections) && !empty($sections)) {

--- a/symphony/content/content.ajaxsections.php
+++ b/symphony/content/content.ajaxsections.php
@@ -41,6 +41,7 @@ class contentAjaxSections extends JSONPage
 
                 if (!empty($fields)) {
                     $options[] = array(
+                        'id' => $section->get('id'),
                         'name' => $section->get('name'),
                         'handle' => $section->get('handle'),
                         'fields' => $fields

--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -1138,8 +1138,6 @@ class contentBlueprintsDatasources extends ResourcesPage
             } else {
                 $xml_errors = null;
 
-                include_once TOOLKIT . '/class.xsltprocess.php';
-
                 General::validateXML($fields['static_xml'], $xml_errors, false, new XsltProcess());
 
                 if (!empty($xml_errors)) {

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -244,12 +244,27 @@ class contentPublish extends AdministrationPage
 
         // Custom field comparisons
         foreach ($data['operators'] as $operator) {
+            
             $filter = trim($operator['filter']);
-
+            
+            // Check selected state
+            $selected = false;
+            
+            // Selected state : Comparison mode "between" (x to y)
+            if ($operator['title'] === 'between' && preg_match('/^(-?(?:\d+(?:\.\d+)?|\.\d+)) to (-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data['filter'] )) {
+                $selected = true;
+            // Selected state : Other comparison modes (except "is")
+            } else if ((!empty($filter) && strpos($data['filter'], $filter) === 0)) {
+                $selected = true;
+            }
+	        
             $comparisons[] = array(
-                $filter,
-                (!empty($filter) && strpos($data['filter'], $filter) === 0),
-                __($operator['title'])
+                $operator['filter'],
+                $selected,
+                __($operator['title']),
+                null,
+                null,
+                array('data-comparison' => $operator['title'])
             );
         }
 
@@ -280,7 +295,7 @@ class contentPublish extends AdministrationPage
 
         $li = new XMLElement('li', __('Comparison mode') . ': ' . $operator['help'], array(
             'class' => 'help',
-            'data-comparison' => trim($operator['filter'])
+            'data-comparison' => $operator['title']
         ));
 
         $wrapper->appendChild($li);
@@ -294,7 +309,7 @@ class contentPublish extends AdministrationPage
             $filter = trim($operator['filter']);
 
             if (!empty($filter) && strpos($data['filter'], $filter) === 0) {
-                $query = substr($data['filter'], strlen($filter));
+                $query = substr($data['filter'], strlen($operator['filter']));
             }
         }
 

--- a/symphony/content/content.systemauthors.php
+++ b/symphony/content/content.systemauthors.php
@@ -600,10 +600,18 @@ class contentSystemAuthors extends AdministrationPage
         }
 
         $isOwner = ($author_id == Symphony::Author()->get('id'));
+        $fields = $_POST['fields'];
+        $this->_Author = AuthorManager::fetchByID($author_id);
+
+        $canEdit = // Managers can edit all Authors, and their own.
+                (Symphony::Author()->isManager() && $this->_Author->isAuthor())
+                // Primary account can edit all accounts.
+                || Symphony::Author()->isPrimaryAccount()
+                // Developers can edit all developers, managers and authors, and their own,
+                // but not the primary account
+                || (Symphony::Author()->isDeveloper() && $this->_Author->isPrimaryAccount() === false);
 
         if (@array_key_exists('save', $_POST['action']) || @array_key_exists('done', $_POST['action'])) {
-            $fields = $_POST['fields'];
-            $this->_Author = AuthorManager::fetchByID($author_id);
             $authenticated = false;
 
             if ($fields['email'] != $this->_Author->get('email')) {
@@ -616,15 +624,10 @@ class contentSystemAuthors extends AdministrationPage
 
                 // Developers don't need to specify the old password, unless it's their own account
             } elseif (
-
                 // All accounts can edit their own
-                $isOwner
-                    // Managers can edit all Authors, and their own.
-                || (Symphony::Author()->isManager() && $this->_Author->isAuthor())
-                    // Primary account can edit all accounts.
-                || Symphony::Author()->isPrimaryAccount()
-                    // Developers can edit all developers, managers and authors, and their own.
-                || Symphony::Author()->isDeveloper() && $this->_Author->isPrimaryAccount() === false
+                $isOwner ||
+                // Is allowed to edit?
+                $canEdit
             ) {
                 $authenticated = true;
             }
@@ -730,6 +733,26 @@ class contentSystemAuthors extends AdministrationPage
                 $this->pageAlert(__('There were some problems while attempting to save. Please check below for problem fields.'), Alert::ERROR);
             }
         } elseif (@array_key_exists('delete', $_POST['action'])) {
+            // Validate rights
+            if (!$canEdit) {
+                $this->pageAlert(__('You are not allowed to delete this author.'), Alert::ERROR);
+                return;
+            }
+            // Admin changing another profile
+            if (!$isOwner) {
+                $entered_password = Symphony::Database()->cleanValue($fields['confirm-change-password']);
+
+                if (!isset($fields['confirm-change-password']) || empty($fields['confirm-change-password'])) {
+                    $this->_errors['confirm-change-password'] = __('Please provide your own password to make changes to this author.');
+                } elseif (Cryptography::compare($entered_password, Symphony::Author()->get('password')) !== true) {
+                    $this->_errors['confirm-change-password'] = __('Wrong password, please enter your own password to make changes to this author.');
+                }
+            }
+            if (is_array($this->_errors) && !empty($this->_errors)) {
+                $this->pageAlert(__('There were some problems while attempting to save. Please check below for problem fields.'), Alert::ERROR);
+                return;
+            }
+
             /**
              * Prior to deleting an author, provided with the Author ID.
              *

--- a/symphony/lib/boot/bundle.php
+++ b/symphony/lib/boot/bundle.php
@@ -21,6 +21,10 @@
             die('<h2>Error</h2><p>Could not locate Symphony configuration file. Please check <code>manifest/config.php</code> exists.</p>');
         }
     } else {
+        // Start with the Exception handler disable before authentication.
+        // This limits the possibility of leaking infos.
+        GenericExceptionHandler::$enabled = false;
+
         // Load configuration file:
         include CONFIG;
         Symphony::initialiseConfiguration($settings);

--- a/symphony/lib/boot/defines.php
+++ b/symphony/lib/boot/defines.php
@@ -241,11 +241,16 @@ define_safe('__SECURE__',
 );
 
 /**
+ * The root url directory.
+ * @var string
+ */
+define_safe('DIRROOT', rtrim(dirname($_SERVER['PHP_SELF']), '\/'));
+
+/**
  * The current domain name.
  * @var string
  */
-define_safe('DOMAIN', HTTP_HOST . rtrim(dirname($_SERVER['PHP_SELF']), '\/'));
-
+define_safe('DOMAIN', HTTP_HOST . DIRROOT);
 
 /**
  * The base URL of this Symphony install, minus the symphony path.

--- a/symphony/lib/core/class.administration.php
+++ b/symphony/lib/core/class.administration.php
@@ -188,7 +188,6 @@ class Administration extends Symphony
             if (is_callable(array($this->Page, 'handleFailedAuthorisation'))) {
                 $this->Page->handleFailedAuthorisation();
             } else {
-                include_once(CONTENT . '/content.login.php');
                 $this->Page = new contentLogin;
 
                 // Include the query string for the login, RE: #2324

--- a/symphony/lib/core/class.administration.php
+++ b/symphony/lib/core/class.administration.php
@@ -150,19 +150,13 @@ class Administration extends Symphony
                     $default_area = preg_replace('/^' . preg_quote(SYMPHONY_URL, '/') . '/i', '', Symphony::Author()->get('default_area'));
                 }
 
+                // Fallback: No default area found
                 if (is_null($default_area)) {
                     if (Symphony::Author()->isDeveloper()) {
-                        $all_sections = SectionManager::fetch();
-                        $section_handle = !empty($all_sections) ? $all_sections[0]->get('handle') : null;
-
-                        if (!is_null($section_handle)) {
-                            // If there are sections created, redirect to the first one (sortorder)
-                            redirect(SYMPHONY_URL . "/publish/{$section_handle}/");
-                        } else {
-                            // If there are no sections created, default to the Section page
-                            redirect(SYMPHONY_URL . '/blueprints/sections/');
-                        }
+                        // Redirect to the section index if author is a developer
+                        redirect(SYMPHONY_URL . '/blueprints/sections/');
                     } else {
+                        // Redirect to the author page if author is not a developer
                         redirect(SYMPHONY_URL . "/system/authors/edit/".Symphony::Author()->get('id')."/");
                     }
                 } else {

--- a/symphony/lib/core/class.cookie.php
+++ b/symphony/lib/core/class.cookie.php
@@ -135,6 +135,7 @@ class Cookie
         }
 
         // Class FrontendPage uses $_COOKIE directly (inside it's __buildPage() function), so try to emulate it.
+        // @deprecated will be removed in Symphony 3.0.0
         $_COOKIE[$this->_index] = &$_SESSION[$this->_index];
 
         return $this->_session;

--- a/symphony/lib/core/class.errorhandler.php
+++ b/symphony/lib/core/class.errorhandler.php
@@ -277,6 +277,7 @@ class GenericExceptionHandler
      * Exception in a user friendly way.
      *
      * @since Symphony 2.4
+     * @since Symphony 2.6.4 the method is protected
      * @param string $template
      *  The template name, which should correspond to something in the TEMPLATE
      *  directory, eg `fatalerror.fatal`.
@@ -290,7 +291,7 @@ class GenericExceptionHandler
      * @return string
      *  The HTML of the formatted error message.
      */
-    public static function renderHtml($template, $heading, $message, $file = null, $line = null, $lines = null, $trace = null, $queries = null)
+    protected static function renderHtml($template, $heading, $message, $file = null, $line = null, $lines = null, $trace = null, $queries = null)
     {
         $html = sprintf(
             file_get_contents(self::getTemplate($template)),

--- a/symphony/lib/core/class.errorhandler.php
+++ b/symphony/lib/core/class.errorhandler.php
@@ -13,7 +13,7 @@
 class GenericExceptionHandler
 {
     /**
-     * Whether the `GenericExceptionHandler` should handle exceptions. Defaults to true.
+     * Whether the `GenericExceptionHandler` should display exceptions. Defaults to true.
      * @since Symphony 2.6.4
      *  When disabled, exception are now rendered usign the fatalerror.disabled template,
      *  to prevent leaking debug data.
@@ -129,6 +129,14 @@ class GenericExceptionHandler
         }
 
         // Pending nothing disasterous, we should have `$e` and `$output` values here.
+        self::sendHeaders($e);
+
+        echo $output;
+        exit;
+    }
+
+    protected static function sendHeaders(Exception $e)
+    {
         if (!headers_sent()) {
             cleanup_session_cookies();
 
@@ -136,6 +144,9 @@ class GenericExceptionHandler
             $httpStatus = null;
             if ($e instanceof SymphonyErrorPage) {
                 $httpStatus = $e->getHttpStatusCode();
+                if (isset($e->getAdditional()->header)) {
+                    header($e->getAdditional()->header);
+                }
             } elseif ($e instanceof FrontendPageNotFoundException) {
                 $httpStatus = Page::HTTP_STATUS_NOT_FOUND;
             }
@@ -147,9 +158,6 @@ class GenericExceptionHandler
             Page::renderStatusCode($httpStatus);
             header('Content-Type: text/html; charset=utf-8');
         }
-
-        echo $output;
-        exit;
     }
 
     /**

--- a/symphony/lib/core/class.errorhandler.php
+++ b/symphony/lib/core/class.errorhandler.php
@@ -81,7 +81,7 @@ class GenericExceptionHandler
             // Instead of just throwing an empty page, return a 404 page.
             if (self::$enabled !== true) {
                 $e = new FrontendPageNotFoundException();
-            };
+            }
 
             $exception_type = get_class($e);
 

--- a/symphony/lib/core/class.errorhandler.php
+++ b/symphony/lib/core/class.errorhandler.php
@@ -93,7 +93,7 @@ class GenericExceptionHandler
      * @return string
      *  The result of the Exception's render function
      */
-    public final static function handler(Exception $e)
+    final public static function handler(Exception $e)
     {
         $output = '';
 
@@ -456,7 +456,7 @@ class GenericErrorHandler
      * @return string
      *  Usually a string of HTML that will displayed to a user
      */
-    public final static function handler($code, $message, $file = null, $line = null)
+    final public static function handler($code, $message, $file = null, $line = null)
     {
         // Only log if the error won't be raised to an exception and the error is not `E_STRICT`
         if (!self::$logDisabled && !in_array($code, array(E_STRICT)) && self::$_Log instanceof Log) {

--- a/symphony/lib/core/class.errorhandler.php
+++ b/symphony/lib/core/class.errorhandler.php
@@ -85,12 +85,15 @@ class GenericExceptionHandler
      * function, the output is displayed and then exited to prevent any further
      * logic from occurring.
      *
+     * @since Symphony 2.6.4
+     *  The method is final
+     *
      * @param Exception $e
      *  The Exception object
      * @return string
      *  The result of the Exception's render function
      */
-    public static function handler(Exception $e)
+    public final static function handler(Exception $e)
     {
         $output = '';
 
@@ -437,6 +440,9 @@ class GenericErrorHandler
      * `E_STRICT` before raising the error as an Exception. This allows all `E_WARNING`
      * to actually be captured by an Exception handler.
      *
+     * @since Symphony 2.6.4
+     *  The method is final
+     *
      * @param integer $code
      *  The error code, one of the PHP error constants
      * @param string $message
@@ -450,7 +456,7 @@ class GenericErrorHandler
      * @return string
      *  Usually a string of HTML that will displayed to a user
      */
-    public static function handler($code, $message, $file = null, $line = null)
+    public final static function handler($code, $message, $file = null, $line = null)
     {
         // Only log if the error won't be raised to an exception and the error is not `E_STRICT`
         if (!self::$logDisabled && !in_array($code, array(E_STRICT)) && self::$_Log instanceof Log) {

--- a/symphony/lib/core/class.errorhandler.php
+++ b/symphony/lib/core/class.errorhandler.php
@@ -28,6 +28,20 @@ class GenericExceptionHandler
     private static $_Log = null;
 
     /**
+     * Whether to log errors or not.
+     * This one is to be used temporarily, e.g., when PHP function is
+     * supposed throw Exception and log should be kept clean.
+     *
+     * @since Symphony 2.6.4
+     * @var boolean
+     * @example
+     *  GenericExceptionHandler::$logDisabled = true;
+     *  DoSomethingThatEndsWithWarningsYouDoNotWantInLogs();
+     *  GenericExceptionHandler::$logDisabled = false;
+     */
+    public static $logDisabled = false;
+
+    /**
      * Initialise will set the error handler to be the `__CLASS__::handler` function.
      *
      * @param Log $Log
@@ -90,7 +104,7 @@ class GenericExceptionHandler
             }
 
             // Exceptions should be logged if they are not caught.
-            if (self::$_Log instanceof Log) {
+            if (!self::$logDisabled && self::$_Log instanceof Log) {
                 self::$_Log->pushExceptionToLog($e, true);
             }
 
@@ -251,7 +265,7 @@ class GenericExceptionHandler
 
             try {
                 // Log the error message
-                if (self::$_Log instanceof Log) {
+                if (!self::$logDisabled && self::$_Log instanceof Log) {
                     self::$_Log->pushToLog(sprintf(
                         '%s %s: %s%s%s',
                         __CLASS__,
@@ -443,6 +457,9 @@ class GenericErrorHandler
         }
 
         if (self::isEnabled()) {
+            // prevent double logging
+            GenericExceptionHandler::$logDisabled = true;
+            // throw Error
             throw new ErrorException($message, 0, $code, $file, $line);
         }
     }

--- a/symphony/lib/core/class.errorhandler.php
+++ b/symphony/lib/core/class.errorhandler.php
@@ -316,7 +316,7 @@ class GenericExceptionHandler
  * raise the errors to Exceptions so they can be dealt with by the
  * `GenericExceptionHandler`. The type of errors that are raised to Exceptions
  * depends on the `error_reporting` level. All errors raised, except
- * `E_NOTICE` and `E_STRICT` are written to the Symphony log.
+ * `E_STRICT` are written to the Symphony log.
  */
 class GenericErrorHandler
 {
@@ -400,8 +400,8 @@ class GenericErrorHandler
     }
 
     /**
-     * The handler function will write the error to the `$Log` if it is not `E_NOTICE`
-     * or `E_STRICT` before raising the error as an Exception. This allows all `E_WARNING`
+     * The handler function will write the error to the `$Log` if it is not
+     * `E_STRICT` before raising the error as an Exception. This allows all `E_WARNING`
      * to actually be captured by an Exception handler.
      *
      * @param integer $code

--- a/symphony/lib/core/class.frontend.php
+++ b/symphony/lib/core/class.frontend.php
@@ -163,23 +163,27 @@ class FrontendPageNotFoundExceptionHandler extends SymphonyErrorPageHandler
 
         // No 404 detected, throw default Symphony error page
         if (is_null($page['id'])) {
-            parent::render(new SymphonyErrorPage(
+            self::sendHeaders($e);
+            $e = new SymphonyErrorPage(
                 $e->getMessage(),
                 __('Page Not Found'),
                 'generic',
                 array(),
                 Page::HTTP_STATUS_NOT_FOUND
-            ));
+            );
+            include $e->getTemplate();
 
             // Recursive 404
         } elseif (isset($previous_exception)) {
-            parent::render(new SymphonyErrorPage(
+            self::sendHeaders($e);
+            $e = new SymphonyErrorPage(
                 __('This error occurred whilst attempting to resolve the 404 page for the original request.') . ' ' . $e->getMessage(),
                 __('Page Not Found'),
                 'generic',
                 array(),
                 Page::HTTP_STATUS_NOT_FOUND
-            ));
+            );
+            include $e->getTemplate();
 
             // Handle 404 page
         } else {
@@ -188,8 +192,7 @@ class FrontendPageNotFoundExceptionHandler extends SymphonyErrorPageHandler
             Frontend::instance()->setException($e);
             $output = Frontend::instance()->display($url);
             echo $output;
-
-            exit;
         }
+        exit;
     }
 }

--- a/symphony/lib/core/class.session.php
+++ b/symphony/lib/core/class.session.php
@@ -103,7 +103,7 @@ class Session
     public static function getDomain()
     {
         if (isset($_SERVER['HTTP_HOST'])) {
-            if (preg_match('/(localhost|127\.0\.0\.1)/', $_SERVER['HTTP_HOST']) || $_SERVER['SERVER_ADDR'] == '127.0.0.1') {
+            if (preg_match('/(localhost|127\.0\.0\.1)/', $_SERVER['HTTP_HOST'])) {
                 return null; // prevent problems on local setups
             }
 

--- a/symphony/lib/core/class.session.php
+++ b/symphony/lib/core/class.session.php
@@ -168,7 +168,7 @@ class Session
             }
 
             if ($empty) {
-                return false;
+                return true;
             }
         }
 
@@ -217,7 +217,7 @@ class Session
      */
     public static function read($id)
     {
-        return Symphony::Database()->fetchVar(
+        return (string)Symphony::Database()->fetchVar(
             'session_data',
             0,
             sprintf(

--- a/symphony/lib/core/class.session.php
+++ b/symphony/lib/core/class.session.php
@@ -105,12 +105,12 @@ class Session
      */
     public static function getDomain()
     {
-        if (isset($_SERVER['HTTP_HOST'])) {
-            if (preg_match('/(localhost|127\.0\.0\.1)/', $_SERVER['HTTP_HOST'])) {
+        if (HTTP_HOST != null) {
+            if (preg_match('/(localhost|127\.0\.0\.1)/', HTTP_HOST)) {
                 return null; // prevent problems on local setups
             }
 
-            return preg_replace('/(^www\.|:\d+$)/i', null, $_SERVER['HTTP_HOST']);
+            return preg_replace('/(^www\.|:\d+$)/i', null, HTTP_HOST);
         }
 
         return null;

--- a/symphony/lib/core/class.session.php
+++ b/symphony/lib/core/class.session.php
@@ -58,6 +58,9 @@ class Session
 
             if (session_id() == '') {
                 ini_set('session.save_handler', 'user');
+                ini_set('session.use_trans_sid', '0');
+                ini_set('session.use_strict_mode', '1');
+                ini_set('session.use_only_cookies', '1');
                 ini_set('session.gc_maxlifetime', $lifetime);
                 ini_set('session.gc_probability', '1');
                 ini_set('session.gc_divisor', Symphony::Configuration()->get('session_gc_divisor', 'symphony'));

--- a/symphony/lib/core/class.session.php
+++ b/symphony/lib/core/class.session.php
@@ -75,7 +75,7 @@ class Session
                 array('Session', 'gc')
             );
 
-            session_set_cookie_params($lifetime, $path, ($domain ? $domain : self::getDomain()), $secure, $httpOnly);
+            session_set_cookie_params($lifetime, rawurlencode($path), ($domain ? $domain : self::getDomain()), $secure, $httpOnly);
             session_cache_limiter('');
 
             if (session_id() == '') {

--- a/symphony/lib/core/class.session.php
+++ b/symphony/lib/core/class.session.php
@@ -159,7 +159,7 @@ class Session
         $session_data = Session::read($id);
         if (is_null($session_data)) {
             $empty = true;
-            $unserialized_data = Session::unserialize($session_data);
+            $unserialized_data = Session::unserialize($data);
 
             foreach ($unserialized_data as $d) {
                 if (!empty($d)) {
@@ -188,7 +188,7 @@ class Session
      * @since Symphony 2.3.3
      * @param string $data
      *  The serialized session data
-     * @return string
+     * @return array
      *  The unserialised session data
      */
     private static function unserialize($data)

--- a/symphony/lib/core/class.symphony.php
+++ b/symphony/lib/core/class.symphony.php
@@ -586,10 +586,6 @@ abstract class Symphony implements Singleton
         if (self::isInstallerAvailable()) {
             $migrations = scandir(DOCROOT . '/install/migrations');
             $migration_file = end($migrations);
-
-            include_once DOCROOT . '/install/lib/class.migration.php';
-            include_once DOCROOT . '/install/migrations/' . $migration_file;
-
             $migration_class = 'migration_' . str_replace('.', '', substr($migration_file, 0, -4));
             return call_user_func(array($migration_class, 'getVersion'));
         }

--- a/symphony/lib/core/class.symphony.php
+++ b/symphony/lib/core/class.symphony.php
@@ -100,9 +100,7 @@ abstract class Symphony implements Singleton
         self::initialiseCookie();
 
         // If the user is not a logged in Author, turn off the verbose error messages.
-        if (!self::isLoggedIn() && is_null(self::$Author)) {
-            GenericExceptionHandler::$enabled = false;
-        }
+        GenericExceptionHandler::$enabled = self::isLoggedIn() && !is_null(self::$Author);
 
         // Engine is ready.
         self::$Profiler->sample('Engine Initialisation');
@@ -564,8 +562,8 @@ abstract class Symphony implements Singleton
      */
     public static function isLoggedIn()
     {
-        // Check to see if Symphony exists, or if we already have an Author instance.
-        if (is_null(self::$_instance) || self::$Author) {
+        // Check to see if we already have an Author instance.
+        if (self::$Author) {
             return true;
         }
 

--- a/symphony/lib/toolkit/cache/cache.database.php
+++ b/symphony/lib/toolkit/cache/cache.database.php
@@ -80,11 +80,11 @@ class CacheDatabase implements iNamespacedCache
         $data = false;
 
         // Check namespace first
-        if (!is_null($namespace)) {
+        if (!is_null($namespace) && is_null($hash)) {
             $data = $this->Database->fetch("
                 SELECT SQL_NO_CACHE *
                 FROM `tbl_cache`
-                WHERE `namespace` = '$namepspace'
+                WHERE `namespace` = '$namespace'
                 AND (`expiry` IS NULL OR UNIX_TIMESTAMP() <= `expiry`)
             ");
         }

--- a/symphony/lib/toolkit/class.cryptography.php
+++ b/symphony/lib/toolkit/class.cryptography.php
@@ -97,7 +97,7 @@ class Cryptography
      */
     public static function generateSalt($length)
     {
-        mt_srand(microtime(true)*100000 + memory_get_usage(true));
+        mt_srand(intval(microtime(true)*100000 + memory_get_usage(true)));
         return substr(sha1(uniqid(mt_rand(), true)), 0, $length);
     }
 }

--- a/symphony/lib/toolkit/class.email.php
+++ b/symphony/lib/toolkit/class.email.php
@@ -11,8 +11,6 @@ class EmailException extends Exception
 {
 }
 
-include_once TOOLKIT . '/class.emailgatewaymanager.php';
-
 /**
  * The Email class is a factory class to make it possible to send emails using different gateways.
  */

--- a/symphony/lib/toolkit/class.entry.php
+++ b/symphony/lib/toolkit/class.entry.php
@@ -256,6 +256,33 @@ class Entry
             $message = null;
             $field = FieldManager::fetch($info['id']);
 
+            /**
+             * Prior to checking a field's post data.
+             *
+             * @delegate EntryPreCheckPostFieldData
+             * @since Symphony 2.7.0
+             * @param string $context
+             * '/backend/' resp. '/frontend/'
+             * @param object $section
+             *  The section of the field
+             * @param object $field
+             *  The field, passed by reference
+             * @param array $post_data
+             *  All post data, passed by reference
+             * @param array $errors
+             *  The errors (of fields already checked), passed by reference
+             */
+            Symphony::ExtensionManager()->notifyMembers(
+                'EntryPreCheckPostFieldData',
+                class_exists('Administration', false) ? '/backend/' : '/frontend/',
+                array(
+                    'section' => $section,
+                    'field' => &$field,
+                    'post_data' => &$data,
+                    'errors' => &$errors
+                )
+            );
+
             if ($ignore_missing_fields && !isset($data[$field->get('element_name')])) {
                 continue;
             }

--- a/symphony/lib/toolkit/class.extensionmanager.php
+++ b/symphony/lib/toolkit/class.extensionmanager.php
@@ -6,12 +6,9 @@
 /**
  * The ExtensionManager class is responsible for managing all extensions
  * in Symphony. Extensions are stored on the file system in the `EXTENSIONS`
- * folder. They are autodiscovered where the Extension class name is the same
+ * folder. They are auto-discovered where the Extension class name is the same
  * as it's folder name (excluding the extension prefix).
  */
-
-include_once FACE . '/interface.fileresource.php';
-include_once TOOLKIT . '/class.extension.php';
 
 class ExtensionManager implements FileResource
 {

--- a/symphony/lib/toolkit/class.field.php
+++ b/symphony/lib/toolkit/class.field.php
@@ -1194,14 +1194,14 @@ class Field
                 'title' => 'contains',
                 'filter' => 'regexp: ',
                 'help' => __('Find values that match the given <a href="%s">MySQL regular expressions</a>.', array(
-                    'http://dev.mysql.com/doc/mysql/en/Regexp.html'
+                    'http://dev.mysql.com/doc/mysql/en/regexp.html'
                 ))
             ),
             array(
                 'title' => 'does not contain',
                 'filter' => 'not-regexp: ',
                 'help' => __('Find values that do not match the given <a href="%s">MySQL regular expressions</a>.', array(
-                    'http://dev.mysql.com/doc/mysql/en/Regexp.html'
+                    'http://dev.mysql.com/doc/mysql/en/regexp.html'
                 ))
             ),
         );

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -365,6 +365,7 @@ class FrontendPage extends XSLTPage
             'website-name' => Symphony::Configuration()->get('sitename', 'general'),
             'page-title' => $page['title'],
             'root' => URL,
+            'root-dir' => '/' . DIRROOT,
             'workspace' => URL . '/workspace',
             'http-host' => HTTP_HOST,
             'root-page' => ($root_page ? $root_page : $page['handle']),

--- a/symphony/lib/toolkit/class.lang.php
+++ b/symphony/lib/toolkit/class.lang.php
@@ -161,6 +161,10 @@ class Lang
      */
     private static function fetch()
     {
+        if (!@is_readable(EXTENSIONS)) {
+            return;
+        }
+
         // Fetch extensions
         $extensions = new DirectoryIterator(EXTENSIONS);
 

--- a/symphony/lib/toolkit/class.mysql.php
+++ b/symphony/lib/toolkit/class.mysql.php
@@ -1036,7 +1036,7 @@ class MySQL
     {
         if ($force_engine) {
             // Silently attempt to change the storage engine. This prevents INNOdb errors.
-            $this->query('SET storage_engine=MYISAM');
+            $this->query('SET default_storage_engine = MYISAM');
         }
 
         $queries = preg_split('/;[\\r\\n]+/', $sql, -1, PREG_SPLIT_NO_EMPTY);

--- a/symphony/lib/toolkit/class.mysql.php
+++ b/symphony/lib/toolkit/class.mysql.php
@@ -738,7 +738,7 @@ class MySQL
      */
     public function delete($table, $where = null)
     {
-        $sql = "DELETE FROM $table";
+        $sql = "DELETE FROM `$table`";
 
         if (!is_null($where)) {
             $sql .= " WHERE $where";

--- a/symphony/lib/toolkit/class.sectionmanager.php
+++ b/symphony/lib/toolkit/class.sectionmanager.php
@@ -8,7 +8,6 @@
  * installation by exposing basic CRUD operations. Sections are stored in the
  * database in `tbl_sections`.
  */
-include_once TOOLKIT . '/class.section.php';
 
 class SectionManager
 {
@@ -84,7 +83,6 @@ class SectionManager
         ));
 
         // Delete all the entries
-        include_once TOOLKIT . '/class.entrymanager.php';
         $entries = Symphony::Database()->fetchCol('id', "SELECT `id` FROM `tbl_entries` WHERE `section_id` = '$section_id'");
         EntryManager::delete($entries);
 

--- a/symphony/lib/toolkit/class.xsrf.php
+++ b/symphony/lib/toolkit/class.xsrf.php
@@ -72,8 +72,18 @@ class XSRF
             throw new Exception('$length must be greater than 0');
         }
 
+        // Use the new PHP 7 random_bytes call, if available
+        if (function_exists('random_bytes')) {
+            $random = random_bytes($length);
+        }
+
+        // Try mcrypt package, if available
+        else if (function_exists('mcrypt_create_iv')) {
+            $random = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
+        }
+
         // Get some random binary data from open ssl, if available
-        if (function_exists('openssl_random_pseudo_bytes')) {
+        else if (function_exists('openssl_random_pseudo_bytes')) {
             $random = openssl_random_pseudo_bytes($length);
         }
 

--- a/symphony/lib/toolkit/class.xsrf.php
+++ b/symphony/lib/toolkit/class.xsrf.php
@@ -61,33 +61,50 @@ class XSRF
      * falling back to using `/dev/urandom` and a microtime implementation
      * otherwise
      *
-     * @param integer $length
+     * @param integer $length optional. By default, 30.
      * @return string
+     *  base64 encoded, url safe
      */
-    public static function generateNonce($length = 20)
+    public static function generateNonce($length = 30)
     {
-        // Base64 encode some random binary data, and strip the "=" if there are any.
-        if (function_exists("openssl_random_pseudo_bytes")) {
-            return str_replace("=", "", base64_encode(openssl_random_pseudo_bytes($length)));
+        $random = null;
+        if ($length < 1) {
+            throw new Exception('$length must be greater than 0');
         }
 
-        // Fallback if openssl not available
-        if (is_readable("/dev/urandom")) {
-            if (($handle = @fopen("/dev/urandom", "rb")) !== false) {
-                $bytes = fread($handle, $length);
-                fclose($handle);
-                return str_replace("=", "", base64_encode($bytes));
+        // Get some random binary data from open ssl, if available
+        if (function_exists('openssl_random_pseudo_bytes')) {
+            $random = openssl_random_pseudo_bytes($length);
+        }
+
+        // Fallback to /dev/urandom
+        else if (is_readable('/dev/urandom')) {
+            if (($handle = @fopen('/dev/urandom', 'rb')) !== false) {
+                $random = @fread($handle, $length);
+                @fclose($handle);
             }
         }
 
-        // Fallback if /dev/urandom not readable.
-        $state = microtime();
+        // Fallback if no random bytes were found
+        if (!$random) {
+            $random = microtime();
 
-        for ($i = 0; $i < 1000; $i += 20) {
-            $state = sha1(microtime() . $state);
+            for ($i = 0; $i < 1000; $i += $length) {
+                $random = sha1(microtime() . $random);
+            }
         }
 
-        return str_replace("=", "", base64_encode(substr($state, 0, $length)));
+        // Convert to base64
+        $random = base64_encode($random);
+
+        // Replace unsafe chars
+        $random = strtr($random, '+/', '-_');
+        $random = str_replace('=', '', $random);
+
+        // Truncate the string to specified lengh
+        $random = substr($random, 0, $length);
+
+        return $random;
     }
 
     /**
@@ -114,7 +131,7 @@ class XSRF
     {
         $token = self::getSessionToken();
         if (is_null($token)) {
-            $nonce = self::generateNonce(20);
+            $nonce = self::generateNonce();
             self::setSessionToken($nonce);
 
         // Handle old tokens (< 2.6.0)

--- a/symphony/lib/toolkit/data-sources/class.datasource.static.php
+++ b/symphony/lib/toolkit/data-sources/class.datasource.static.php
@@ -14,8 +14,6 @@ class StaticXMLDatasource extends Datasource
 {
     public function execute(array &$param_pool = null)
     {
-        include_once TOOLKIT . '/class.xsltprocess.php';
-
         $result = new XMLElement($this->dsParamROOTELEMENT);
         $this->dsParamSTATIC = stripslashes($this->dsParamSTATIC);
 

--- a/symphony/lib/toolkit/fields/field.date.php
+++ b/symphony/lib/toolkit/fields/field.date.php
@@ -75,14 +75,14 @@ class FieldDate extends Field implements ExportableField, ImportableField
                 'title' => 'contains',
                 'filter' => 'regexp: ',
                 'help' => __('Find values that match the given <a href="%s">MySQL regular expressions</a>.', array(
-                    'http://dev.mysql.com/doc/mysql/en/Regexp.html'
+                    'http://dev.mysql.com/doc/mysql/en/regexp.html'
                 ))
             ),
             array(
                 'title' => 'does not contain',
                 'filter' => 'not-regexp: ',
                 'help' => __('Find values that do not match the given <a href="%s">MySQL regular expressions</a>.', array(
-                    'http://dev.mysql.com/doc/mysql/en/Regexp.html'
+                    'http://dev.mysql.com/doc/mysql/en/regexp.html'
                 ))
             ),
             array(

--- a/symphony/lib/toolkit/fields/field.input.php
+++ b/symphony/lib/toolkit/fields/field.input.php
@@ -197,8 +197,6 @@ class FieldInput extends Field implements ExportableField, ImportableField
         if ($encode === true) {
             $value = General::sanitize($value);
         } else {
-            include_once TOOLKIT . '/class.xsltprocess.php';
-
             if (!General::validateXML($data['value'], $errors, false, new XsltProcess)) {
                 $value = html_entity_decode($data['value'], ENT_QUOTES, 'UTF-8');
                 $value = $this->__replaceAmpersands($value);

--- a/symphony/lib/toolkit/fields/field.taglist.php
+++ b/symphony/lib/toolkit/fields/field.taglist.php
@@ -614,50 +614,133 @@ class FieldTagList extends Field implements ExportableField, ImportableField
         }
     }
 
+    public function fetchFilterableOperators()
+    {
+        return array(
+            array(
+                'title' => 'is',
+                'filter' => ' ',
+                'help' => __('Find values that are an exact match for the given string.')
+            ),
+            array(
+                'filter' => 'sql: NOT NULL',
+                'title' => 'is not empty',
+                'help' => __('Find entries where any value is selected.')
+            ),
+            array(
+                'filter' => 'sql: NULL',
+                'title' => 'is empty',
+                'help' => __('Find entries where no value is selected.')
+            ),
+            array(
+                'filter' => 'sql-null-or-not: ',
+                'title' => 'is empty or not',
+                'help' => __('Find entries where no value is selected or it is not equal to this value.')
+            ),
+            array(
+                'filter' => 'not: ',
+                'title' => 'is not',
+                'help' => __('Find entries where the value is not equal to this value.')
+            ),
+            array(
+                'filter' => 'regexp: ',
+                'title' => 'regexp',
+                'help' => __('Find entries where the value matches the regex.')
+            ),
+            array(
+                'filter' => 'not-regexp: ',
+                'title' => 'is not regexp',
+                'help' => __('Find entries where the value does not match the regex.')
+            )
+        );
+    }
+
     public function buildDSRetrievalSQL($data, &$joins, &$where, $andOperation = false)
     {
         $field_id = $this->get('id');
 
         if (self::isFilterRegex($data[0])) {
             $this->buildRegexSQL($data[0], array('value', 'handle'), $joins, $where);
-        } elseif ($andOperation) {
-            foreach ($data as $value) {
-                $this->_key++;
-                $value = $this->cleanValue($value);
-                $joins .= "
-                    LEFT JOIN
-                        `tbl_entries_data_{$field_id}` AS t{$field_id}_{$this->_key}
-                        ON (e.id = t{$field_id}_{$this->_key}.entry_id)
-                ";
-                $where .= "
-                    AND (
-                        t{$field_id}_{$this->_key}.value = '{$value}'
-                        OR t{$field_id}_{$this->_key}.handle = '{$value}'
-                    )
-                ";
+        } else if (preg_match('/^sql:\s*/', $data[0], $matches)) {
+            $data = trim(array_pop(explode(':', $data[0], 2)));
+
+            if (strpos($data, "NOT NULL") !== false) {
+
+                // Check for NOT NULL (ie. Entries that have any value)
+                $joins .= " LEFT JOIN
+                                `tbl_entries_data_{$field_id}` AS `t{$field_id}`
+                            ON (`e`.`id` = `t{$field_id}`.entry_id)";
+                $where .= " AND `t{$field_id}`.value IS NOT NULL ";
+
+            } else if (strpos($data, "NULL") !== false) {
+
+                // Check for NULL (ie. Entries that have no value)
+                $joins .= " LEFT JOIN
+                                `tbl_entries_data_{$field_id}` AS `t{$field_id}`
+                            ON (`e`.`id` = `t{$field_id}`.entry_id)";
+                $where .= " AND `t{$field_id}`.value IS NULL ";
+
             }
         } else {
-            if (!is_array($data)) {
-                $data = array($data);
+            $negation = false;
+            $null = false;
+            if (preg_match('/^not:/', $data[0])) {
+                $data[0] = preg_replace('/^not:/', null, $data[0]);
+                $negation = true;
+            } elseif (preg_match('/^sql-null-or-not:/', $data[0])) {
+                $data[0] = preg_replace('/^sql-null-or-not:/', null, $data[0]);
+                $negation = true;
+                $null = true;
             }
-
+            
             foreach ($data as &$value) {
                 $value = $this->cleanValue($value);
             }
 
-            $this->_key++;
-            $data = implode("', '", $data);
-            $joins .= "
-                LEFT JOIN
-                    `tbl_entries_data_{$field_id}` AS t{$field_id}_{$this->_key}
-                    ON (e.id = t{$field_id}_{$this->_key}.entry_id)
-            ";
-            $where .= "
-                AND (
-                    t{$field_id}_{$this->_key}.value IN ('{$data}')
-                    OR t{$field_id}_{$this->_key}.handle IN ('{$data}')
-                )
-            ";
+            if ($andOperation) {
+                $condition = ($negation) ? '!=' : '=';
+                foreach ($data as $key => $bit) {
+                    $joins .= " LEFT JOIN `tbl_entries_data_$field_id` AS `t{$field_id}_{$this->_key}` ON (`e`.`id` = `t{$field_id}_{$this->_key}`.entry_id) ";
+                    $where .= " AND (
+                                        t{$field_id}_{$this->_key}.value $condition '$bit''
+                                        OR t{$field_id}_{$this->_key}.handle $condition '$bit'' 
+                                    )";
+
+                    if ($null) {
+                        $where .= " OR `t{$field_id}_{$this->_key}`.`value` IS NULL) ";
+                    } else {
+                        $where .= ") ";
+                    }
+                }
+            } else {
+                $condition = ($negation) ? 'NOT IN' : 'IN';
+
+                $data = "'".implode("', '", $data)."'";
+
+                // Apply a different where condition if we are using $negation. RE: #29
+                if ($negation) {
+                    $condition = 'NOT EXISTS';
+                    $where .= " AND $condition (
+                        SELECT *
+                        FROM `tbl_entries_data_$field_id` AS `t{$field_id}_{$this->_key}`
+                        WHERE `t{$field_id}_{$this->_key}`.entry_id = `e`.id AND (
+                            `t{$field_id}_{$this->_key}`.handle IN ($data) OR
+                            `t{$field_id}_{$this->_key}`.value IN ($data)
+                        )
+                    )";
+                } else {
+
+                    // Normal filtering
+                    $joins .= " LEFT JOIN `tbl_entries_data_$field_id` AS `t{$field_id}_{$this->_key}` ON (`e`.`id` = `t{$field_id}_{$this->_key}`.entry_id) ";
+                    $where .= " AND (
+                                    t{$field_id}_{$this->_key}.value IN ($data)
+                                    OR t{$field_id}_{$this->_key}.handle IN ($data)
+                                ";
+
+                    // If we want entries with null values included in the result
+                    $where .= ($null) ? " OR `t{$field_id}_{$this->_key}`.`relation_id` IS NULL) " : ") ";
+                }
+            }
         }
 
         return true;

--- a/symphony/lib/toolkit/fields/field.textarea.php
+++ b/symphony/lib/toolkit/fields/field.textarea.php
@@ -62,8 +62,6 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
         }
 
         if ($validate === true) {
-            include_once(TOOLKIT . '/class.xsltprocess.php');
-
             if (!General::validateXML($result, $errors, false, new XsltProcess)) {
                 $result = html_entity_decode($result, ENT_QUOTES, 'UTF-8');
                 $result = $this->__replaceAmpersands($result);

--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -428,11 +428,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
 
             // Grab the existing entry data to preserve the MIME type and size information
             if (isset($entry_id)) {
-                $row = Symphony::Database()->fetchRow(0, sprintf(
-                    "SELECT `file`, `mimetype`, `size`, `meta` FROM `tbl_entries_data_%d` WHERE `entry_id` = %d",
-                    $this->get('id'),
-                    $entry_id
-                ));
+                $row = $this->getCurrentValues($entry_id);
 
                 if (empty($row) === false) {
                     $result = $row;
@@ -468,14 +464,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
 
         // Check to see if the entry already has a file associated with it:
         if (is_null($entry_id) === false) {
-            $row = Symphony::Database()->fetchRow(0, sprintf(
-                "SELECT *
-                FROM `tbl_entries_data_%s`
-                WHERE `entry_id` = %d
-                LIMIT 1",
-                $this->get('id'),
-                $entry_id
-            ));
+            $row = $this->getCurrentValues($entry_id);
 
             $existing_file = isset($row['file']) ? $this->getFilePath($row['file']) : null;
 
@@ -560,6 +549,19 @@ class FieldUpload extends Field implements ExportableField, ImportableField
             'mimetype' =>   $data['type'],
             'meta' =>       serialize(static::getMetaInfo($file, $data['type']))
         );
+    }
+
+    protected function getCurrentValues($entry_id)
+    {
+        return Symphony::Database()->fetchRow(0, sprintf(
+            "SELECT `file`, `mimetype`, `size`, `meta`
+                FROM `tbl_entries_data_%d`
+                WHERE `entry_id` = %d
+                LIMIT 1
+            ",
+            $this->get('id'),
+            $entry_id
+        ));
     }
 
     /*-------------------------------------------------------------------------

--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -60,14 +60,14 @@ class FieldUpload extends Field implements ExportableField, ImportableField
                 'title' => 'contains',
                 'filter' => 'regexp: ',
                 'help' => __('Find files that match the given <a href="%s">MySQL regular expressions</a>.', array(
-                    'http://dev.mysql.com/doc/mysql/en/Regexp.html'
+                    'http://dev.mysql.com/doc/mysql/en/regexp.html'
                 ))
             ),
             array(
                 'title' => 'does not contain',
                 'filter' => 'not-regexp: ',
                 'help' => __('Find files that do not match the given <a href="%s">MySQL regular expressions</a>.', array(
-                    'http://dev.mysql.com/doc/mysql/en/Regexp.html'
+                    'http://dev.mysql.com/doc/mysql/en/regexp.html'
                 ))
             ),
             array(

--- a/symphony/template/blueprints.datasource.tpl
+++ b/symphony/template/blueprints.datasource.tpl
@@ -41,7 +41,7 @@ class datasource<!-- CLASS NAME --> extends <!-- CLASS EXTENDS -->
     {
         $result = new XMLElement($this->dsParamROOTELEMENT);
 
-        try{
+        try {
             $result = parent::execute($param_pool);
         } catch (FrontendPageNotFoundException $e) {
             // Work around. This ensures the 404 page is displayed and

--- a/symphony/template/fatalerror.disabled.tpl
+++ b/symphony/template/fatalerror.disabled.tpl
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Symphony Error</title>
+	<link media="screen" href="{ASSETS_URL}/css/symphony.min.css" type="text/css" rel="stylesheet">
+</head>
+<body id="error">
+	<div class="frame">
+		<ul>
+			<li>
+				<h1><em>Symphony %s:</em> %s</h1>
+			</li>
+			<li>
+				<p>Please log in to have more detail.</p>
+			</li>
+		</ul>
+	</div>
+</body>
+</html>

--- a/symphony/template/usererror.database.php
+++ b/symphony/template/usererror.database.php
@@ -1,7 +1,5 @@
 <?php
 
-include_once TOOLKIT . '/class.htmlpage.php';
-
 $Page = new HTMLPage();
 
 $Page->Html->setElementStyle('html');

--- a/symphony/template/usererror.generic.php
+++ b/symphony/template/usererror.generic.php
@@ -1,7 +1,5 @@
 <?php
 
-include_once TOOLKIT . '/class.htmlpage.php';
-
 $Page = new HTMLPage();
 
 $Page->Html->setElementStyle('html');

--- a/symphony/template/usererror.missing_extension.php
+++ b/symphony/template/usererror.missing_extension.php
@@ -1,7 +1,5 @@
 <?php
 
-include_once TOOLKIT . '/class.htmlpage.php';
-
 // The extension cannot be found, show an error message and
 // let the user remove or rename the extension folder.
 if (isset($_POST['extension-missing'])) {

--- a/symphony/template/usererror.xslt.php
+++ b/symphony/template/usererror.xslt.php
@@ -1,7 +1,5 @@
 <?php
 
-include_once TOOLKIT . '/class.htmlpage.php';
-
 $Page = new HTMLPage();
 
 $Page->Html->setElementStyle('html');

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -154,4 +154,8 @@ return array(
     'migration_261' => $baseDir . '/install/migrations/2.6.1.php',
     'migration_262' => $baseDir . '/install/migrations/2.6.2.php',
     'migration_263' => $baseDir . '/install/migrations/2.6.3.php',
+    'migration_264' => $baseDir . '/install/migrations/2.6.4.php',
+    'migration_265' => $baseDir . '/install/migrations/2.6.5.php',
+    'migration_266' => $baseDir . '/install/migrations/2.6.6.php',
+    'migration_267' => $baseDir . '/install/migrations/2.6.7.php',
 );


### PR DESCRIPTION
Ok this one is a biggie.

I've been wrapping my head around this for quite some time now and with #2504 I though that it was to time to do it.

I won't repeat what I've already described in each commit, it should be easy to follow.

The biggest problem was that the `GenericExceptionHandler` was only disabled after a failed auth. Now, it's activated after a successful auth.

Basically, when the `GenericExceptionHandler` is disabled (i.e `$enabled === false`), we still let it through but display a generic message that does not leak anything. This is not a breaking change since we shortcut'ed the thing with a 404 (which was better then nothing)

I did not changed the default value in the class *per se*, but made it switch to false before we register the functions. I am still not sure about that.