### PR TITLE
Add requiresTable perf optimization

### DIFF
--- a/symphony/lib/toolkit/class.entrymanager.php
+++ b/symphony/lib/toolkit/class.entrymanager.php
@@ -116,7 +116,13 @@ class EntryManager
                 continue;
             }
 
-            Symphony::Database()->delete('tbl_entries_data_' . $field_id, sprintf("
+            // Check if table exists
+            $table_name = 'tbl_entries_data_' . General::intval($field_id);
+            if (!$field->requiresTable() || !Symphony::Database()->tableExists($table_name)) {
+                continue;
+            }
+
+            Symphony::Database()->delete($table_name, sprintf("
                 `entry_id` = %d", $entry_id
             ));
 
@@ -141,7 +147,7 @@ class EntryManager
                 $fields[$ii] = array_merge($data, $fields[$ii]);
             }
 
-            Symphony::Database()->insert($fields, 'tbl_entries_data_' . $field_id);
+            Symphony::Database()->insert($fields, $table_name);
         }
 
         $entry->set('id', $entry_id);
@@ -185,7 +191,7 @@ class EntryManager
 
                 // Check if table exists
                 $table_name = 'tbl_entries_data_' . General::intval($field_id);
-                if (!Symphony::Database()->tableExists($table_name)) {
+                if (!$field->requiresTable() || !Symphony::Database()->tableExists($table_name)) {
                     continue;
                 }
 

--- a/symphony/lib/toolkit/class.field.php
+++ b/symphony/lib/toolkit/class.field.php
@@ -1674,7 +1674,9 @@ class Field
             return FieldManager::edit($id, $fields);
         } elseif ($id = FieldManager::add($fields)) {
             $this->set('id', $id);
-            $this->createTable();
+            if ($this->requiresTable()) {
+                $this->createTable();
+            }
             return true;
         }
 
@@ -1688,6 +1690,7 @@ class Field
      * additional columns to store the specific data created by the field.
      *
      * @throws DatabaseException
+     * @see Field::requiresTable()
      * @return boolean
      */
     public function createTable()
@@ -1702,6 +1705,26 @@ class Field
               KEY `value` (`value`)
             ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;"
         );
+    }
+
+    /**
+     * Tells Symphony that this field needs a table in order to store
+     * data for each of its entries. Used when adding/deleting this field in a section
+     * or entries are edited/added, data as a performance optimization.
+     * It defaults to true, which force table creation.
+     *
+     * Developers are encouraged to update their null create table implementation
+     * with this method.
+     *
+     * @since Symphony 2.7.0
+     * @see Field::createTable()
+     * @throws DatabaseException
+     * @return boolean
+     *  true if Symphony should call `createTable()`
+     */
+    public function requiresTable()
+    {
+        return true;
     }
 
     /**

--- a/symphony/lib/toolkit/class.fieldmanager.php
+++ b/symphony/lib/toolkit/class.fieldmanager.php
@@ -185,6 +185,9 @@ class FieldManager implements FileResource
      * existing section associations. This function additionally call the Field's `tearDown`
      * method so that it can cleanup any additional settings or entry tables it may of created.
      *
+     * @since Symphony 2.7.0 it will check to see if the field requires a data table before
+     * blindly trying to delete it.
+     *
      * @throws DatabaseException
      * @throws Exception
      * @param integer $id
@@ -200,7 +203,9 @@ class FieldManager implements FileResource
         Symphony::Database()->delete('tbl_fields_'.$existing->handle(), sprintf(" `field_id` = %d", $id));
         SectionManager::removeSectionAssociation($id);
 
-        Symphony::Database()->query('DROP TABLE IF EXISTS `tbl_entries_data_'.$id.'`');
+        if ($existing->requiresTable()) {
+            Symphony::Database()->query('DROP TABLE IF EXISTS `tbl_entries_data_'.$id.'`');
+        }
 
         return true;
     }


### PR DESCRIPTION
As suggested by @jonmifsud in #2664, this commit adds a new method in
the Field class, happily named requiresTable. Analogous to createTable,
this boolean flag tells Symphony to act on a table or not, reducing the
need to check for existing table when it is known to not exist.

---

BTW, while doing this, I saw this:

1. The `EntryManager::add()` method should also use LOCKS.
1. The `EntryManager::edit()` implementation and the `EntryManager::add()` implementation are ALMOST IDENTICAL and should be extracted.

I am willing to send a PR that addresses both concerns.