### PR TITLE
Add the Content-ID header on attachments

### DIFF
--- a/symphony/lib/toolkit/class.emailgateway.php
+++ b/symphony/lib/toolkit/class.emailgateway.php
@@ -307,7 +307,7 @@ abstract class EmailGateway
      *
      * @since Symphony 3.0.0
      *   The file array can contain a 'cid' key.
-     *   When set to true, the Content-ID header field is added.
+     *   When set to true, the Content-ID header field is added with the filename as id.
      *   The file array can contain a 'disposition' key.
      *   When set, it is used in the Content-Disposition header
      *
@@ -718,7 +718,7 @@ abstract class EmailGateway
      * @param string $file optional the path of the attachment
      * @param string $filename optional the name of the attached file
      * @param string $charset optional the charset of the attached file
-     * @param boolean $cid  optional add a generated Content-ID header field
+     * @param string|boolean $cid optional add a Content-ID header field. If true, uses the filename as the cid
      * @param string $disposition optional the value of the Content-Disposition header field
      *
      * @return array
@@ -774,7 +774,7 @@ abstract class EmailGateway
             $bin['Content-Disposition'] = $disposition . '; filename="' .$filename .'"';
         }
         if ($cid) {
-            $bin['Content-ID'] = "<$filename@" .  DOMAIN . '>';
+            $bin['Content-ID'] = $cid === true ? "<$filename>" : $cid;
         }
         return $bin;
     }

--- a/symphony/lib/toolkit/class.emailgateway.php
+++ b/symphony/lib/toolkit/class.emailgateway.php
@@ -635,9 +635,9 @@ abstract class EmailGateway
                      . $this->contentInfoString(
                             isset($file['mime-type']) ? $file['mime-type'] : null,
                             $file['file'],
-                            isset($file['filename']) ? $file['filename'] : null
-                            isset($file['charset']) ? $file['charset'] : null
-                            isset($file['cid']) ? $file['cid'] : null
+                            isset($file['filename']) ? $file['filename'] : null,
+                            isset($file['charset']) ? $file['charset'] : null,
+                            isset($file['cid']) ? $file['cid'] : null,
                             isset($file['disposition']) ? $file['disposition'] : 'attachment'
                         )
                      . EmailHelper::base64ContentTransferEncode($file_content);

--- a/symphony/lib/toolkit/class.emailgateway.php
+++ b/symphony/lib/toolkit/class.emailgateway.php
@@ -752,6 +752,7 @@ abstract class EmailGateway
         return array(
             'Content-Type'              => $type.';'.$charset.' name="'.$filename.'"',
             'Content-Transfer-Encoding' => 'base64',
+            'Content-ID'                => "<$filename>",
             'Content-Disposition'       => 'attachment; filename="' .$filename .'"',
         );
     }


### PR DESCRIPTION
This allows developer to reference attachments in the html body to allow
images to be viewed offline.

You can use it as follow:

``` html
<img src="cid:name-of-the-file.ext" />
```

Where the name-of-the-file.ext part matches the actual file name of the
file. Notice the `cid:` prefix, which makes it work!

@michael-e I can wait for you to review this. If @brendo or even @creativedutchmen could do it too I would appreciate, since your _mail-fu_ is greater than mine.

I've tested with and without references and everything works.
