### PR TITLE
Open site name backend header link into a new window.

### DIFF
--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -451,7 +451,7 @@ class AdministrationPage extends HTMLPage
         }
 
         $h1 = new XMLElement('h1');
-        $h1->appendChild(Widget::Anchor(Symphony::Configuration()->get('sitename', 'general'), rtrim(URL, '/') . '/'));
+        $h1->appendChild(Widget::Anchor(Symphony::Configuration()->get('sitename', 'general'), rtrim(URL, '/') . '/', null, null, null, array('target' => '_blank')));
         $this->Header->appendChild($h1);
 
         $this->appendUserLinks();


### PR DESCRIPTION
A proposal: User should not lose focus from the backend.

Maybe 100% of the time so far I targeted the header link to a new tab / window. How about you?

If the user wants to leave the backend, (s)he should do it on purpose, so either by logging out or closing the window.