### PR TITLE
Remove unecessary call to clearstatcache()

### DIFF
--- a/symphony/lib/toolkit/class.general.php
+++ b/symphony/lib/toolkit/class.general.php
@@ -942,8 +942,6 @@ class General
      */
     public static function writeFile($file, $data, $perm = 0644, $mode = 'w', $trim = false)
     {
-        clearstatcache();
-
         if (static::checkFileWritable($file) === false) {
             return false;
         }


### PR DESCRIPTION
Already done in static::checkFile() call.

Fixes #2671
Re #2683
Re #2618

Wait for #2683 to merge in since it will need to be rebased.