### PR TITLE
Add sql: null and sql: not null filters

### DIFF
--- a/symphony/lib/toolkit/class.field.php
+++ b/symphony/lib/toolkit/class.field.php
@@ -1193,12 +1193,12 @@ class Field
             array(
                 'filter' => 'sql: NOT NULL',
                 'title' => 'is not empty',
-                'help' => __('Find entries where any value is selected.')
+                'help' => __('Find entries with a non-empty value.')
             ),
             array(
                 'filter' => 'sql: NULL',
                 'title' => 'is empty',
-                'help' => __('Find entries where no value is selected.')
+                'help' => __('Find entries with an empty value.')
             ),
             array(
                 'title' => 'contains',

--- a/symphony/lib/toolkit/class.field.php
+++ b/symphony/lib/toolkit/class.field.php
@@ -1191,17 +1191,27 @@ class Field
                 'help' => __('Find values that are an exact match for the given string.')
             ),
             array(
+                'filter' => 'sql: NOT NULL',
+                'title' => 'is not empty',
+                'help' => __('Find entries where any value is selected.')
+            ),
+            array(
+                'filter' => 'sql: NULL',
+                'title' => 'is empty',
+                'help' => __('Find entries where no value is selected.')
+            ),
+            array(
                 'title' => 'contains',
                 'filter' => 'regexp: ',
                 'help' => __('Find values that match the given <a href="%s">MySQL regular expressions</a>.', array(
-                    'http://dev.mysql.com/doc/mysql/en/regexp.html'
+                    'https://dev.mysql.com/doc/mysql/en/regexp.html'
                 ))
             ),
             array(
                 'title' => 'does not contain',
                 'filter' => 'not-regexp: ',
                 'help' => __('Find values that do not match the given <a href="%s">MySQL regular expressions</a>.', array(
-                    'http://dev.mysql.com/doc/mysql/en/regexp.html'
+                    'https://dev.mysql.com/doc/mysql/en/regexp.html'
                 ))
             ),
         );
@@ -1330,7 +1340,7 @@ class Field
      * flavours differs at times.
      *
      * @since Symphony 2.3
-     * @link http://dev.mysql.com/doc/refman/5.5/en/regexp.html
+     * @link https://dev.mysql.com/doc/refman/en/regexp.html
      * @param string $filter
      *  The full filter, eg. `regexp: ^[a-d]`
      * @param array $columns
