### PR TITLE
Fix deprecate in content.blueprintsdatasources

### DIFF
--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -168,7 +168,7 @@ class contentBlueprintsDatasources extends ResourcesPage
 
                             // Handle pre Symphony 2.2.1 Static DS's
                         } else {
-                            $fields['static_xml'] = trim($existing->grab());
+                            $fields['static_xml'] = trim($existing->execute());
                         }
                         break;
                     default:


### PR DESCRIPTION
Datasource::grab() is deprecated since Symphony 2.3.1
Using `execute()` instead