### PR TITLE
Remove the attempt at fixing duplication of data

### DIFF
--- a/symphony/lib/toolkit/fields/field.checkbox.php
+++ b/symphony/lib/toolkit/fields/field.checkbox.php
@@ -414,10 +414,9 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
         } else {
             $sort = sprintf(
                 'ORDER BY (
-                    SELECT DISTINCT %s
+                    SELECT %s
                     FROM tbl_entries_data_%d AS `ed`
                     WHERE entry_id = e.id
-                    LIMIT 0, 1
                 ) %s',
                 '`ed`.value',
                 $this->get('id'),

--- a/symphony/lib/toolkit/fields/field.date.php
+++ b/symphony/lib/toolkit/fields/field.date.php
@@ -749,10 +749,9 @@ class FieldDate extends Field implements ExportableField, ImportableField
         } else {
             $sort = sprintf(
                 'ORDER BY (
-                    SELECT DISTINCT %s
+                    SELECT %s
                     FROM tbl_entries_data_%d AS `ed`
                     WHERE entry_id = e.id
-                    LIMIT 0, 1
                 ) %s',
                 '`ed`.date',
                 $this->get('id'),

--- a/symphony/lib/toolkit/fields/field.input.php
+++ b/symphony/lib/toolkit/fields/field.input.php
@@ -353,10 +353,9 @@ class FieldInput extends Field implements ExportableField, ImportableField
         } else {
             $sort = sprintf(
                 'ORDER BY (
-                    SELECT DISTINCT %s
+                    SELECT %s
                     FROM tbl_entries_data_%d AS `ed`
                     WHERE entry_id = e.id
-                    LIMIT 0, 1
                 ) %s',
                 '`ed`.value',
                 $this->get('id'),

--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -797,10 +797,9 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         } else {
             $sort = sprintf(
                 'ORDER BY (
-                    SELECT DISTINCT %s
+                    SELECT %s
                     FROM tbl_entries_data_%d AS `ed`
                     WHERE entry_id = e.id
-                    LIMIT 0, 1
                 ) %s',
                 '`ed`.file',
                 $this->get('id'),


### PR DESCRIPTION
58bc57f added DISTINCT and LIMIT clauses to sub-queries used for sorts.
The sub-query MUST return only one row, and (sometimes) it does not.
See <INSERT REF HERE>

As demonstrated by @michael-e, doing this does not suffice, since the
php code also needs to change (or we would need to add more DISTINCT
which is not better).

The new table locking mechanism (#2585) + making sure we update existing sites
that are missing the unique key should prevent (hopefully) any data
corroption before it can happen.