### PR TITLE
Fix broken AND ( + ) filtering

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -388,6 +388,8 @@ class contentPublish extends AdministrationPage
         if (isset($_REQUEST['filter'])) {
             // legacy implementation, convert single filter to an array
             // split string in the form ?filter=handle:value
+            // @deprecated
+            // This should be removed in Symphony 4.0.0
             if (!is_array($_REQUEST['filter'])) {
                 list($field_handle, $filter_value) = explode(':', $_REQUEST['filter'], 2);
                 $filters[$field_handle] = rawurldecode($filter_value);
@@ -403,9 +405,9 @@ class contentPublish extends AdministrationPage
 
                 if (!is_array($value)) {
                     $filter_type = Datasource::determineFilterType($value);
-                    $value = preg_split('/'.($filter_type == Datasource::FILTER_AND ? '\+' : '(?<!\\\\),').'\s*/', $value, -1, PREG_SPLIT_NO_EMPTY);
-                    $value = array_map('trim', $value);
-                    $value = array_map(array('Datasource', 'removeEscapedCommas'), $value);
+                    $value = Datasource::splitFilter($filter_type, $value);
+                } else {
+                    $filter_type = Datasource::FILTER_OR;
                 }
 
                 // Handle date meta data #2003

--- a/symphony/lib/toolkit/class.datasource.php
+++ b/symphony/lib/toolkit/class.datasource.php
@@ -202,12 +202,16 @@ class Datasource
     }
 
     /**
-     * By default, all Symphony filters are considering to be OR and "+" filters
+     * By default, all Symphony filters are considering to be OR and " + " filters
      * are used for AND. They are all used and Entries must match each filter to be included.
-     * It is possible to use OR filtering in a field by using an "," to separate the values.
-     * eg. If the filter is "test1, test2", this will match any entries where this field
+     * It is possible to use OR filtering in a field by using an ", " to separate the values.
+     *
+     * If the filter is "test1, test2", this will match any entries where this field
      * is test1 OR test2. If the filter is "test1 + test2", this will match entries
-     * where this field is test1 AND test2. Not all fields supports this feature.
+     * where this field is test1 AND test2. The spaces around the + are required.
+     *
+     * Not all fields supports this feature.
+     *
      * This function is run on each filter (ie. each field) in a datasource.
      *
      * @param string $value
@@ -217,7 +221,32 @@ class Datasource
      */
     public static function determineFilterType($value)
     {
-        return (preg_match('/\s+\+\s+/', $value) ? Datasource::FILTER_AND : Datasource::FILTER_OR);
+        // Check for two possible combos
+        //  1. The old pattern, which is ' + '
+        //  2. A new pattern, which accounts for '+' === ' ' in urls
+        $pattern = '/(\s+\+\s+)|(\+\+\+)/';
+        return preg_match($pattern, $value) === 1 ? Datasource::FILTER_AND : Datasource::FILTER_OR;
+    }
+
+    /**
+     * Splits the filter string value into an array.
+     *
+     * @since Symphony 2.7.0
+     * @param int $filter_type
+     *  The filter's type, as determined by `determineFilterType()`.
+     *  Valid values are Datasource::FILTER_OR or Datasource::FILTER_AND
+     * @param string $value
+     *  The filter's value
+     * @return array
+     *  The splitted filter value, according to its type
+     */
+    public static function splitFilter($filter_type, $value)
+    {
+        $pattern = $filter_type === Datasource::FILTER_AND ? '\+' : '(?<!\\\\),';
+        $value = preg_split('/\s*' . $pattern . '\s*/', $value, -1, PREG_SPLIT_NO_EMPTY);
+        $value = array_map('trim', $value);
+        $value = array_map(array('Datasource', 'removeEscapedCommas'), $value);
+        return $value;
     }
 
     /**

--- a/symphony/lib/toolkit/data-sources/class.datasource.section.php
+++ b/symphony/lib/toolkit/data-sources/class.datasource.section.php
@@ -369,10 +369,9 @@ class SectionDatasource extends Datasource
 
             if (!is_array($filter)) {
                 $filter_type = Datasource::determineFilterType($filter);
-                $value = preg_split('/'.($filter_type == Datasource::FILTER_AND ? '\+' : '(?<!\\\\),').'\s*/', $filter, -1, PREG_SPLIT_NO_EMPTY);
-                $value = array_map('trim', $value);
-                $value = array_map(array('Datasource', 'removeEscapedCommas'), $value);
+                $value = Datasource::splitFilter($filter_type, $filter);
             } else {
+                $filter_type = Datasource::FILTER_OR;
                 $value = $filter;
             }
 


### PR DESCRIPTION
Right now, usign a single + for the AND filter did not worked.
The + symbol we used is a space character in urls, where most of the
filters comes from.

So, the idea is to add a new split token, namely "+++" which makes
"filter 1 + filter 2" work.

This change remove code duplication in the publish page and in the section data source.

Fixes #2561