### PR TITLE
Fix broken filter after a sort

### DIFF
--- a/symphony/assets/css/src/symphony.tables.css
+++ b/symphony/assets/css/src/symphony.tables.css
@@ -72,22 +72,25 @@ th a:after {
 }
 
 th a:active,
-th a.active,
 th a.active:after {
 	color: #808080;
 }
 
-th a:after,
-th a.active:hover:after,
-th a.active[href$=asc]:after {
-	content: '\2193';
+th a:after {
 	margin-left: 0.3rem;
+	content: '';
 }
 
-th a.active:after,
-th a[href$=asc]:after,
-th a.active[href$=asc]:hover:after {
-	content: '\2191';
+th a[href*="order=desc"]:after,
+th a.active[href*="order=asc"]:after,
+th a.active[href*="order=desc"]:hover:after {
+	content: '\2193'; /* down arrow */
+}
+
+th a[href*="order=asc"]:after,
+th a.active[href*="order=desc"]:after,
+th a.active[href*="order=asc"]:hover:after {
+	content: '\2191'; /* up arrow */
 }
 
 table.busy td {

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -17,6 +17,12 @@ class contentPublish extends AdministrationPage
     public function sort(&$sort, &$order, $params)
     {
         $section = $params['current-section'];
+        $filters = '';
+        // Format the filter query string
+        if (isset($params['filters']) && !empty($params['filters'])) {
+            $filters = preg_replace('/^&amp;/i', '', $params['filters'], 1);
+            $filters = '?' . trim($filters);
+        }
 
         // If `?unsort` is appended to the URL, then sorting is reverted
         // to 'none', aka. by 'entry-id'.
@@ -24,11 +30,11 @@ class contentPublish extends AdministrationPage
             $section->setSortingField('id', false);
             $section->setSortingOrder('desc');
 
-            redirect(Administration::instance()->getCurrentPageURL());
+            redirect(Administration::instance()->getCurrentPageURL() . $filters);
         }
 
         // By default, sorting information are retrieved from
-        // the filesystem and stored inside the `Configuration` object
+        // the file system and stored inside the `Configuration` object
         if (is_null($sort) && is_null($order)) {
             $sort = $section->getSortingField();
             $order = $section->getSortingOrder();
@@ -37,18 +43,11 @@ class contentPublish extends AdministrationPage
             EntryManager::setFetchSorting($sort, $order);
         } else {
             $sort = General::sanitize($sort);
-            $filters = '';
 
             // Ensure that this field is infact sortable, otherwise
             // fallback to IDs
             if (($field = FieldManager::fetch($sort)) instanceof Field && !$field->isSortable()) {
                 $sort = $section->getDefaultSortingField();
-            }
-
-            // Format the filter query string
-            if ($params['filters']) {
-                $filters = preg_replace('/^&amp;/i', '', $params['filters'], 1);
-                $filters = '?' . trim($filters);
             }
 
             // If the sort order or direction differs from what is saved,

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -37,6 +37,7 @@ class contentPublish extends AdministrationPage
             EntryManager::setFetchSorting($sort, $order);
         } else {
             $sort = General::sanitize($sort);
+            $filters = '';
 
             // Ensure that this field is infact sortable, otherwise
             // fallback to IDs
@@ -44,26 +45,23 @@ class contentPublish extends AdministrationPage
                 $sort = $section->getDefaultSortingField();
             }
 
+            // Format the filter query string
+            if ($params['filters']) {
+                $filters = preg_replace('/^&amp;/i', '', $params['filters'], 1);
+                $filters = '?' . trim($filters);
+            }
+
             // If the sort order or direction differs from what is saved,
             // update the config file and reload the page
             if ($sort != $section->getSortingField() || $order != $section->getSortingOrder()) {
                 $section->setSortingField($sort, false);
                 $section->setSortingOrder($order);
-
-                if ($params['filters']) {
-                    $params['filters'] = '?' . trim($params['filters'], '&amp;');
-                }
-
-                redirect(Administration::instance()->getCurrentPageURL() . $params['filters']);
+                redirect(Administration::instance()->getCurrentPageURL() . $filters);
             }
 
-            // If the sort order or direction remains the same, reload the page
+            // If the sort order and direction remains the same, reload the page
             if ($sort == $section->getSortingField() && $order == $section->getSortingOrder()) {
-                if ($params['filters']) {
-                    $params['filters'] = '?' . trim($params['filters'], '&amp;');
-                }
-
-                redirect(Administration::instance()->getCurrentPageURL() . $params['filters']);
+                redirect(Administration::instance()->getCurrentPageURL() . $filters);
             }
         }
     }


### PR DESCRIPTION
Sorting a column while a filter is active is removing the last character
of the filter from the URL after the sort is applied, if and only if, it
ends with one of those for chars: &amp;

I do not understand why both 7328c19a5 and 4631a4371 used
`trim($params['filters'], '&amp;');` to get rid of the leading '&amp;'
in the filter string.

This commits merges both mention commits into the same line, and
properly removes the leading &amp; chars.

Fixes #2465