### PR TITLE
Fix 2497

### DIFF
--- a/symphony/lib/toolkit/class.smtp.php
+++ b/symphony/lib/toolkit/class.smtp.php
@@ -32,8 +32,6 @@ class SMTP
     protected $_header_fields = array();
 
     protected $_from = null;
-    protected $_subject = null;
-    protected $_to = array();
 
     protected $_ip = '127.0.0.1';
     protected $_connection = false;

--- a/symphony/lib/toolkit/class.smtp.php
+++ b/symphony/lib/toolkit/class.smtp.php
@@ -33,7 +33,7 @@ class SMTP
 
     protected $_from = null;
 
-    protected $_ip = '127.0.0.1';
+    protected $_helo_host = null;
     protected $_connection = false;
 
     protected $_helo = false;
@@ -55,7 +55,8 @@ class SMTP
      *    $options['secure'] can be ssl, tls or null.
      *    $options['username'] the username used to login to the server. Leave empty for no authentication.
      *    $options['password'] the password used to login to the server. Leave empty for no authentication.
-     *    $options['local_ip'] the ip address used in the ehlo/helo commands. Only ip's are accepted.
+     *    $options['helo_hostname'] the hostname address used in the EHLO/HELO commands. Ideally an FQDN.
+     *    $options['local_ip'] the ip address used in the EHLO/HELO commands if no helo_hostname is given.
      * @throws SMTPException
      */
     public function __construct($host = '127.0.0.1', $port = null, $options = array())
@@ -79,10 +80,12 @@ class SMTP
             }
         }
 
-        if (is_null($options['local_ip'])) {
-            $this->_ip = gethostbyname(php_uname('n'));
+        if (!empty($options['helo_hostname'])) {
+            $this->_helo_host = $options['helo_hostname'];
+        } elseif (!empty($options['local_ip'])) {
+            $this->_helo_host = '[' . $options['local_ip'] . ']';
         } else {
-            $this->_ip = $options['local_ip'];
+            $this->_helo_host = '[' . gethostbyname(php_uname('n')) . ']';
         }
 
         if ($port === null) {
@@ -350,7 +353,7 @@ class SMTP
      */
     protected function _ehlo()
     {
-        $this->_send('EHLO [' . $this->_ip . ']');
+        $this->_send('EHLO ' . $this->_helo_host);
         $this->_expect(array(250, 220), 300);
     }
 
@@ -363,7 +366,7 @@ class SMTP
      */
     protected function _helo()
     {
-        $this->_send('HELO [' . $this->_ip . ']');
+        $this->_send('HELO ' . $this->_helo_host);
         $this->_expect(array(250, 220), 300);
     }
 

--- a/symphony/lib/toolkit/email-gateways/email.smtp.php
+++ b/symphony/lib/toolkit/email-gateways/email.smtp.php
@@ -13,6 +13,7 @@
 class SMTPGateway extends EmailGateway
 {
     protected $_SMTP;
+    protected $_helo_hostname;
     protected $_host;
     protected $_port;
     protected $_protocol = 'tcp';
@@ -58,11 +59,11 @@ class SMTPGateway extends EmailGateway
         $this->validate();
 
         $settings = array();
+        $settings['helo_hostname'] = $this->_helo_hostname;
         if ($this->_auth) {
             $settings['username'] = $this->_user;
             $settings['password'] = $this->_pass;
         }
-
         $settings['secure'] = $this->_secure;
 
         try {
@@ -178,6 +179,17 @@ class SMTPGateway extends EmailGateway
 
         parent::closeConnection();
         return false;
+    }
+
+    /**
+     * Sets the HELO/EHLO hostanme
+     *
+     * @param string $helo_hostname
+     * @return void
+     */
+    public function setHeloHostname($helo_hostname = null)
+    {
+        $this->_helo_hostname = $helo_hostname;
     }
 
     /**
@@ -299,6 +311,7 @@ class SMTPGateway extends EmailGateway
      */
     public function setConfiguration($config)
     {
+        $this->setHeloHostname($config['helo_hostname']);
         $this->setFrom($config['from_address'], $config['from_name']);
         $this->setHost($config['host']);
         $this->setPort($config['port']);
@@ -328,6 +341,15 @@ class SMTPGateway extends EmailGateway
         $group->setAttribute('class', 'settings condensed pickable');
         $group->setAttribute('id', 'smtp');
         $group->appendChild(new XMLElement('legend', __('Email: SMTP')));
+
+        $div = new XMLElement('div');
+
+        $label = Widget::Label(__('HELO Hostname'));
+        $label->appendChild(Widget::Input('settings[email_smtp][helo_hostname]', $this->_helo_hostname));
+        $div->appendChild($label);
+
+        $group->appendChild($div);
+        $group->appendChild(new XMLElement('p', __('A fully qualified domain name (FQDN) of your server, e.g. "www.example.com". If left empty, Symphony will attempt to find an IP address for the EHLO/HELO greeting.'), array('class' => 'help')));
 
         $div = new XMLElement('div');
         $div->setAttribute('class', 'two columns');


### PR DESCRIPTION
This implements a HELO Hostname setting for SMTP email. The setting is the first setting on the preferences page — one might argue about that, but it seemed most logical to me.