### PR TITLE
Update class.cryptography.php for PHP 7 strictness.

### DIFF
--- a/symphony/lib/toolkit/class.cryptography.php
+++ b/symphony/lib/toolkit/class.cryptography.php
@@ -97,7 +97,7 @@ class Cryptography
      */
     public static function generateSalt($length)
     {
-        mt_srand(microtime(true)*100000 + memory_get_usage(true));
+        mt_srand(intval(microtime(true)*100000 + memory_get_usage(true)));
         return substr(sha1(uniqid(mt_rand(), true)), 0, $length);
     }
 }


### PR DESCRIPTION
mt_srand function argument must be an integer.