### PR TITLE
Fix Namespace Cache Typo & remove useless query

### DIFF
--- a/symphony/lib/toolkit/cache/cache.database.php
+++ b/symphony/lib/toolkit/cache/cache.database.php
@@ -80,11 +80,11 @@ class CacheDatabase implements iNamespacedCache
         $data = false;
 
         // Check namespace first
-        if (!is_null($namespace)) {
+        if (!is_null($namespace) && is_null($hash)) {
             $data = $this->Database->fetch("
                 SELECT SQL_NO_CACHE *
                 FROM `tbl_cache`
-                WHERE `namespace` = '$namepspace'
+                WHERE `namespace` = '$namespace'
                 AND (`expiry` IS NULL OR UNIX_TIMESTAMP() <= `expiry`)
             ");
         }


### PR DESCRIPTION
First of all there's a big 'error' on the namespace which never matched as there was a typo.

Second if a hash exists; the namespace query is run for no reason as data is overwritten by the if statement underneath.