### PR TITLE
Unused code #796

### DIFF
--- a/symphony/lib/toolkit/class.pagemanager.php
+++ b/symphony/lib/toolkit/class.pagemanager.php
@@ -300,14 +300,6 @@ class PageManager
                 'path' => $page_path
             );
 
-            if (!PageManager::createPageFiles($page_path, $child['handle'], $child['path'], $child['handle'])) {
-                $success = false;
-            }
-
-            if (!PageManager::edit($child_id, $fields)) {
-                $success = false;
-            }
-
             $success = PageManager::editPageChildren($child_id, $page_path . '/' . $child['handle']);
         }
 

--- a/symphony/lib/toolkit/class.pagemanager.php
+++ b/symphony/lib/toolkit/class.pagemanager.php
@@ -300,6 +300,14 @@ class PageManager
                 'path' => $page_path
             );
 
+            if (!PageManager::createPageFiles($page_path, $child['handle'], $child['path'], $child['handle'])) {
+                return = false;
+            }
+
+            if (!PageManager::edit($child_id, $fields)) {
+                return = false;
+            }
+
             $success = PageManager::editPageChildren($child_id, $page_path . '/' . $child['handle']);
         }
 

--- a/symphony/lib/toolkit/class.pagemanager.php
+++ b/symphony/lib/toolkit/class.pagemanager.php
@@ -301,11 +301,11 @@ class PageManager
             );
 
             if (!PageManager::createPageFiles($page_path, $child['handle'], $child['path'], $child['handle'])) {
-                return = false;
+                return false;
             }
 
             if (!PageManager::edit($child_id, $fields)) {
-                return = false;
+                return false;
             }
 
             $success = PageManager::editPageChildren($child_id, $page_path . '/' . $child['handle']);

--- a/symphony/lib/toolkit/fields/field.taglist.php
+++ b/symphony/lib/toolkit/fields/field.taglist.php
@@ -721,8 +721,6 @@ class FieldTagList extends Field implements ExportableField, ImportableField
                     $this->_key++;
                 }
             } else {
-                $condition = ($negation) ? 'NOT IN' : 'IN';
-
                 $data = "'".implode("', '", $data)."'";
 
                 // Apply a different where condition if we are using $negation. RE: #29

--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -496,7 +496,6 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         if (file_exists($abs_path . '/' . $data['name'])) {
             $extension = General::getExtension($data['name']);
             $new_file = substr($abs_path . '/' . $data['name'], 0, -1 - strlen($extension));
-            $renamed_file = $new_file;
             $count = 1;
 
             do {


### PR DESCRIPTION
In class.pagemanager : `$success` will always be = PageManager::editPageChildren(...);
but we want to return false. Small fix to `return false;`

in field.taglist : the `$condition` wasn't use at all in the `else`.

in field.upload : `$renamed_file = $new_file;` was simply not use.
Did couple tests without it and upload working as espected.