@@ -1382,6 +1392,77 @@ class Field
     }
 
     /**
+     * Test whether the input string is a NULL/NOT NULL SQL clause, by searching
+     * for the prefix of `sql:` in the given `$string`, followed by `(NOT )? NULL`
+     *
+     * @since Symphony 2.7.0
+     * @param string $string
+     *  The string to test.
+     * @return boolean
+     *  True if the string is prefixed with `sql:`, false otherwise.
+     */
+    protected static function isFilterSQL($string)
+    {
+        if (preg_match('/^sql:\s*(NOT )?NULL$/i', $string)) {
+            return true;
+        }
+    }
+
+    /**
+     * Builds a basic NULL/NOT NULL SQL statement given a `$filter`.
+     *  This function supports `sql: NULL` or `sql: NOT NULL`.
+     *
+     * @since Symphony 2.7.0
+     * @link https://dev.mysql.com/doc/refman/en/regexp.html
+     * @param string $filter
+     *  The full filter, eg. `sql: NULL`
+     * @param array $columns
+     *  The array of columns that need the given `$filter` applied to. The conditions
+     *  will be added using `OR`.
+     * @param string $joins
+     *  A string containing any table joins for the current SQL fragment. By default
+     *  Datasources will always join to the `tbl_entries` table, which has an alias of
+     *  `e`. This parameter is passed by reference.
+     * @param string $where
+     *  A string containing the WHERE conditions for the current SQL fragment. This
+     *  is passed by reference and is expected to be used to add additional conditions
+     *  specific to this field
+     */
+    public function buildFilterSQL($filter, array $columns, &$joins, &$where)
+    {
+        $this->_key++;
+        $field_id = $this->get('id');
+        $filter = $this->cleanValue($filter);
+        $pattern = '';
+
+        if (preg_match('/^sql:\s*NOT NULL$/i', $filter)) {
+            $pattern = 'NOT NULL';
+        } else if (preg_match('/^sql:\s*NULL$/i', $filter)) {
+            $pattern = 'NULL';
+        } else {
+            // No match, return
+            return;
+        }
+
+        $joins .= "
+            LEFT JOIN
+                `tbl_entries_data_{$field_id}` AS t{$field_id}_{$this->_key}
+                ON (e.id = t{$field_id}_{$this->_key}.entry_id)
+        ";
+
+        $where .= "AND ( ";
+
+        foreach ($columns as $key => $col) {
+            $modifier = ($key === 0) ? '' : 'OR';
+
+            $where .= "
+                {$modifier} t{$field_id}_{$this->_key}.{$col} IS {$pattern}
+            ";
+        }
+        $where .= ")";
+    }
+
+    /**
      * Construct the SQL statement fragments to use to retrieve the data of this
      * field when utilized as a data source.
      *
@@ -1414,9 +1495,13 @@ class Field
         if (self::isFilterRegex($data[0])) {
             $this->buildRegexSQL($data[0], array('value'), $joins, $where);
 
+            // SQL filtering: allows for NULL/NOT NULL statements
+        } else if (self::isFilterSQL($data[0])) {
+            $this->buildFilterSQL($data[0], array('value'), $joins, $where);
+
             // AND operation, iterates over `$data` and uses a new JOIN for
             // every item.
-        } elseif ($andOperation) {
+        } else if ($andOperation) {
             foreach ($data as $value) {
                 $this->_key++;
                 $value = $this->cleanValue($value);
@@ -1431,7 +1516,7 @@ class Field
             }
 
             // Default logic, this will use a single JOIN statement and collapse
-            // `$data` into a string to be used inconjuction with IN
+            // `$data` into a string to be used in conjunction with IN
         } else {
             foreach ($data as &$value) {
                 $value = $this->cleanValue($value);

--- a/symphony/lib/toolkit/fields/field.author.php
+++ b/symphony/lib/toolkit/fields/field.author.php
@@ -464,7 +464,9 @@ class FieldAuthor extends Field implements ExportableField
                     ) {$regex} '{$pattern}'
                 )
             ";
-        } elseif ($andOperation) {
+        } else if (self::isFilterSQL($data[0])) {
+            $this->buildFilterSQL($data[0], array('username', 'first_name', 'last_name'), $joins, $where);
+        } else if ($andOperation) {
             foreach ($data as $value) {
                 $this->_key++;
                 $value = $this->cleanValue($value);

--- a/symphony/lib/toolkit/fields/field.date.php
+++ b/symphony/lib/toolkit/fields/field.date.php
@@ -72,17 +72,27 @@ class FieldDate extends Field implements ExportableField, ImportableField
                 'help' => __('Find values that are an exact match for the given string.')
             ),
             array(
+                'filter' => 'sql: NOT NULL',
+                'title' => 'is not empty',
+                'help' => __('Find entries where any value is selected.')
+            ),
+            array(
+                'filter' => 'sql: NULL',
+                'title' => 'is empty',
+                'help' => __('Find entries where no value is selected.')
+            ),
+            array(
                 'title' => 'contains',
                 'filter' => 'regexp: ',
                 'help' => __('Find values that match the given <a href="%s">MySQL regular expressions</a>.', array(
-                    'http://dev.mysql.com/doc/mysql/en/regexp.html'
+                    'https://dev.mysql.com/doc/mysql/en/regexp.html'
                 ))
             ),
             array(
                 'title' => 'does not contain',
                 'filter' => 'not-regexp: ',
                 'help' => __('Find values that do not match the given <a href="%s">MySQL regular expressions</a>.', array(
-                    'http://dev.mysql.com/doc/mysql/en/regexp.html'
+                    'https://dev.mysql.com/doc/mysql/en/regexp.html'
                 ))
             ),
             array(
@@ -260,7 +270,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
 
             // Switch between earlier than and later than logic
             // The earlier/later range is defined by MySQL's support. RE: #1560
-            // @link http://dev.mysql.com/doc/refman/5.0/en/datetime.html
+            // @link https://dev.mysql.com/doc/refman/en/datetime.html
             switch ($match[2]) {
                 case 'later':
                     $string = $later . ' to ' . self::$max_date;
@@ -700,6 +710,8 @@ class FieldDate extends Field implements ExportableField, ImportableField
     {
         if (self::isFilterRegex($data[0])) {
             $this->buildRegexSQL($data[0], array('value'), $joins, $where);
+        } else if (self::isFilterSQL($data[0])) {
+            $this->buildFilterSQL($data[0], array('value'), $joins, $where);
         } else {
             $parsed = array();
 

--- a/symphony/lib/toolkit/fields/field.input.php
+++ b/symphony/lib/toolkit/fields/field.input.php
@@ -297,7 +297,9 @@ class FieldInput extends Field implements ExportableField, ImportableField
 
         if (self::isFilterRegex($data[0])) {
             $this->buildRegexSQL($data[0], array('value', 'handle'), $joins, $where);
-        } elseif ($andOperation) {
+        } else if (self::isFilterSQL($data[0])) {
+            $this->buildFilterSQL($data[0], array('value', 'handle'), $joins, $where);
+        } else if ($andOperation) {
             foreach ($data as $value) {
                 $this->_key++;
                 $value = $this->cleanValue($value);

--- a/symphony/lib/toolkit/fields/field.taglist.php
+++ b/symphony/lib/toolkit/fields/field.taglist.php
@@ -651,12 +651,12 @@ class FieldTagList extends Field implements ExportableField, ImportableField
             ),
             array(
                 'filter' => 'regexp: ',
-                'title' => 'regexp',
+                'title' => 'contains',
                 'help' => __('Find entries where the value matches the regex.')
             ),
             array(
                 'filter' => 'not-regexp: ',
-                'title' => 'is not regexp',
+                'title' => 'does not contain',
                 'help' => __('Find entries where the value does not match the regex.')
             )
         );
@@ -668,26 +668,8 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
         if (self::isFilterRegex($data[0])) {
             $this->buildRegexSQL($data[0], array('value', 'handle'), $joins, $where);
-        } else if (preg_match('/^sql:\s*/', $data[0], $matches)) {
-            $data = trim(array_pop(explode(':', $data[0], 2)));
-
-            if (strpos($data, "NOT NULL") !== false) {
-
-                // Check for NOT NULL (ie. Entries that have any value)
-                $joins .= " LEFT JOIN
-                                `tbl_entries_data_{$field_id}` AS `t{$field_id}`
-                            ON (`e`.`id` = `t{$field_id}`.entry_id)";
-                $where .= " AND `t{$field_id}`.value IS NOT NULL ";
-
-            } else if (strpos($data, "NULL") !== false) {
-
-                // Check for NULL (ie. Entries that have no value)
-                $joins .= " LEFT JOIN
-                                `tbl_entries_data_{$field_id}` AS `t{$field_id}`
-                            ON (`e`.`id` = `t{$field_id}`.entry_id)";
-                $where .= " AND `t{$field_id}`.value IS NULL ";
-
-            }
+        } else if (self::isFilterSQL($data[0])) {
+            $this->buildFilterSQL($data[0], array('value', 'handle'), $joins, $where);
         } else {
             $negation = false;
             $null = false;

--- a/symphony/lib/toolkit/fields/field.textarea.php
+++ b/symphony/lib/toolkit/fields/field.textarea.php
@@ -361,6 +361,8 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
 
         if (self::isFilterRegex($data[0])) {
             $this->buildRegexSQL($data[0], array('value'), $joins, $where);
+        } else if (self::isFilterSQL($data[0])) {
+            $this->buildFilterSQL($data[0], array('value'), $joins, $where);
         } else {
             if (is_array($data)) {
                 $data = $data[0];

--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -57,17 +57,27 @@ class FieldUpload extends Field implements ExportableField, ImportableField
                 'help' => __('Find files that are an exact match for the given string.')
             ),
             array(
+                'filter' => 'sql: NOT NULL',
+                'title' => 'is not empty',
+                'help' => __('Find entries where any value is selected.')
+            ),
+            array(
+                'filter' => 'sql: NULL',
+                'title' => 'is empty',
+                'help' => __('Find entries where no value is selected.')
+            ),
+            array(
                 'title' => 'contains',
                 'filter' => 'regexp: ',
                 'help' => __('Find files that match the given <a href="%s">MySQL regular expressions</a>.', array(
-                    'http://dev.mysql.com/doc/mysql/en/regexp.html'
+                    'https://dev.mysql.com/doc/mysql/en/regexp.html'
                 ))
             ),
             array(
                 'title' => 'does not contain',
                 'filter' => 'not-regexp: ',
                 'help' => __('Find files that do not match the given <a href="%s">MySQL regular expressions</a>.', array(
-                    'http://dev.mysql.com/doc/mysql/en/regexp.html'
+                    'https://dev.mysql.com/doc/mysql/en/regexp.html'
                 ))
             ),
             array(
@@ -728,7 +738,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         if (preg_match('/^mimetype:/', $data[0])) {
             $data[0] = str_replace('mimetype:', '', $data[0]);
             $column = 'mimetype';
-        } elseif (preg_match('/^size:/', $data[0])) {
+        } else if (preg_match('/^size:/', $data[0])) {
             $data[0] = str_replace('size:', '', $data[0]);
             $column = 'size';
         } else {
@@ -737,7 +747,9 @@ class FieldUpload extends Field implements ExportableField, ImportableField
 
         if (self::isFilterRegex($data[0])) {
             $this->buildRegexSQL($data[0], array($column), $joins, $where);
-        } elseif ($andOperation) {
+        } else if (self::isFilterSQL($data[0])) {
+            $this->buildFilterSQL($data[0], array($column), $joins, $where);
+        } else if ($andOperation) {
             foreach ($data as $value) {
                 $this->_key++;
                 $value = $this->cleanValue($value);

--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -59,12 +59,12 @@ class FieldUpload extends Field implements ExportableField, ImportableField
             array(
                 'filter' => 'sql: NOT NULL',
                 'title' => 'is not empty',
-                'help' => __('Find entries where any value is selected.')
+                'help' => __('Find entries where a file has been saved.')
             ),
             array(
                 'filter' => 'sql: NULL',
                 'title' => 'is empty',
-                'help' => __('Find entries where no value is selected.')
+                'help' => __('Find entries where no file has been saved.')
             ),
             array(
                 'title' => 'contains',


### PR DESCRIPTION
Right now, there was no easy way to get empty or not empty fields via the
data source. This change adds the `sql: null` and `sql: not null` filter
values.

To prevent SQL injection, only those two cases are allowed.

Fixes #2626 

---

Also, this PR #2565, will remove the not-needed input tag when dealing with non-editable filters.

cc @cylkee 