### PR TITLE
Prevent acting on non existing tables (Fix #2663)

### DIFF
--- a/symphony/lib/toolkit/class.mysql.php
+++ b/symphony/lib/toolkit/class.mysql.php
@@ -872,6 +872,7 @@ class MySQL
      * if the `$table` contains the `$field`.
      *
      * @since Symphony 2.3
+     * @link  https://dev.mysql.com/doc/refman/en/describe.html
      * @param string $table
      *  The table name
      * @param string $field
@@ -882,8 +883,9 @@ class MySQL
      */
     public function tableContainsField($table, $field)
     {
+        $table = MySQL::cleanValue($table);
+        $field = MySQL::cleanValue($field);
         $results = $this->fetch("DESC `{$table}` `{$field}`");
-
         return (is_array($results) && !empty($results));
     }
 
@@ -892,6 +894,7 @@ class MySQL
      * if it exists or not.
      *
      * @since Symphony 2.3.4
+     * @link  https://dev.mysql.com/doc/refman/en/show-tables.html
      * @param string $table
      *  The table name
      * @throws DatabaseException
@@ -900,8 +903,8 @@ class MySQL
      */
     public function tableExists($table)
     {
+        $table = MySQL::cleanValue($table);
         $results = $this->fetch(sprintf("SHOW TABLES LIKE '%s'", $table));
-
         return (is_array($results) && !empty($results));
     }
 


### PR DESCRIPTION
This change makes sure that the changes introduced in 4b5067f38 do not
cause a bug when the table does not exists. The old code (pre 2.7.0)
discarded all errors on delete, then checked if it had data to be
inserted. If not, the insert statement would be skipped.

The locking mechanism did add a lock statement before the delete, and
added logging all exceptions. That resulted in log "vomit".

This changes propose 2 ways of fixing this log problem:
1. It moves the empty data checks BEFORE the lock (so before the delete
as well).
2. It checks in the database if the table exist before doing anything.

4b5067f38 also un-lock the table before doing the insert. I think that
it should still maintain the lock until both delete and insert are done.

Fixes #2663

cc @animaux @michael-e