### PR TITLE
Authors delegates

### DIFF
--- a/symphony/content/content.systemauthors.php
+++ b/symphony/content/content.systemauthors.php
@@ -165,10 +165,13 @@ class contentSystemAuthors extends AdministrationPage
                  *  An array of `Widget::TableData`, passed by reference
                  * @param array $columns
                  * An array of the current columns
+                 * @param Author $author
+                 *  The Author object.
                  */
                 Symphony::ExtensionManager()->notifyMembers('AddCustomAuthorColumnData', '/system/authors/', array(
                     'tableData' => &$tableData,
                     'columns' => $columns,
+                    'author' => $a,
                 ));
 
                 $aTableBody[] = Widget::TableRow($tableData);
@@ -445,10 +448,14 @@ class contentSystemAuthors extends AdministrationPage
         * constant.
         * @param string $default_area
         * The current `default_area` for this Author.
+        * @param Author $author
+        *  The Author object.
+        *  This parameter is available @since Symphony 2.7.0
         */
         Symphony::ExtensionManager()->notifyMembers('AddDefaultAuthorAreas', '/system/authors/', array(
             'options' => &$options,
             'default_area' => $author->get('default_area'),
+            'author' => $author,
         ));
 
         $label->appendChild(Widget::Select('fields[default_area]', $options));

--- a/symphony/content/content.systemauthors.php
+++ b/symphony/content/content.systemauthors.php
@@ -539,11 +539,17 @@ class contentSystemAuthors extends AdministrationPage
         * @param array $fields
         *  The POST fields
         *  This parameter is available @since Symphony 2.7.0
+        * @param array $errors
+        *  The error array used to validate the Author.
+        *  Extension should register their own errors elsewhere and used the value
+        *  to modify the UI accordingly.
+        *  This parameter is available @since Symphony 2.7.0
         */
         Symphony::ExtensionManager()->notifyMembers('AddElementstoAuthorForm', '/system/authors/', array(
             'form' => &$this->Form,
             'author' => $author,
             'fields' => $_POST['fields'],
+            'errors' => $this->_errors,
         ));
     }
 

--- a/symphony/content/content.systemauthors.php
+++ b/symphony/content/content.systemauthors.php
@@ -72,6 +72,21 @@ class contentSystemAuthors extends AdministrationPage
             ));
         }
 
+        /**
+         * Allows the creation of custom table columns for each author. Called
+         * after all the table headers columns have been added.
+         *
+         * @delegate AddCustomAuthorColumn
+         * @since Symphony 2.7.0
+         * @param string $context
+         * '/system/authors/'
+         * @param array $columns
+         * An array of the current columns, passed by reference
+         */
+        Symphony::ExtensionManager()->notifyMembers('AddCustomAuthorColumn', '/system/authors/', array(
+            'columns' => &$columns
+        ));
+
         $aTableHead = Sortable::buildTableHeaders($columns, $sort, $order, (isset($_REQUEST['filter']) ? '&amp;filter=' . $_REQUEST['filter'] : ''));
 
         $aTableBody = array();
@@ -130,12 +145,33 @@ class contentSystemAuthors extends AdministrationPage
 
                 $td5 = Widget::TableData($a->get("language") == null ? __("System Default") : $languages[$a->get("language")]);
 
+                $tableData = array();
                 // Add a row to the body array, assigning each cell to the row
                 if (Symphony::Author()->isDeveloper() || Symphony::Author()->isManager()) {
-                    $aTableBody[] = Widget::TableRow(array($td1, $td2, $td3, $td4, $td5));
+                    $tableData = array($td1, $td2, $td3, $td4, $td5);
                 } else {
-                    $aTableBody[] = Widget::TableRow(array($td1, $td2, $td3));
+                    $tableData = array($td1, $td2, $td3);
                 }
+
+                /**
+                 * Allows Extensions to inject custom table data for each Author
+                 * into the Authors Index
+                 *
+                 * @delegate AddCustomAuthorColumnData
+                 * @since Symphony 2.7.0
+                 * @param string $context
+                 * '/system/authors/'
+                 * @param array $tableData
+                 *  An array of `Widget::TableData`, passed by reference
+                 * @param array $columns
+                 * An array of the current columns
+                 */
+                Symphony::ExtensionManager()->notifyMembers('AddCustomAuthorColumnData', '/system/authors/', array(
+                    'tableData' => &$tableData,
+                    'columns' => $columns,
+                ));
+
+                $aTableBody[] = Widget::TableRow($tableData);
             }
         }
 

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -1131,6 +1131,25 @@ class AdministrationPage extends HTMLPage
 
         ksort($nav);
         $this->_navigation = $nav;
