### PR TITLE
Fixes for strict PHP error reporting

### DIFF
--- a/symphony/content/content.blueprintssections.php
+++ b/symphony/content/content.blueprintssections.php
@@ -14,9 +14,8 @@ class contentBlueprintsSections extends AdministrationPage
 
     public function build(array $context = array())
     {
-        $section_id = $context[1];
-
-        if (isset($section_id)) {
+        if (isset($context[1])) {
+            $section_id = $context[1];
             $context['associations'] = array(
                 'parent' => SectionManager::fetchParentAssociations($section_id),
                 'child' => SectionManager::fetchChildAssociations($section_id)

--- a/symphony/lib/boot/func.utilities.php
+++ b/symphony/lib/boot/func.utilities.php
@@ -211,7 +211,7 @@ function cleanup_session_cookies()
 function is_session_empty()
 {
     $session_is_empty = true;
-    if (is_array($_SESSION)) {
+    if (isset($_SESSION) && is_array($_SESSION)) {
         foreach ($_SESSION as $contents) {
             if (!empty($contents)) {
                 $session_is_empty = false;

--- a/symphony/lib/boot/func.utilities.php
+++ b/symphony/lib/boot/func.utilities.php
@@ -133,6 +133,8 @@ function ini_size_to_bytes($val)
     $val = trim($val);
     $last = strtolower($val[strlen($val)-1]);
 
+    $val = (int) $val;
+
     switch ($last) {
         case 'g':
             $val *= 1024;

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -806,7 +806,9 @@ class AdministrationPage extends HTMLPage
                 continue;
             }
 
-            if ($this->doesAuthorHaveAccess($n['limit'])) {
+            $item_limit = isset($n['limit']) ? $n['limit'] : null;
+
+            if ($this->doesAuthorHaveAccess($item_limit)) {
                 $xGroup = new XMLElement('li', General::sanitize($n['name']), array('role' => 'presentation'));
 
                 if (isset($n['class']) && trim($n['name']) !== '') {
@@ -823,7 +825,9 @@ class AdministrationPage extends HTMLPage
                             continue;
                         }
 
-                        if ($this->doesAuthorHaveAccess($c['limit'])) {
+                        $child_item_limit = isset($c['limit']) ? $c['limit'] : null;
+
+                        if ($this->doesAuthorHaveAccess($child_item_limit)) {
                             $xChild = new XMLElement('li');
                             $xChild->setAttribute('role', 'menuitem');
                             $linkChild = Widget::Anchor(General::sanitize($c['name']), SYMPHONY_URL . $c['link']);

--- a/symphony/lib/toolkit/class.general.php
+++ b/symphony/lib/toolkit/class.general.php
@@ -1439,6 +1439,9 @@ class General
         );
 
         $last = strtolower($file_size[strlen($file_size)-1]);
+
+        $file_size = (int) $file_size;
+
         switch ($last) {
             case 'g':
                 $file_size *= 1024;

--- a/symphony/lib/toolkit/class.widget.php
+++ b/symphony/lib/toolkit/class.widget.php
@@ -403,7 +403,7 @@ class Widget
                     $th->setAttribute('scope', $col[1]);
                 }
 
-                if (is_array($col[2]) && !empty($col[2])) {
+                if (!empty($col[2]) && is_array($col[2])) {
                     $th->setAttributeArray($col[2]);
                 }
 
@@ -710,7 +710,7 @@ class Widget
      */
     private static function __SelectBuildOption($option)
     {
-        @list($value, $selected, $desc, $class, $id, $attributes) = $option;
+        list($value, $selected, $desc, $class, $id, $attributes) = array_pad($option, 6, null);
 
         if (!$desc) {
             $desc = $value;
@@ -871,7 +871,7 @@ class Widget
             if ($time === true) {
                 $separator = DateTimeObj::getSetting('datetime_separator');
                 $time = DateTimeObj::convertTimeToMoment(DateTimeObj::getSetting('time_format'));
-        
+
                 $calendar->setAttribute('data-calendar', 'datetime');
                 $calendar->setAttribute('data-format', $date . $separator . $time);
             } else {

--- a/symphony/lib/toolkit/class.xsrf.php
+++ b/symphony/lib/toolkit/class.xsrf.php
@@ -23,7 +23,11 @@ class XSRF
      */
     public static function getSessionToken()
     {
-        $token = $_SESSION[__SYM_COOKIE_PREFIX__]['xsrf-token'];
+        $token = null;
+
+        if (isset($_SESSION[__SYM_COOKIE_PREFIX__]['xsrf-token'])) {
+            $token = $_SESSION[__SYM_COOKIE_PREFIX__]['xsrf-token'];
+        }
 
         if (is_array($token)) {
             $token = key($token);

--- a/symphony/lib/toolkit/events/class.event.section.php
+++ b/symphony/lib/toolkit/events/class.event.section.php
@@ -471,7 +471,7 @@ abstract class SectionEvent extends Event
             $can_proceed = true;
 
             foreach ($this->filter_results as $fr) {
-                list($name, $status, $message, $attributes) = $fr;
+                list($name, $status, $message, $attributes) = array_pad($fr, 4, null);
 
                 $result->appendChild(
                     self::buildFilterElement($name, ($status ? 'passed' : 'failed'), $message, $attributes)


### PR DESCRIPTION
Symphony sets the desired (gracious) error reporting in `/lib/boot/bundle.php`:

```php
error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
```

In order to secure code quality, some Content Management Systems (at least Wordpress) provide a way to switch to stricter error reporting during development. Symphony has no config option for this, but you can easily replace the above with the following, for example:

```php
error_reporting(E_ALL);
```

At the moment this will definitely break a lot. But we know that PHP tends to become stricter with every release, so fixing every warning or notice would probably ease the transition to PHP 8 or later.

With this pull request, I include some example fixes (mainly related to the Symphony backend, just clicking around…). They are just a start, and they must be reviewed.

Fixing everything would be a big undertaking, and it should be done by people who know PHP better than I do. I am definitely too bad when it comes to serious programming.