### PR TITLE
Replace url state with canonical url

### DIFF
--- a/symphony/assets/js/src/backend.js
+++ b/symphony/assets/js/src/backend.js
@@ -68,6 +68,19 @@
 
 		// Render view
 		Symphony.View.render();
+
+		// Update state to canonical url
+		if (window.history.replaceState) {
+			// Let extensions read the window.location, delay change on load
+			$(window).load(function () {
+				$('head > link[rel="canonical"][href]').eq(0).each(function () {
+					var href = $(this).attr('href');
+					if (href) {
+						window.history.replaceState(document.title, null, href);
+					}
+				});
+			});
+		}
 	});
 
 })(window.jQuery, window.Symphony);

--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -65,6 +65,7 @@ class contentBlueprintsDatasources extends ResourcesPage
         }
 
         $providers = Symphony::ExtensionManager()->getProvidersOf(iProvider::DATASOURCE);
+        $canonical_link = null;
         $isEditing = false;
         $about = $handle = null;
         $fields = array(
@@ -105,6 +106,7 @@ class contentBlueprintsDatasources extends ResourcesPage
             $handle = $this->_context[1];
             $existing = DatasourceManager::create($handle, array(), false);
             $order = isset($existing->dsParamORDER) ? stripslashes($existing->dsParamORDER) : 'asc';
+            $canonical_link = '/blueprints/datasources/edit/' . $handle . '/';
 
             if (!$existing->allowEditorToParse()) {
                 redirect(SYMPHONY_URL . '/blueprints/datasources/info/' . $handle . '/');
@@ -199,6 +201,12 @@ class contentBlueprintsDatasources extends ResourcesPage
 
         $this->setPageType('form');
         $this->setTitle(__(($isEditing ? '%1$s &ndash; %2$s &ndash; %3$s' : '%2$s &ndash; %3$s'), array($name, __('Data Sources'), __('Symphony'))));
+        if ($canonical_link) {
+            $this->addElementToHead(new XMLElement('link', null, array(
+                'rel' => 'canonical',
+                'href' => SYMPHONY_URL . $canonical_link,
+            )));
+        }
         $this->appendSubheading(($isEditing ? $name : __('Untitled')));
         $this->insertBreadcrumbs(array(
             Widget::Anchor(__('Data Sources'), SYMPHONY_URL . '/blueprints/datasources/'),

--- a/symphony/content/content.blueprintsevents.php
+++ b/symphony/content/content.blueprintsevents.php
@@ -69,9 +69,10 @@ class contentBlueprintsEvents extends ResourcesPage
         }
 
         $isEditing = ($readonly ? true : false);
-        $fields = array("name"=>null, "filters"=>null);
-        $about = array("name"=>null);
+        $fields = array('name' => null, 'filters' => null);
+        $about = array('name' => null);
         $providers = Symphony::ExtensionManager()->getProvidersOf(iProvider::EVENT);
+        $canonical_link = null;
 
         if (isset($_POST['fields'])) {
             $fields = $_POST['fields'];
@@ -108,6 +109,8 @@ class contentBlueprintsEvents extends ResourcesPage
                     $fields['filters'] = array_map('stripslashes', $existing->eParamFILTERS);
                 }
             }
+
+            $canonical_link = '/blueprints/events/' . $this->_context[0] . '/' . $handle . '/';
         }
 
         // Handle name on edited changes, or from reading an edited datasource
@@ -119,6 +122,12 @@ class contentBlueprintsEvents extends ResourcesPage
 
         $this->setPageType('form');
         $this->setTitle(__(($isEditing ? '%1$s &ndash; %2$s &ndash; %3$s' : '%2$s &ndash; %3$s'), array($name, __('Events'), __('Symphony'))));
+        if ($canonical_link) {
+            $this->addElementToHead(new XMLElement('link', null, array(
+                'rel' => 'canonical',
+                'href' => SYMPHONY_URL . $canonical_link,
+            )));
+        }
         $this->appendSubheading(($isEditing ? $about['name'] : __('Untitled')));
         $this->insertBreadcrumbs(array(
             Widget::Anchor(__('Events'), SYMPHONY_URL . '/blueprints/events/'),

--- a/symphony/content/content.blueprintspages.php
+++ b/symphony/content/content.blueprintspages.php
@@ -219,7 +219,7 @@ class contentBlueprintsPages extends AdministrationPage
         $this->setPageType('form');
         $fields = array("title"=>null, "handle"=>null, "parent"=>null, "params"=>null, "type"=>null, "data_sources"=>null);
         $existing = $fields;
-
+        $canonical_link = '/blueprints/pages/';
         $nesting = (Symphony::Configuration()->get('pages_table_nest_children', 'symphony') == 'yes');
 
         // Verify page exists:
@@ -229,12 +229,15 @@ class contentBlueprintsPages extends AdministrationPage
             }
 
             $existing = PageManager::fetchPageByID($page_id);
+            $canonical_link .= 'edit/' . $page_id . '/';
 
             if (!$existing) {
                 Administration::instance()->errorPageNotFound();
             } else {
                 $existing['type'] = PageManager::fetchPageTypes($page_id);
             }
+        } else {
+            $canonical_link .= 'new/';
         }
 
         // Status message:
@@ -282,6 +285,7 @@ class contentBlueprintsPages extends AdministrationPage
             $fields['events'] = preg_split('/,/i', $fields['events'], -1, PREG_SPLIT_NO_EMPTY);
         } elseif (isset($_REQUEST['parent']) && is_numeric($_REQUEST['parent'])) {
             $fields['parent'] = $_REQUEST['parent'];
+            $canonical_link .= '?parent=' . urlencode($_REQUEST['parent']);
         }
 
         $title = $fields['title'];
