### PR TITLE
Tag list field: accept an array of tags

### DIFF
--- a/symphony/lib/toolkit/fields/field.taglist.php
+++ b/symphony/lib/toolkit/fields/field.taglist.php
@@ -397,9 +397,9 @@ class FieldTagList extends Field implements ExportableField, ImportableField
         }
 
         if ($this->get('validator')) {
-			if (!is_array($data)) {
-				$data = preg_split('/\,\s*/i', $data, -1, PREG_SPLIT_NO_EMPTY);
-			}
+            if (!is_array($data)) {
+                $data = preg_split('/\,\s*/i', $data, -1, PREG_SPLIT_NO_EMPTY);
+            }
             $data = array_filter(array_map('trim', $data));
 
             if (empty($data)) {
@@ -419,10 +419,10 @@ class FieldTagList extends Field implements ExportableField, ImportableField
     {
         $status = self::__OK__;
 
-		if (!is_array($data)) {
-        	$data = preg_split('/\,\s*/i', $data, -1, PREG_SPLIT_NO_EMPTY);
-		}
-		$data = array_filter(array_map('trim', $data));
+        if (!is_array($data)) {
+            $data = preg_split('/\,\s*/i', $data, -1, PREG_SPLIT_NO_EMPTY);
+        }
+        $data = array_filter(array_map('trim', $data));
 
         if (empty($data)) {
             return null;

--- a/symphony/lib/toolkit/fields/field.taglist.php
+++ b/symphony/lib/toolkit/fields/field.taglist.php
@@ -397,8 +397,10 @@ class FieldTagList extends Field implements ExportableField, ImportableField
         }
 
         if ($this->get('validator')) {
-            $data = preg_split('/\,\s*/i', $data, -1, PREG_SPLIT_NO_EMPTY);
-            $data = array_map('trim', $data);
+			if (!is_array($data)) {
+				$data = preg_split('/\,\s*/i', $data, -1, PREG_SPLIT_NO_EMPTY);
+			}
+            $data = array_filter(array_map('trim', $data));
 
             if (empty($data)) {
                 return self::__OK__;
@@ -416,8 +418,11 @@ class FieldTagList extends Field implements ExportableField, ImportableField
     public function processRawFieldData($data, &$status, &$message = null, $simulate = false, $entry_id = null)
     {
         $status = self::__OK__;
-        $data = preg_split('/\,\s*/i', $data, -1, PREG_SPLIT_NO_EMPTY);
-        $data = array_map('trim', $data);
+
+		if (!is_array($data)) {
+        	$data = preg_split('/\,\s*/i', $data, -1, PREG_SPLIT_NO_EMPTY);
+		}
+		$data = array_filter(array_map('trim', $data));
 
         if (empty($data)) {
             return null;
@@ -692,7 +697,7 @@ class FieldTagList extends Field implements ExportableField, ImportableField
                 $negation = true;
                 $null = true;
             }
-            
+
             foreach ($data as &$value) {
                 $value = $this->cleanValue($value);
             }
@@ -703,7 +708,7 @@ class FieldTagList extends Field implements ExportableField, ImportableField
                     $joins .= " LEFT JOIN `tbl_entries_data_$field_id` AS `t{$field_id}_{$this->_key}` ON (`e`.`id` = `t{$field_id}_{$this->_key}`.entry_id) ";
                     $where .= " AND (
                                         t{$field_id}_{$this->_key}.value $condition '$bit''
-                                        OR t{$field_id}_{$this->_key}.handle $condition '$bit'' 
+                                        OR t{$field_id}_{$this->_key}.handle $condition '$bit''
                                     )";
 
                     if ($null) {


### PR DESCRIPTION
While the tag list field always returned string (parameter pool) and array values (XML) in the output, it did only accept a string of tags on post. This commit extends the field to accept an array of tags as well which is helpful, if you are building a tag list widget on the front-end and would like to post back to the system.

This change is supposed to be backwards compatible (it doesn't change the behaviour for posted string values).