### PR TITLE
New class "field-value-readonly"

### DIFF
--- a/symphony/assets/css/src/symphony.forms.css
+++ b/symphony/assets/css/src/symphony.forms.css
@@ -13,7 +13,8 @@
 
 input,
 textarea,
-select[multiple] {
+select[multiple],
+.field-value-readonly {
 	box-sizing: border-box;
 	width: 100%;
 	margin-top: 0.2rem;
@@ -124,6 +125,14 @@ input[type='submit']::-moz-focus-inner,
 select::-moz-focus-inner,
 input[type='file'] > input[type='button']::-moz-focus-inner {
 	border: none;
+}
+
+.field-value-readonly {
+	display: block;
+	min-height: 2.2rem;
+	padding-left: 0;
+	border: none;
+	opacity: 0.5;
 }
 
 /* Errors */


### PR DESCRIPTION
Adds a new class that allows for consistent styling of field values that are displayed as plain text and are not editable _(As seen in extensions like „System Date Fields“, „Members“, „Member Last Visit“, and maybe more)_.

See https://github.com/symphonycms/symphony-2/issues/2532 for details.

I’m planning to send PRs for the affected extensions after this has been published in the core.