@@ -298,6 +302,10 @@ class contentBlueprintsPages extends AdministrationPage
                 __('Symphony')
             )
         ));
+        $this->addElementToHead(new XMLElement('link', null, array(
+            'rel' => 'canonical',
+            'href' => SYMPHONY_URL . $canonical_link,
+        )));
 
         $page_id = isset($page_id) ? $page_id : null;
 

--- a/symphony/content/content.blueprintssections.php
+++ b/symphony/content/content.blueprintssections.php
@@ -325,6 +325,7 @@ class contentBlueprintsSections extends AdministrationPage
         $meta = $section->get();
         $section_id = $meta['id'];
         $types = array();
+        $canonical_link = '/blueprints/sections/edit/' . $section_id . '/';
 
         $formHasErrors = (is_array($this->_errors) && !empty($this->_errors));
 
@@ -382,6 +383,11 @@ class contentBlueprintsSections extends AdministrationPage
 
         $this->setPageType('form');
         $this->setTitle(__('%1$s &ndash; %2$s &ndash; %3$s', array(General::sanitize($meta['name']), __('Sections'), __('Symphony'))));
+        $this->addElementToHead(new XMLElement('link', null, array(
+            'rel' => 'canonical',
+            'href' => SYMPHONY_URL . $canonical_link,
+        )));
+
         $this->appendSubheading(General::sanitize($meta['name']),
             Widget::Anchor(__('View Entries'), SYMPHONY_URL . '/publish/' . $section->get('handle'), __('View Section Entries'), 'button')
         );

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -1178,6 +1178,7 @@ class contentPublish extends AdministrationPage
         $base = '/publish/'.$this->_context['section_handle'] . '/';
         $new_link = $base . 'new/';
         $filter_link = $base;
+        $canonical_link = $base . 'edit/' . $entry_id . '/';
 
         EntryManager::setFetchSorting('id', 'DESC');
 
