### PR TITLE
Prevent cookie issues when running behind a proxy

### DIFF
--- a/symphony/lib/core/class.session.php
+++ b/symphony/lib/core/class.session.php
@@ -103,7 +103,7 @@ class Session
     public static function getDomain()
     {
         if (isset($_SERVER['HTTP_HOST'])) {
-            if (preg_match('/(localhost|127\.0\.0\.1)/', $_SERVER['HTTP_HOST']) || $_SERVER['SERVER_ADDR'] == '127.0.0.1') {
+            if (preg_match('/(localhost|127\.0\.0\.1)/', $_SERVER['HTTP_HOST'])) {
                 return null; // prevent problems on local setups
             }
 


### PR DESCRIPTION
Removing the condition prevents that the `getDomain` function returns `null` just because  `$_SERVER['SERVER_ADDR']` is the local IP. The latter is the case if Symphony/Apache run behind a reverse proxy (e.g. nginx).