### PR TITLE
Fix the wrong count of associated entries

### DIFF
--- a/symphony/lib/toolkit/fields/field.taglist.php
+++ b/symphony/lib/toolkit/fields/field.taglist.php
@@ -76,20 +76,14 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
     public function fetchAssociatedEntryCount($value)
     {
-        if (function_exists('cleanValue') === false) {
-            function cleanValue($val)
-            {
-                return Symphony::Database()->cleanValue($val);
-            }
-        }
-
-        $value = array_map("cleanValue", explode(',', $value));
+        $value = array_map(array($this, 'cleanValue'), explode(',', $value));
+        $value = implode("','", $value);
         $count = (int)Symphony::Database()->fetchVar('count', 0, sprintf("
-            SELECT COUNT(DISTINCT handle) AS `count`
+            SELECT COUNT(handle) AS `count`
             FROM `tbl_entries_data_%d`
             WHERE `handle` IN ('%s')",
             $this->get('id'),
-            implode("','", $value)
+            $value
         ));
 
         return $count;


### PR DESCRIPTION
The DISTINCT keywords was always returning 0 or 1.
Removing it makes the count working ok.

b10c4f67284da6eb3cb3a22a8598b44068fbb336 introduced the DISTINCT
keyword, but loads of other things, so it is hard to tell if something
made it not work.

Fixes #2455