### PR TITLE
Fix "secure" flag on cookies; fixes #2627

### DIFF
--- a/symphony/lib/core/class.cookie.php
+++ b/symphony/lib/core/class.cookie.php
@@ -109,7 +109,7 @@ class Cookie
         $this->_domain = $domain;
         $this->_httpOnly = $httpOnly;
 
-        if (defined(__SECURE__)) {
+        if (defined('__SECURE__')) {
             $this->_secure = __SECURE__;
         }
 


### PR DESCRIPTION
I suggest to also backport this fix to the 2.6.x branch.