+
+        /**
+         * Immediately after the navigation array as been built. Provided with the
+         * navigation array. Manipulating it will alter the navigation for all pages.
+         * Developers can also alter the 'limit' property of each page to allow more
+         * or less access to them.
+         * Preventing a user from accessing the page affects both the navigation and the
+         * page access rights: user will get a 403 Forbidden error if not authorized.
+         *
+         * @delegate NavigationPostBuild
+         * @since Symphony 2.7.0
+         * @param string $context
+         *  '/backend/'
+         * @param array $nav
+         *  An associative array of the current navigation, passed by reference
+         */
+        Symphony::ExtensionManager()->notifyMembers('NavigationPostBuild', '/backend/', array(
+            'navigation' => &$this->_navigation
+        ));
     }
 
     /**

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -522,6 +522,7 @@ class AdministrationPage extends HTMLPage
         $hasAccess = $this->doesAuthorHaveAccess($page_limit);
 
         if ($hasAccess) {
+            $page_context = $this->getContext();
             /**
              * Immediately after the core access rules allowed access to this page
              * (i.e. not called if the core rules denied it).
@@ -546,6 +547,10 @@ class AdministrationPage extends HTMLPage
                 'allowed' => &$hasAccess,
                 'page_limit' => $page_limit,
                 'page_url' => $page,
+                'section' => array(
+                    'id' => !isset($page_context['section_handle']) ? 0 : SectionManager::fetchIDFromHandle($page_context['section_handle']),
+                    'handle' => $page_context['section_handle']
+                ),
             ));
         }
 
@@ -1010,13 +1015,49 @@ class AdministrationPage extends HTMLPage
                     );
                 }
 
-                $nav[$group_index]['children'][] = array(
-                    'link' => '/publish/' . $s->get('handle') . '/',
-                    'name' => $s->get('name'),
-                    'type' => 'section',
-                    'section' => array('id' => $s->get('id'), 'handle' => $s->get('handle')),
-                    'visible' => ($s->get('hidden') == 'no' ? 'yes' : 'no')
-                );
+                $hasAccess = true;
+                /**
+                 * Immediately after the core access rules allowed access to this page
+                 * (i.e. not called if the core rules denied it).
+                 * Extension developers must only further restrict access to it.
+                 * Extension developers must also take care of checking the current value
+                 * of the allowed parameter in order to prevent conflicts with other extensions.
+                 * `$context['allowed'] = $context['allowed'] && customLogic();`
+                 *
+                 * @delegate CanAccessPage
+                 * @since Symphony 2.7.0
+                 * @see doesAuthorHaveAccess()
+                 * @param string $context
+                 *  '/backend/'
+                 * @param bool $allowed
+                 *  A flag to further restrict access to the page, passed by reference
+                 * @param string $page_limit
+                 *  The computed page limit for the current page
+                 * @param string $page_url
+                 *  The computed page url for the current page
+                 */
+                Symphony::ExtensionManager()->notifyMembers('CanAccessPage', '/backend/', array(
+                    'allowed' => &$hasAccess,
+                    'page_limit' => $c['limit'],
+                    'page_url' => $c['link'],
+                    'section' => array(
+                        'id' => $s->get('id'),
+                        'handle' => $s->get('handle')
+                    ),
+                ));
+
+                if ($hasAccess) {
+                    $nav[$group_index]['children'][] = array(
+                        'link' => '/publish/' . $s->get('handle') . '/',
+                        'name' => $s->get('name'),
+                        'type' => 'section',
+                        'section' => array(
+                            'id' => $s->get('id'),
+                            'handle' => $s->get('handle')
+                        ),
+                        'visible' => ($s->get('hidden') == 'no' ? 'yes' : 'no')
+                    );
+                }
             }
         }
     }

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -866,6 +866,10 @@ class AdministrationPage extends HTMLPage
      * Returns the `$_navigation` variable of this Page. If it is empty,
      * it will be built by `__buildNavigation`
      *
+     * When it calls `__buildNavigation`, it fires a delegate, NavigationPostBuild,
+     * to allow extensions to manipulate the navigation.
+     *
+     * @uses NavigationPostBuild
      * @see __buildNavigation()
      * @return array
      */
@@ -1109,6 +1113,10 @@ class AdministrationPage extends HTMLPage
      * navigation. Additionally, this function will set the active group of the navigation
      * by checking the current page against the array of links.
      *
+     * It fires a delegate, NavigationPostBuild, to allow extensions to manipulate
+     * the navigation.
+     *
+     * @uses NavigationPostBuild
      * @link https://github.com/symphonycms/symphony-2/blob/master/symphony/assets/xml/navigation.xml
      * @link https://github.com/symphonycms/symphony-2/blob/master/symphony/lib/toolkit/class.extension.php
      */

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -795,7 +795,9 @@ class AdministrationPage extends HTMLPage
          * @param array $nav
          *  An associative array of the current navigation, passed by reference
          */
-        Symphony::ExtensionManager()->notifyMembers('NavigationPreRender', '/backend/', array('navigation' => &$nav));
+        Symphony::ExtensionManager()->notifyMembers('NavigationPreRender', '/backend/', array(
+            'navigation' => &$nav,
+        ));
 
         $navElement = new XMLElement('nav', null, array('id' => 'nav', 'role' => 'navigation'));
         $contentNav = new XMLElement('ul', null, array('class' => 'content', 'role' => 'menubar'));
@@ -1148,7 +1150,7 @@ class AdministrationPage extends HTMLPage
          *  An associative array of the current navigation, passed by reference
          */
         Symphony::ExtensionManager()->notifyMembers('NavigationPostBuild', '/backend/', array(
-            'navigation' => &$this->_navigation
+            'navigation' => &$this->_navigation,
         ));
     }
 


### PR DESCRIPTION
This has sitting in branches since November 2015... So this PR is long overdue! It's been rebased countless time, and now it needs to be released!

It adds a bunch of delegates related to the Authors and offer new delegates for extensions to be able to adapt the experience on a user basis.

- AddCustomAuthorColumn, which allows developers to add columns into the index page
- AuthorPreCreate, just before author creation. The creation can be forbidden.
- AuthorPostDelete, just after deletion. This allows extension do to some clean up
- NavigationPostBuild, which allows developers to edit the nav
- CanAccessPage, which controls if the author can see the page. Also used to check for links in the nav.

