### PR TITLE
Add data-attributes to publish filtering interface

### DIFF
--- a/symphony/assets/js/src/symphony.filtering.js
+++ b/symphony/assets/js/src/symphony.filtering.js
@@ -88,12 +88,13 @@
 			var item = $(this),
 				comparison;
 
-			// Show help contextually
+			// Case: Adding a new filter instance
 			if(item.is('.instance')) {
-				comparison = item.find('.comparison').val();
+				comparison = item.find('.comparison option:selected').attr('data-comparison');
 			}
+			// Case: selecting a new comparison mode of an existing filter instance
 			else {
-				comparison = item.val();
+				comparison = item.find('option:selected').attr('data-comparison');
 				item = item.parents('.instance');
 			}
 
@@ -127,7 +128,7 @@
 
 			filtering.find('.instance:not(.template):visible').each(function() {
 				var item = $(this),
-					filterPrefix = item.find('.comparison option:selected').data('filter-prefix'),
+					filterPrefix = item.find('.comparison').val(),
 					query = item.find('.filter'),
 					value;
 

--- a/symphony/assets/js/src/symphony.filtering.js
+++ b/symphony/assets/js/src/symphony.filtering.js
@@ -127,15 +127,15 @@
 
 			filtering.find('.instance:not(.template):visible').each(function() {
 				var item = $(this),
-					comparison = $.trim(item.find('.comparison').val()),
+					filterPrefix = item.find('.comparison option:selected').data('filter-prefix'),
 					query = item.find('.filter'),
 					value;
 
-				if (!!comparison) {
-					comparison = comparison + ' ';
+				if (filterPrefix.length === 0 || !filterPrefix.trim()) {
+					filterPrefix = '';
 				}
 
-				value = 'filter[' + query.attr('name') + ']=' + comparison + $.trim(query.val());
+				value = 'filter[' + query.attr('name') + ']=' + filterPrefix + $.trim(query.val());
 				filters.push(value);
 			});
 

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -212,16 +212,7 @@ class contentPublish extends AdministrationPage
         $label = Widget::Label();
         $label->setAttribute('class', 'column secondary');
 
-        $comparisons = array();
-        
-        foreach($data['comparisons'] as $key=>$comparison) {
-            $comparisons[$key][0] = $comparison[2];
-            $comparisons[$key][1] = $comparison[1];
-            $comparisons[$key][2] = $comparison[2];
-            $comparisons[$key][5] = array('data-filter-prefix' => $comparison[0]);
-        }
-        
-        $select = Widget::Select($data['type'] . '-comparison', $comparisons, array(
+        $select = Widget::Select($data['type'] . '-comparison', $data['comparisons'], array(
             'class' => 'comparison'
         ));
 
@@ -268,9 +259,12 @@ class contentPublish extends AdministrationPage
             }
 	        
             $comparisons[] = array(
-                $operator['filter'],
+	            __($operator['title']),
                 $selected,
-                __($operator['title'])
+                __($operator['title']),
+                null,
+                null,
+                array('data-filter-prefix' => $operator['filter'])
             );
         }
 

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -259,7 +259,7 @@ class contentPublish extends AdministrationPage
             }
 	        
             $comparisons[] = array(
-	            __($operator['title']),
+                __($operator['title']),
                 $selected,
                 __($operator['title']),
                 null,

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -316,7 +316,7 @@ class contentPublish extends AdministrationPage
             $filter = trim($operator['filter']);
 
             if (!empty($filter) && strpos($data['filter'], $filter) === 0) {
-                $query = substr($data['filter'], strlen($filter));
+                $query = substr($data['filter'], strlen($operator['filter']));
             }
         }
 

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -215,11 +215,11 @@ class contentPublish extends AdministrationPage
         $comparisons = array();
         
         foreach($data['comparisons'] as $key=>$comparison) {
-    		$comparisons[$key][0] = $comparison[2];
-    		$comparisons[$key][1] = $comparison[1];
-			$comparisons[$key][2] = $comparison[2];
-			$comparisons[$key][5] = array('data-filter-prefix' => $comparison[0]);
-		}
+            $comparisons[$key][0] = $comparison[2];
+            $comparisons[$key][1] = $comparison[1];
+            $comparisons[$key][2] = $comparison[2];
+            $comparisons[$key][5] = array('data-filter-prefix' => $comparison[0]);
+        }
         
         $select = Widget::Select($data['type'] . '-comparison', $comparisons, array(
             'class' => 'comparison'
@@ -261,11 +261,11 @@ class contentPublish extends AdministrationPage
             
             // Selected state : Comparison mode "between" (x to y)
             if ($operator['title'] === 'between' && preg_match('/^(-?(?:\d+(?:\.\d+)?|\.\d+)) to (-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data['filter'] )) {
-	            $selected = true;
-	        // Selected state : Other comparison modes (except "is")
+                $selected = true;
+            // Selected state : Other comparison modes (except "is")
             } else if ((!empty($filter) && strpos($data['filter'], $filter) === 0)) {
-	            $selected = true;
-	        }
+                $selected = true;
+            }
 	        
             $comparisons[] = array(
                 $operator['filter'],

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -212,7 +212,16 @@ class contentPublish extends AdministrationPage
         $label = Widget::Label();
         $label->setAttribute('class', 'column secondary');
 
-        $select = Widget::Select($data['type'] . '-comparison', $data['comparisons'], array(
+        $comparisons = array();
+        
+        foreach($data['comparisons'] as $key=>$comparison) {
+    		$comparisons[$key][0] = $comparison[2];
+    		$comparisons[$key][1] = $comparison[1];
+			$comparisons[$key][2] = $comparison[2];
+			$comparisons[$key][5] = array('data-filter-prefix' => $comparison[0]);
+		}
+        
+        $select = Widget::Select($data['type'] . '-comparison', $comparisons, array(
             'class' => 'comparison'
         ));
 
@@ -244,11 +253,23 @@ class contentPublish extends AdministrationPage
 
         // Custom field comparisons
         foreach ($data['operators'] as $operator) {
+            
             $filter = trim($operator['filter']);
-
+            
+            // Check selected state
+            $selected = false;
+            
+            // Selected state : Comparison mode "between" (x to y)
+            if ($operator['title'] === 'between' && preg_match('/^(-?(?:\d+(?:\.\d+)?|\.\d+)) to (-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data['filter'] )) {
+	            $selected = true;
+	        // Selected state : Other comparison modes (except "is")
+            } else if ((!empty($filter) && strpos($data['filter'], $filter) === 0)) {
+	            $selected = true;
+	        }
+	        
             $comparisons[] = array(
-                $filter,
-                (!empty($filter) && strpos($data['filter'], $filter) === 0),
+                $operator['filter'],
+                $selected,
                 __($operator['title'])
             );
         }

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -259,12 +259,12 @@ class contentPublish extends AdministrationPage
             }
 	        
             $comparisons[] = array(
-                __($operator['title']),
+                $operator['filter'],
                 $selected,
                 __($operator['title']),
                 null,
                 null,
-                array('data-filter-prefix' => $operator['filter'])
+                array('data-comparison' => $operator['title'])
             );
         }
 
@@ -302,7 +302,7 @@ class contentPublish extends AdministrationPage
 
         $li = new XMLElement('li', __('Comparison mode') . ': ' . $operator['help'], array(
             'class' => 'help',
-            'data-comparison' => trim($operator['filter'])
+            'data-comparison' => $operator['title']
         ));
 
         $wrapper->appendChild($li);


### PR DESCRIPTION
This PR introduces data-attributes to the publish filtering interface. This allows for better and more precise and flexible handling of comparison modes and their help texts.

It also removes the (annoying) leading whitespace in the input fields of publish filtering interface.

See https://github.com/symphonycms/symphony-2/issues/2499 for details.