### PR TITLE
Update install.sql for MySQL 5.7

### DIFF
--- a/install/includes/install.sql
+++ b/install/includes/install.sql
@@ -7,7 +7,7 @@ CREATE TABLE `tbl_authors` (
   `first_name` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
   `last_name` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
   `email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `last_seen` datetime DEFAULT '0000-00-00 00:00:00',
+  `last_seen` datetime DEFAULT '1000-01-01 00:00:00',
   `user_type` enum('author','manager','developer') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'author',
   `primary` enum('yes','no') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'no',
   `default_area` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,


### PR DESCRIPTION
In MySQL 5.7 a datetime field cannot have a default value of "0000-00-00" for the date, the minimum value is "1000-01-01".