### PR TITLE
Sorting entries in associations drawer

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -244,12 +244,12 @@ class contentPublish extends AdministrationPage
 
         // Custom field comparisons
         foreach ($data['operators'] as $operator) {
-            
+
             $filter = trim($operator['filter']);
-            
+
             // Check selected state
             $selected = false;
-            
+
             // Selected state : Comparison mode "between" (x to y)
             if ($operator['title'] === 'between' && preg_match('/^(-?(?:\d+(?:\.\d+)?|\.\d+)) to (-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data['filter'] )) {
                 $selected = true;
@@ -257,7 +257,7 @@ class contentPublish extends AdministrationPage
             } else if ((!empty($filter) && strpos($data['filter'], $filter) === 0)) {
                 $selected = true;
             }
-	        
+
             $comparisons[] = array(
                 $operator['filter'],
                 $selected,
@@ -1601,10 +1601,27 @@ class contentPublish extends AdministrationPage
             $content = new XMLElement('div', null, array('class' => 'content'));
             $content->setSelfClosingTag(false);
 
+            // backup global sorting
+            $sorting = EntryManager::getFetchSorting();
+
             // Process Parent Associations
             if (!is_null($parent_associations) && !empty($parent_associations)) {
                 foreach ($parent_associations as $as) {
                     if ($field = FieldManager::fetch($as['parent_section_field_id'])) {
+
+                        // Get the related section
+                        $parent_section = SectionManager::fetch($as['child_parent_id']);
+
+                        if (!($parent_section instanceof Section)) {
+                            continue;
+                        }
+
+                        // set global sorting for associated section
+                        EntryManager::setFetchSorting(
+                            $parent_section->getSortingField(),
+                            $parent_section->getSortingOrder()
+                        );
+
                         if (isset($_GET['prepopulate'])) {
                             $prepopulate_field = key($_GET['prepopulate']);
                         }
@@ -1663,6 +1680,12 @@ class contentPublish extends AdministrationPage
                     if (!($child_section instanceof Section)) {
                         continue;
                     }
+
+                    // set global sorting for associated section
+                    EntryManager::setFetchSorting(
+                        $child_section->getSortingField(),
+                        $child_section->getSortingOrder()
+                    );
 
                     // Get the visible field instance (using the sorting field, this is more flexible than visibleColumns())
                     // Get the link field instance
@@ -1749,6 +1772,12 @@ class contentPublish extends AdministrationPage
                     $content->appendChild($element);
                 }
             }
+
+            // reset global sorting
+            EntryManager::setFetchSorting(
+                $sorting->field,
+                $sorting->direction
+            );
         }
 
         $drawer = Widget::Drawer('section-associations', __('Show Associations'), $content);


### PR DESCRIPTION
Would make a lot more sense to me if the associations drawer would show entries of associated sections in the same order as the publish index table.

My quick and dirty hack seems to work fine so far, but not sure if this has any nasty side effects or if there's a more elegant solution to the problem (maybe #2553).

Also not sure if others agree with me on this matter in general, so feel free to dismiss this pull request if this is actually not a desired behavior.

On a side note, I guess it would be possible to provide this functionality as an extension, but the extension would have to duplicate most of the core code for the associations drawer. Might still be an option for bringing this to the `2.6.x` branch as well, though.
