### PR TITLE
Prevent data loss on save (entries and sections)

### DIFF
--- a/install/includes/install.sql
+++ b/install/includes/install.sql
@@ -229,8 +229,17 @@ CREATE TABLE `tbl_sections` (
   `hidden` enum('yes','no') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'no',
   `filter` enum('yes','no') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'yes',
   `navigation_group` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'Content',
+  `author_id` int(11) unsigned NOT NULL DEFAULT 1,
+  `creation_date` datetime NOT NULL,
+  `creation_date_gmt` datetime NOT NULL,
+  `modification_date` datetime NOT NULL,
+  `modification_date_gmt` datetime NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `handle` (`handle`)
+  UNIQUE KEY `handle` (`handle`),
+  KEY `creation_date` (`creation_date`),
+  KEY `creation_date_gmt` (`creation_date_gmt`),
+  KEY `modification_date` (`modification_date`),
+  KEY `modification_date_gmt` (`modification_date_gmt`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- *** STRUCTURE: `tbl_sections_association` ***

--- a/install/migrations/2.7.0.php
+++ b/install/migrations/2.7.0.php
@@ -34,6 +34,7 @@
                 Symphony::Database()->query("
                     ALTER TABLE `tbl_sections`
                         ADD COLUMN `author_id` int(11) unsigned NOT NULL DEFAULT 1,
+                        ADD COLUMN `modification_author_id` int(11) unsigned NOT NULL DEFAULT 1,
                         ADD COLUMN `creation_date` datetime NOT NULL DEFAULT '$now',
                         ADD COLUMN `creation_date_gmt` datetime NOT NULL DEFAULT '$nowGMT',
                         ADD COLUMN `modification_date` datetime NOT NULL DEFAULT '$now',
@@ -42,6 +43,11 @@
                         ADD KEY `creation_date_gmt` (`creation_date_gmt`),
                         ADD KEY `modification_date` (`modification_date`),
                         ADD KEY `modification_date_gmt` (`modification_date_gmt`);
+                ");
+                Symphony::Database()->query("
+                    ALTER TABLE `tbl_entries`
+                        ADD COLUMN `modification_author_id` int(11) unsigned NOT NULL DEFAULT 1
+                            AFTER `author_id`
                 ");
             }
 

--- a/install/migrations/2.7.0.php
+++ b/install/migrations/2.7.0.php
@@ -4,7 +4,7 @@
     {
         public static function getVersion()
         {
-            return '2.7.0.beta2';
+            return '2.7.0.beta3';
         }
 
         public static function getReleaseNotes()
@@ -25,6 +25,24 @@
                 ');
             } catch (Exception $ex) {
                 // ignore
+            }
+
+            if (version_compare(Symphony::Configuration()->get('version', 'symphony'), '2.7.0.beta3', '<')) {
+                // Add dates and author columns
+                $now = DateTimeObj::get('Y-m-d H:i:s');
+                $nowGMT = DateTimeObj::getGMT('Y-m-d H:i:s');
+                Symphony::Database()->query("
+                    ALTER TABLE `tbl_sections`
+                        ADD COLUMN `author_id` int(11) unsigned NOT NULL DEFAULT 1,
+                        ADD COLUMN `creation_date` datetime NOT NULL DEFAULT '$now',
+                        ADD COLUMN `creation_date_gmt` datetime NOT NULL DEFAULT '$nowGMT',
+                        ADD COLUMN `modification_date` datetime NOT NULL DEFAULT '$now',
+                        ADD COLUMN `modification_date_gmt` datetime NOT NULL DEFAULT '$nowGMT',
+                        ADD KEY `creation_date` (`creation_date`),
+                        ADD KEY `creation_date_gmt` (`creation_date_gmt`),
+                        ADD KEY `modification_date` (`modification_date`),
+                        ADD KEY `modification_date_gmt` (`modification_date_gmt`);
+                ");
             }
 
             // Update the version information

--- a/symphony/assets/js/src/backend.views.js
+++ b/symphony/assets/js/src/backend.views.js
@@ -181,6 +181,21 @@ Symphony.View.add('/:context*:', function() {
 		}
 	});
 
+	// Timestamp validation overwrite
+	Symphony.Elements.header.find('.notifier .js-tv-overwrite').on('click.admin', function (e){
+		var action = $(this).attr('data-action') || 'save';
+		var hidden = Symphony.Elements.contents.find('input[name="action[ignore-timestamp]"]');
+		hidden.prop('checked', true);
+		e.preventDefault();
+		e.stopPropagation();
+		e.stopImmediatePropagation();
+		// Click on the action button:
+		// This is needed since we need to send the button's data in the POST
+		Symphony.Elements.contents.find('> form').find('input, button')
+			.filter('[name="action[' + action + ']"]').first().click();
+		return false;
+	});
+
 	// Catch all JavaScript errors and write them to the Symphony Log
 	Symphony.Elements.window.on('error.admin', function(event) {
 		$.ajax({

--- a/symphony/content/content.blueprintssections.php
+++ b/symphony/content/content.blueprintssections.php
@@ -600,7 +600,10 @@ class contentBlueprintsSections extends AdministrationPage
                 $navigation_group = preg_replace('/^set-navigation-group-/', null, $_POST['with-selected']);
 
                 foreach ($checked as $section_id) {
-                    SectionManager::edit($section_id, array('navigation_group' => urldecode($navigation_group)));
+                    SectionManager::edit($section_id, array(
+                        'navigation_group' => urldecode($navigation_group),
+                        'modification_author_id' => Symphony::Author()->get('id'),
+                    ));
                 }
 
                 redirect(SYMPHONY_URL . '/blueprints/sections/');
@@ -734,6 +737,9 @@ class contentBlueprintsSections extends AdministrationPage
                      */
                     Symphony::ExtensionManager()->notifyMembers('SectionPreCreate', '/blueprints/sections/', array('meta' => &$meta, 'fields' => &$fields));
 
+                    $meta['author_id'] = Symphony::Author()->get('id');
+                    $meta['modification_author_id'] = $meta['author_id'];
+
                     if (!$section_id = SectionManager::add($meta)) {
                         $this->pageAlert(__('An unknown database occurred while attempting to create the section.'), Alert::ERROR);
                     }
@@ -760,6 +766,8 @@ class contentBlueprintsSections extends AdministrationPage
                      *  and the value being a Field object, passed by reference
                      */
                     Symphony::ExtensionManager()->notifyMembers('SectionPreEdit', '/blueprints/sections/', array('section_id' => $section_id, 'meta' => &$meta, 'fields' => &$fields));
+
+                    $meta['modification_author_id'] = Symphony::Author()->get('id');
 
                     if (!SectionManager::edit($section_id, $meta)) {
                         $canProceed = false;

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -1131,6 +1131,8 @@ class contentPublish extends AdministrationPage
                  */
                 Symphony::ExtensionManager()->notifyMembers('EntryPreCreate', '/publish/new/', array('section' => $section, 'entry' => &$entry, 'fields' => &$fields));
 
+                $entry->set('modification_author_id', Symphony::Author()->get('id'));
+
                 // Check to see if the dancing was premature
                 if (!$entry->commit()) {
                     $this->pageAlert(null, Alert::ERROR);
@@ -1195,6 +1197,7 @@ class contentPublish extends AdministrationPage
             $entry = EntryManager::create();
             $entry->set('id', $entry_id);
             $entry->set('author_id', $existingEntry->get('author_id'));
+            $entry->set('modification_author_id', $existingEntry->get('modification_author_id'));
             $entry->set('section_id', $existingEntry->get('section_id'));
             $entry->set('creation_date', $existingEntry->get('creation_date'));
             $entry->set('modification_date', $existingEntry->get('modification_date'));
@@ -1430,6 +1433,8 @@ class contentPublish extends AdministrationPage
                  * @param array $fields
                  */
                 Symphony::ExtensionManager()->notifyMembers('EntryPreEdit', '/publish/edit/', array('section' => $section, 'entry' => &$entry, 'fields' => $fields));
+
+                $entry->set('modification_author_id', Symphony::Author()->get('id'));
 
                 // Check to see if the dancing was premature
                 if (!$entry->commit()) {

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -1371,4 +1371,54 @@ class AdministrationPage extends HTMLPage
 
         $this->Header->appendChild($ul);
     }
+
+    /**
+     * Adds a localized Alert message for failed timestamp validations.
+     * It also adds meta information about the last author and timestamp.
+     *
+     * @since Symphony 2.7.0
+     * @param string $errorMessage
+     *  The error message to display.
+     * @param Entry|Section $existingObject
+     *  The Entry or section object that failed validation.
+     * @param string $action
+     *  The requested action.
+     */
+    public function addTimestampValidationPageAlert($errorMessage, $existingObject, $action)
+    {
+        $author = AuthorManager::fetchByID($existingObject->get('author_id'));
+
+        $formatteAuthorName = $existingObject->get('author_id') === Symphony::Author()->get('id')
+            ? __('yourself')
+            : (!$author
+                ? __('an unknown user')
+                : $author->get('first_name') . ' ' . $author->get('last_name'));
+
+        $msg = $this->_errors['timestamp'] . ' ' . __(
+            'made by %s at %s.', array(
+                $formatteAuthorName,
+                Widget::Time($existingObject->get('modification_date'))->generate(),
+            )
+        );
+
+        $currentUrl = Administration::instance()->getCurrentPageURL();
+        $overwritelink = Widget::Anchor(
+            __('Replace changes?'),
+            $currentUrl,
+            __('Overwrite'),
+            'js-tv-overwrite',
+            null,
+            array(
+                'data-action' => General::sanitize($action)
+            )
+        );
+        $ignorelink = Widget::Anchor(
+            __('View changes.'),
+            $currentUrl,
+            __('View the updated entry')
+        );
+        $actions = $overwritelink->generate() . ' ' . $ignorelink->generate();
+        
+        $this->pageAlert("$msg $actions", Alert::ERROR);
+    }
 }

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -1386,9 +1386,12 @@ class AdministrationPage extends HTMLPage
      */
     public function addTimestampValidationPageAlert($errorMessage, $existingObject, $action)
     {
-        $author = AuthorManager::fetchByID($existingObject->get('author_id'));
-
-        $formatteAuthorName = $existingObject->get('author_id') === Symphony::Author()->get('id')
+        $authorId = $existingObject->get('modification_author_id');
+        if (!$authorId) {
+            $authorId = $existingObject->get('author_id');
+        }
+        $author = AuthorManager::fetchByID($authorId);
+        $formatteAuthorName = $authorId === Symphony::Author()->get('id')
             ? __('yourself')
             : (!$author
                 ? __('an unknown user')

--- a/symphony/lib/toolkit/class.entry.php
+++ b/symphony/lib/toolkit/class.entry.php
@@ -102,7 +102,7 @@ class Entry
         $fields = $this->get();
         $fields['creation_date'] = $fields['modification_date'] = DateTimeObj::get('Y-m-d H:i:s');
         $fields['creation_date_gmt'] = $fields['modification_date_gmt'] = DateTimeObj::getGMT('Y-m-d H:i:s');
-        $fields['author_id'] = is_null($this->get('author_id')) ? '1' : $this->get('author_id'); // Author_id cannot be null
+        $fields['author_id'] = is_null($this->get('author_id')) ? 1 : (int)$this->get('author_id'); // Author_id cannot be null
 
         Symphony::Database()->insert($fields, 'tbl_entries');
 

--- a/symphony/lib/toolkit/class.entry.php
+++ b/symphony/lib/toolkit/class.entry.php
@@ -103,6 +103,7 @@ class Entry
         $fields['creation_date'] = $fields['modification_date'] = DateTimeObj::get('Y-m-d H:i:s');
         $fields['creation_date_gmt'] = $fields['modification_date_gmt'] = DateTimeObj::getGMT('Y-m-d H:i:s');
         $fields['author_id'] = is_null($this->get('author_id')) ? 1 : (int)$this->get('author_id'); // Author_id cannot be null
+        $fields['modification_author_id'] = is_null($this->get('modification_author_id')) ? $fields['author_id'] : (int)$this->get('modification_author_id');
 
         Symphony::Database()->insert($fields, 'tbl_entries');
 

--- a/symphony/lib/toolkit/class.entry.php
+++ b/symphony/lib/toolkit/class.entry.php
@@ -328,6 +328,10 @@ class Entry
         if (!$this->get('creation_date_gmt')) {
             $this->set('creation_date_gmt', $this->get('modification_date_gmt'));
         }
+
+        if (!$this->get('author_id')) {
+            $this->set('author_id', 1);
+        }
     }
 
     /**

--- a/symphony/lib/toolkit/class.entrymanager.php
+++ b/symphony/lib/toolkit/class.entrymanager.php
@@ -209,14 +209,15 @@ class EntryManager
      */
     public static function edit(Entry $entry)
     {
-        // Update modification date.
+        // Update modification date and modification author.
         Symphony::Database()->update(
             array(
+                'modification_author_id' => $entry->get('modification_author_id'),
                 'modification_date' => $entry->get('modification_date'),
                 'modification_date_gmt' => $entry->get('modification_date_gmt')
             ),
             'tbl_entries',
-            sprintf(' `id` = %d', $entry->get('id'))
+            sprintf(' `id` = %d', (int)$entry->get('id'))
         );
 
         // Iterate over all data for this entry
@@ -442,7 +443,8 @@ class EntryManager
         }
 
         $sql = sprintf("
-            SELECT %s`e`.`id`, `e`.section_id, `e`.`author_id`,
+            SELECT %s`e`.`id`, `e`.section_id,
+                `e`.`author_id`, `e`.`modification_author_id`,
                 `e`.`creation_date` AS `creation_date`,
                 `e`.`modification_date` AS `modification_date`
                 %s
@@ -583,6 +585,7 @@ class EntryManager
 
             $obj->set('id', $entry['meta']['id']);
             $obj->set('author_id', $entry['meta']['author_id']);
+            $obj->set('modification_author_id', $entry['meta']['modification_author_id']);
             $obj->set('section_id', $entry['meta']['section_id']);
             $obj->set('creation_date', DateTimeObj::get('c', $entry['meta']['creation_date']));
 

--- a/symphony/lib/toolkit/class.field.php
+++ b/symphony/lib/toolkit/class.field.php
@@ -1719,7 +1719,7 @@ class Field
         } elseif ($id = FieldManager::add($fields)) {
             $this->set('id', $id);
             if ($this->requiresTable()) {
-                $this->createTable();
+                return $this->createTable();
             }
             return true;
         }
@@ -1769,6 +1769,42 @@ class Field
     public function requiresTable()
     {
         return true;
+    }
+
+    /**
+     * Checks that we are working with a valid field handle and
+     * that the setting table exists.
+     *
+     * @since Symphony 2.7.0
+     * @return boolean
+     *   true if the table exists, false otherwise
+     */
+    public function tableExists()
+    {
+        if (!$this->_handle) {
+            return false;
+        }
+        return Symphony::Database()->tableExists('tbl_fields_' . $this->_handle);
+    }
+
+    /**
+     * Checks that we are working with a valid field handle and field id, and
+     * checks that the field record exists in the settings table.
+     *
+     * @since Symphony 2.7.0
+     * @return boolean
+     *   true if the field id exists in the table, false otherwise
+     */
+    public function exists()
+    {
+        if (!$this->get('id') || !$this->_handle) {
+            return false;
+        }
+        return !empty(Symphony::Database()->fetch(sprintf(
+            'SELECT `id` FROM `tbl_fields_%s` WHERE `field_id` = %d',
+            $this->_handle,
+            General::intval($this->get('id'))
+        )));
     }
 
     /**

--- a/symphony/lib/toolkit/class.sectionmanager.php
+++ b/symphony/lib/toolkit/class.sectionmanager.php
@@ -38,6 +38,7 @@ class SectionManager
         $defaults['creation_date'] = $defaults['modification_date'] = DateTimeObj::get('Y-m-d H:i:s');
         $defaults['creation_date_gmt'] = $defaults['modification_date_gmt'] = DateTimeObj::getGMT('Y-m-d H:i:s');
         $defaults['author_id'] = 1;
+        $defaults['modification_author_id'] = 1;
         $settings = array_replace($defaults, $settings);
         if (!Symphony::Database()->insert($settings, 'tbl_sections')) {
             return false;
@@ -66,6 +67,7 @@ class SectionManager
         $defaults['modification_date'] = DateTimeObj::get('Y-m-d H:i:s');
         $defaults['modification_date_gmt'] = DateTimeObj::getGMT('Y-m-d H:i:s');
         $defaults['author_id'] = 1;
+        $defaults['modification_author_id'] = 1;
         $settings = array_replace($defaults, $settings);
         if (!Symphony::Database()->update($settings, 'tbl_sections', sprintf(" `id` = %d", $section_id))) {
             return false;

--- a/symphony/lib/toolkit/class.sectionmanager.php
+++ b/symphony/lib/toolkit/class.sectionmanager.php
@@ -37,7 +37,7 @@ class SectionManager
         $defaults = array();
         $defaults['creation_date'] = $defaults['modification_date'] = DateTimeObj::get('Y-m-d H:i:s');
         $defaults['creation_date_gmt'] = $defaults['modification_date_gmt'] = DateTimeObj::getGMT('Y-m-d H:i:s');
-        $defaults['author_id'] = '1';
+        $defaults['author_id'] = 1;
         $settings = array_replace($defaults, $settings);
         if (!Symphony::Database()->insert($settings, 'tbl_sections')) {
             return false;

--- a/symphony/lib/toolkit/class.sectionmanager.php
+++ b/symphony/lib/toolkit/class.sectionmanager.php
@@ -34,6 +34,11 @@ class SectionManager
      */
     public static function add(array $settings)
     {
+        $defaults = array();
+        $defaults['creation_date'] = $defaults['modification_date'] = DateTimeObj::get('Y-m-d H:i:s');
+        $defaults['creation_date_gmt'] = $defaults['modification_date_gmt'] = DateTimeObj::getGMT('Y-m-d H:i:s');
+        $defaults['author_id'] = '1';
+        $settings = array_replace($defaults, $settings);
         if (!Symphony::Database()->insert($settings, 'tbl_sections')) {
             return false;
         }
@@ -57,6 +62,11 @@ class SectionManager
      */
     public static function edit($section_id, array $settings)
     {
+        $defaults = array();
+        $defaults['modification_date'] = DateTimeObj::get('Y-m-d H:i:s');
+        $defaults['modification_date_gmt'] = DateTimeObj::getGMT('Y-m-d H:i:s');
+        $defaults['author_id'] = 1;
+        $settings = array_replace($defaults, $settings);
         if (!Symphony::Database()->update($settings, 'tbl_sections', sprintf(" `id` = %d", $section_id))) {
             return false;
         }
@@ -175,6 +185,14 @@ class SectionManager
 
             foreach ($s as $name => $value) {
                 $obj->set($name, $value);
+            }
+
+            $obj->set('creation_date', DateTimeObj::get('c', $obj->get('creation_date')));
+
+            if (!empty($obj->get('modification_date'))) {
+                $obj->set('modification_date', DateTimeObj::get('c', $obj->get('modification_date')));
+            } else {
+                $obj->set('modification_date', $obj->get('creation_date'));
             }
 
             self::$_pool[$obj->get('id')] = $obj;

--- a/symphony/lib/toolkit/class.timestampvalidator.php
+++ b/symphony/lib/toolkit/class.timestampvalidator.php
@@ -38,23 +38,25 @@ class TimestampValidator
      * if equal to the supplied $timestamp
      *
      * @param int|string $id
-     *   The record id to check
-     * @param  string $timestamp
-     *   The user supplied timestamp
+     *  The record id to check
+     * @param string $timestamp
+     *  The user supplied timestamp
      * @return boolean
-     *   True if the $timestamp is the latest or the $id is invalid, false other wise
+     *  True if the $timestamp is the latest or the $id is invalid, false other wise
      */
     public function check($id, $timestamp)
     {
         $id = General::intval(MySQL::cleanValue($id));
         if ($id < 1) {
-            return true;
+            return false;
         }
         $timestamp = MySQL::cleanValue($timestamp);
-        $results = Symphony::Database()->fetchVar('id', 0, "
+        $sql = "
             SELECT `id` FROM `{$this->table}`
-                WHERE `id` = $id AND `modification_date` = '$timestamp'
-        ");
+                WHERE `id` = $id
+                    AND `modification_date` = '$timestamp'
+        ";
+        $results = Symphony::Database()->fetchVar('id', 0, $sql);
         return !empty($results) && General::intval($results) === $id;
     }
 }

--- a/symphony/lib/toolkit/class.timestampvalidator.php
+++ b/symphony/lib/toolkit/class.timestampvalidator.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @package toolkit
+ */
+
+/**
+ * This class checks against the Database for the latest timestamp, to make
+ * sure the data being saved is the one the user saw.
+ *
+ * @since Symphony 2.7.0
+ */
+
+class TimestampValidator
+{
+    /**
+     * The name of the table to check against
+     * @var string
+     */
+    private $table = '';
+
+    /**
+     * Creates a new TimestampValidator object, for a particular table.
+     * The `tbl_` prefix is automatically added.
+     *
+     * @param string $table
+     *   The table name
+     */
+    public function __construct($table)
+    {
+        General::ensureType(array(
+            'table' => array('var' => $table, 'type'=> 'string'),
+        ));
+        $this->table = 'tbl_' . MySQL::cleanValue($table);
+    }
+
+    /**
+     * Checks if the modified date of the record identified with $id
+     * if equal to the supplied $timestamp
+     *
+     * @param int|string $id
+     *   The record id to check
+     * @param  string $timestamp
+     *   The user supplied timestamp
+     * @return boolean
+     *   True if the $timestamp is the latest or the $id is invalid, false other wise
+     */
+    public function check($id, $timestamp)
+    {
+        $id = General::intval(MySQL::cleanValue($id));
+        if ($id < 1) {
+            return true;
+        }
+        $timestamp = MySQL::cleanValue($timestamp);
+        $results = Symphony::Database()->fetchVar('id', 0, "
+            SELECT `id` FROM `{$this->table}`
+                WHERE `id` = $id AND `modification_date` = '$timestamp'
+        ");
+        return !empty($results) && General::intval($results) === $id;
+    }
+}

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -97,6 +97,7 @@ return array(
     'TextFormatter' => $baseDir . '/symphony/lib/toolkit/class.textformatter.php',
     'TextPage' => $baseDir . '/symphony/lib/toolkit/class.textpage.php',
     'TextformatterManager' => $baseDir . '/symphony/lib/toolkit/class.textformattermanager.php',
+    'TimestampValidator' => $baseDir . '/symphony/lib/toolkit/class.timestampvalidator.php',
     'Throwable' => $baseDir . '/symphony/lib/core/class.throwable.php',
     'Updater' => $baseDir . '/install/lib/class.updater.php',
     'UpdaterPage' => $baseDir . '/install/lib/class.updaterpage.php',


### PR DESCRIPTION
We add a timestamp check before saving records.

When saving a section, if the data changes between the render of the
page and the form post, it can lead to data loss if a field was added.
The SQL will crash because it assumes the fields did not change.

When saving and entry, the SQL was ok, but still, it can lead to data
loss.

At both places, the fix provided here makes sure we are editing the
lastest version of the record.

cc @brendo @michael-e 