### PR TITLE
Add Referrer-Policy: same-origin for backend pages

### DIFF
--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -455,6 +455,10 @@ class AdministrationPage extends HTMLPage
             $this->addHeaderToPage('Access-Control-Allow-Origin', URL);
         }
 
+        if (!array_key_exists('Referrer-Policy', $this->headers())) {
+            $this->addHeaderToPage('Referrer-Policy', 'same-origin');
+        }
+
         if (isset($_REQUEST['action'])) {
             $this->action();
             Symphony::Profiler()->sample('Page action run', PROFILE_LAP);

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -455,7 +455,7 @@ class AdministrationPage extends HTMLPage
             $this->addHeaderToPage('Access-Control-Allow-Origin', URL);
         }
 
-        if (!array_key_exists('Referrer-Policy', $this->headers())) {
+        if (!array_key_exists('referrer-policy', $this->headers())) {
             $this->addHeaderToPage('Referrer-Policy', 'same-origin');
         }
 


### PR DESCRIPTION
Re #2248

This will prevent leaking the url of backend pages in referrers.