### PR TITLE
Add unattended installation process

### DIFF
--- a/install/includes/unattend.php
+++ b/install/includes/unattend.php
@@ -1,0 +1,45 @@
+<?php
+    $settings = array(
+        // Remove if you want only to prefill
+        'action' => array(
+            'install' => true,
+        ),
+        // Remove if you want to selected the language
+        'lang' => 'en',
+        // Posts fields
+        // Fields with default values can be removed
+        'fields' => array(
+            'general' => array(
+                'sitename' => '',
+            ),
+            'symphony' => array(
+                'admin-path' => '',
+            ),
+            'region' => array(
+                'timezone' => '',
+                'date_format' => '',
+                'time_format' => '',
+            ),
+            'database' => array(
+                'db' => '',
+                'user' => '',
+                'password' => '',
+                'host' => '',
+                'port' => '',
+                'tbl_prefix' => '',
+            ),
+            'file' => array(
+                'write_mode' => '',
+            ),
+            'directory' => array(
+                'write_mode' => '',
+            ),
+            'user' => array(
+                'username' => '',
+                'password' => '',
+                'firstname' => '',
+                'lastname' => '',
+                'email' => '',
+            ),
+        ),
+    );

--- a/install/lib/class.installerpage.php
+++ b/install/lib/class.installerpage.php
@@ -107,6 +107,7 @@
 
             $this->Form->appendChild($h2);
             $this->Form->appendChild($p);
+            $this->setHttpStatus(Page::HTTP_STATUS_ERROR);
         }
 
         protected function viewRequirements()
@@ -121,6 +122,7 @@
 
                 $this->Form->appendChild($div);
             }
+            $this->setHttpStatus(Page::HTTP_STATUS_ERROR);
         }
 
         protected function viewLanguages()
@@ -174,6 +176,7 @@
             $this->Form->appendChild(
                 new XMLElement('pre', $code)
             );
+            $this->setHttpStatus(Page::HTTP_STATUS_ERROR);
         }
 
         protected function viewSuccess()
@@ -225,7 +228,7 @@
 
         protected function viewConfiguration()
         {
-            /* -----------------------------------------------
+        /* -----------------------------------------------
          * Populating fields array
          * -----------------------------------------------
          */
@@ -426,6 +429,10 @@
             $Submit->appendChild(Widget::Input('action[install]', __('Install Symphony'), 'submit'));
 
             $this->Form->appendChild($Submit);
+
+            if (isset($this->_params['errors'])) {
+                $this->setHttpStatus(Page::HTTP_STATUS_BAD_REQUEST);
+            }
         }
 
         private function __appendError(array $codes, XMLElement &$element, $message = null)


### PR DESCRIPTION
This commit adds the ability to install Symphony without the need to
fill the install form manually. The only thing needed to implement it is
to fake POST data with a php file, namely manifest/unattend.php.

The unattended process can launch the installation process or simply
prefill the form. This is done with the 'action' array.

If something goes wrong, the form will be shown, with all the error
messages. Next form POSTs will override values coming from the
unattend.php file, giving you a quick way to fix the problems.

This feature was motivated with the need to be able to automatize the
install process without much change to the current code base.

Finally, a scaffolding version of a unattend.php file is provided in the
install/includes folder.

---

I'd like to have review on this as much as possible! Feedback is welcome!