@@ -1235,6 +1236,7 @@ class contentPublish extends AdministrationPage
         if (isset($_REQUEST['prepopulate'])) {
             $new_link .= $this->getPrepopulateString();
             $filter_link .= $this->getFilterString();
+            $canonical_link .= $this->getPrepopulateString();
         }
 
         if (isset($this->_context['flag'])) {
@@ -1298,6 +1300,10 @@ class contentPublish extends AdministrationPage
         $this->setPageType('form');
         $this->Form->setAttribute('enctype', 'multipart/form-data');
         $this->setTitle(__('%1$s &ndash; %2$s &ndash; %3$s', array($title, General::sanitize($section->get('name')), __('Symphony'))));
+        $this->addElementToHead(new XMLElement('link', null, array(
+            'rel' => 'canonical',
+            'href' => SYMPHONY_URL . $canonical_link,
+        )));
 
         $sidebar_fields = $section->fetchFields(null, 'sidebar');
         $main_fields = $section->fetchFields(null, 'main');

--- a/symphony/content/content.systemauthors.php
+++ b/symphony/content/content.systemauthors.php
@@ -208,6 +208,7 @@ class contentSystemAuthors extends AdministrationPage
         $this->setPageType('form');
         $isOwner = false;
         $isEditing = ($this->_context[0] == 'edit');
+        $canonical_link = null;
 
         if (isset($_POST['fields'])) {
             $author = $this->_Author;
@@ -223,6 +224,7 @@ class contentSystemAuthors extends AdministrationPage
                     Page::HTTP_STATUS_NOT_FOUND
                 );
             }
+            $canonical_link = '/system/authors/edit/' . $author_id . '/';
         } else {
             $author = new Author;
         }
@@ -240,6 +242,12 @@ class contentSystemAuthors extends AdministrationPage
         }
 
         $this->setTitle(__(($this->_context[0] == 'new' ? '%2$s &ndash; %3$s' : '%1$s &ndash; %2$s &ndash; %3$s'), array($author->getFullName(), __('Authors'), __('Symphony'))));
+        if ($canonical_link) {
+            $this->addElementToHead(new XMLElement('link', null, array(
+                'rel' => 'canonical',
+                'href' => SYMPHONY_URL . $canonical_link,
+            )));
+        }
         $this->appendSubheading(($this->_context[0] == 'new' ? __('Untitled') : $author->getFullName()));
         $this->insertBreadcrumbs(array(
             Widget::Anchor(__('Authors'), SYMPHONY_URL . '/system/authors/'),

--- a/symphony/content/content.systemextensions.php
+++ b/symphony/content/content.systemextensions.php
@@ -19,11 +19,16 @@ class contentSystemExtensions extends AdministrationPage
 
     public function __viewIndex()
     {
+        $canonical_link = '/system/extensions/';
         $this->setPageType('table');
         $this->setTitle(__('%1$s &ndash; %2$s', array(__('Extensions'), __('Symphony'))));
+        $this->addElementToHead(new XMLElement('link', null, array(
+            'rel' => 'canonical',
+            'href' => SYMPHONY_URL . $canonical_link,
+        )));
         $this->appendSubheading(__('Extensions'));
 
-        $this->Form->setAttribute('action', SYMPHONY_URL . '/system/extensions/');
+        $this->Form->setAttribute('action', SYMPHONY_URL . $canonical_link);
 
         Sortable::initialize($this, $extensions, $sort, $order);
 

--- a/symphony/content/content.systempreferences.php
+++ b/symphony/content/content.systempreferences.php
@@ -20,7 +20,10 @@ class contentSystemPreferences extends AdministrationPage
     {
         $this->setPageType('form');
         $this->setTitle(__('%1$s &ndash; %2$s', array(__('Preferences'), __('Symphony'))));
-
+        $this->addElementToHead(new XMLElement('link', null, array(
+            'rel' => 'canonical',
+            'href' => SYMPHONY_URL . '/system/preferences/',
+        )));
         $this->appendSubheading(__('Preferences'));
 
         $bIsWritable = true;


### PR DESCRIPTION
I often see urls being shared with the various flags (saved, created) in them.
I also often see them while browsing the history.

Those ideally would not exists, but since we do a redirection on save, we need a way to still display the messages to the user.

The idea behind this commit is to hack the url usign javascript: if the page includes a link rel="canonical" tag in the head section, the javascript will replace the current state with the canonical url. It's also done only on full page load, to let extension read the value before replacing it.

This would not break the existing behaviour and could be removed when the redirection will be removed.

---

Maybe I should create function dedicated to adding the link tag...