### PR TITLE
Revert the fix using DISTINCT in order to overcome data corruption

### DIFF
--- a/symphony/lib/toolkit/class.entrymanager.php
+++ b/symphony/lib/toolkit/class.entrymanager.php
@@ -408,13 +408,13 @@ class EntryManager
         // Handle when the sort field is an actual Field
         } elseif (self::$_fetchSortField && $field = FieldManager::fetch(self::$_fetchSortField)) {
             if ($field->isSortable()) {
-                $field->buildSortingSQL($joins, $where, $sort, self::$_fetchSortDirection, $select);
+                $field->buildSortingSQL($joins, $where, $sort, self::$_fetchSortDirection);
             }
 
         // Handle if the section has a default sorting field
         } elseif ($section->getSortingField() && $field = FieldManager::fetch($section->getSortingField())) {
             if ($field->isSortable()) {
-                $field->buildSortingSQL($joins, $where, $sort, $section->getSortingOrder(), $select);
+                $field->buildSortingSQL($joins, $where, $sort, $section->getSortingOrder());
             }
 
         // No sort specified, so just sort on system id
@@ -434,7 +434,6 @@ class EntryManager
             SELECT %s`e`.`id`, `e`.section_id, `e`.`author_id`,
                 `e`.`creation_date` AS `creation_date`,
                 `e`.`modification_date` AS `modification_date`
-                %s
             FROM `tbl_entries` AS `e`
             %s
             WHERE 1
@@ -445,7 +444,6 @@ class EntryManager
             %s
             ",
             $group ? 'DISTINCT ' : '',
-            $select ? ', ' . $select : '',
             $joins,
             $entry_id ? "AND `e`.`id` IN ('".implode("', '", $entry_id)."') " : '',
             $section_id ? sprintf("AND `e`.`section_id` = %d", $section_id) : '',

--- a/symphony/lib/toolkit/class.field.php
+++ b/symphony/lib/toolkit/class.field.php
@@ -1467,19 +1467,14 @@ class Field
      * @param string $order (optional)
      *  an optional sorting direction. this defaults to ascending. if this
      *  is declared either 'random' or 'rand' then a random sort is applied.
-     * @param  string $select (optional)
-     *  an optional select clause to append. This is needed when sorting on a column
-     *  that is not part of the projection. In MySQL 5.7 strict mode, it is now required to
-     *  add all columns in the ORDER BY clause in the SELECT's projection.
      */
-    public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC', &$select = null)
+    public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC')
     {
         if (in_array(strtolower($order), array('random', 'rand'))) {
             $sort = 'ORDER BY RAND()';
         } else {
             $joins .= "LEFT OUTER JOIN `tbl_entries_data_".$this->get('id')."` AS `ed` ON (`e`.`id` = `ed`.`entry_id`) ";
             $sort = sprintf('ORDER BY `ed`.`value` %s', $order);
-            $select = '`ed`.`value`';
         }
     }
 

--- a/symphony/lib/toolkit/data-sources/class.datasource.navigation.php
+++ b/symphony/lib/toolkit/data-sources/class.datasource.navigation.php
@@ -81,10 +81,10 @@ class NavigationDatasource extends Datasource
 
         // Build the Query appending the Parent and/or Type WHERE clauses
         $pages = Symphony::Database()->fetch(sprintf(
-            "SELECT DISTINCT p.`id`, p.`title`, p.`handle`, p.`sortorder`,
-                (SELECT COUNT(id) FROM `tbl_pages` WHERE parent = p.id) AS children
-            FROM `tbl_pages` AS p
-            LEFT JOIN `tbl_pages_types` AS pt ON (p.id = pt.page_id)
+            "SELECT DISTINCT `p`.`id`, `p`.`title`, `p`.`handle`, `p`.`sortorder`,
+                (SELECT COUNT(id) FROM `tbl_pages` WHERE `parent` = `p`.`id`) AS children
+            FROM `tbl_pages` AS `p`
+            LEFT JOIN `tbl_pages_types` AS `pt` ON (`p`.`id` = `pt`.`page_id`)
             WHERE 1 = 1
             %s
             %s

--- a/symphony/lib/toolkit/data-sources/class.datasource.navigation.php
+++ b/symphony/lib/toolkit/data-sources/class.datasource.navigation.php
@@ -81,10 +81,10 @@ class NavigationDatasource extends Datasource
 
         // Build the Query appending the Parent and/or Type WHERE clauses
         $pages = Symphony::Database()->fetch(sprintf(
-            "SELECT DISTINCT `p`.`id`, `p`.`title`, `p`.`handle`, `p`.`sortorder`,
-                (SELECT COUNT(id) FROM `tbl_pages` WHERE `parent` = `p`.`id`) AS children
-            FROM `tbl_pages` AS `p`
-            LEFT JOIN `tbl_pages_types` AS `pt` ON (`p`.`id` = `pt`.`page_id`)
+            "SELECT DISTINCT p.`id`, p.`title`, p.`handle`, p.`sortorder`,
+                (SELECT COUNT(id) FROM `tbl_pages` WHERE parent = p.id) AS children
+            FROM `tbl_pages` AS p
+            LEFT JOIN `tbl_pages_types` AS pt ON (p.id = pt.page_id)
             WHERE 1 = 1
             %s
             %s

--- a/symphony/lib/toolkit/fields/field.author.php
+++ b/symphony/lib/toolkit/fields/field.author.php
@@ -537,7 +537,7 @@ class FieldAuthor extends Field implements ExportableField
         Sorting:
     -------------------------------------------------------------------------*/
 
-    public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC', &$select = null)
+    public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC')
     {
         if (in_array(strtolower($order), array('random', 'rand'))) {
             $sort = 'ORDER BY RAND()';
@@ -547,7 +547,6 @@ class FieldAuthor extends Field implements ExportableField
                 LEFT OUTER JOIN `tbl_authors` AS `a` ON (ed.author_id = a.id)
             ";
             $sort = sprintf('ORDER BY `a`.`first_name` %1$s, `a`.`last_name` %1$s', $order);
-            $select = '`a`.`first_name`, `a`.`last_name`';
         }
     }
 

--- a/symphony/lib/toolkit/fields/field.checkbox.php
+++ b/symphony/lib/toolkit/fields/field.checkbox.php
@@ -407,17 +407,16 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
         Sorting:
     -------------------------------------------------------------------------*/
 
-    public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC', &$select = null)
+    public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC')
     {
         if (in_array(strtolower($order), array('random', 'rand'))) {
             $sort = 'ORDER BY RAND()';
         } else {
             $sort = sprintf(
                 'ORDER BY (
-                    SELECT DISTINCT %s
+                    SELECT %s
                     FROM tbl_entries_data_%d AS `ed`
                     WHERE entry_id = e.id
-                    LIMIT 0, 1
                 ) %s',
                 '`ed`.value',
                 $this->get('id'),

--- a/symphony/lib/toolkit/fields/field.date.php
+++ b/symphony/lib/toolkit/fields/field.date.php
@@ -730,17 +730,16 @@ class FieldDate extends Field implements ExportableField, ImportableField
         Sorting:
     -------------------------------------------------------------------------*/
 
-    public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC', &$select = null)
+    public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC')
     {
         if (in_array(strtolower($order), array('random', 'rand'))) {
             $sort = 'ORDER BY RAND()';
         } else {
             $sort = sprintf(
                 'ORDER BY (
-                    SELECT DISTINCT %s
+                    SELECT %s
                     FROM tbl_entries_data_%d AS `ed`
                     WHERE entry_id = e.id
-                    LIMIT 0, 1
                 ) %s',
                 '`ed`.date',
                 $this->get('id'),

--- a/symphony/lib/toolkit/fields/field.input.php
+++ b/symphony/lib/toolkit/fields/field.input.php
@@ -344,17 +344,16 @@ class FieldInput extends Field implements ExportableField, ImportableField
         Sorting:
     -------------------------------------------------------------------------*/
 
-    public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC', &$select = null)
+    public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC')
     {
         if (in_array(strtolower($order), array('random', 'rand'))) {
             $sort = 'ORDER BY RAND()';
         } else {
             $sort = sprintf(
                 'ORDER BY (
-                    SELECT DISTINCT %s
+                    SELECT %s
                     FROM tbl_entries_data_%d AS `ed`
                     WHERE entry_id = e.id
-                    LIMIT 0, 1
                 ) %s',
                 '`ed`.value',
                 $this->get('id'),

--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -778,7 +778,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         Sorting:
     -------------------------------------------------------------------------*/
 
-    public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC', &$select = null)
+    public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC')
     {
         if (in_array(strtolower($order), array('random', 'rand'))) {
             $sort = 'ORDER BY RAND()';


### PR DESCRIPTION
This PR reverts https://github.com/symphonycms/symphony-2/commit/58bc57f2a4153ce0d7ad0e47406ab4a9e6b60746 and the related commit 3b30f8e. It keeps (resp. re-adds) some formatting improvements that were contained in the first (main) commit.