### PR TITLE
Fix for MySQL ANSI compliance issue with order by clause and MySQL 5.7

### DIFF
--- a/symphony/lib/toolkit/data-sources/class.datasource.navigation.php
+++ b/symphony/lib/toolkit/data-sources/class.datasource.navigation.php
@@ -81,7 +81,7 @@ class NavigationDatasource extends Datasource
 
         // Build the Query appending the Parent and/or Type WHERE clauses
         $pages = Symphony::Database()->fetch(sprintf(
-            "SELECT DISTINCT p.id, p.title, p.handle, (SELECT COUNT(id) FROM `tbl_pages` WHERE parent = p.id) AS children
+            "SELECT DISTINCT p.id, p.`sortorder`, p.title, p.handle, (SELECT COUNT(id) FROM `tbl_pages` WHERE parent = p.id) AS children
             FROM `tbl_pages` AS p
             LEFT JOIN `tbl_pages_types` AS pt ON (p.id = pt.page_id)
             WHERE 1 = 1


### PR DESCRIPTION
After upgrading to MySQL 5.7 on Ubuntu 16.04.1 LTS, the datasource for navigation stopped working with this error:

`Expression #1 of ORDER BY clause is not in SELECT list, references column 'symphony.s.sortorder' which is not in SELECT list; this is incompatible with DISTINCT`

The attached code makes the SQL compliant and fixes the issue.   This is my first pull request so I hope I have done it correctly.  It is against 2.7.x as I am using PHP 7.