### PR TITLE
Push deprecated warnings to log

### DIFF
--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -172,10 +172,12 @@ class contentBlueprintsDatasources extends ResourcesPage
                             $fields['static_xml'] = stripslashes(trim($existing->dsParamSTATIC));
 
                             // Handle Symphony 2.2.2 to 2.3 DS's
+                            // This is deprecated and will be removed in Symphony 3.0.0
                         } elseif (isset($existing->dsSTATIC)) {
                             $fields['static_xml'] = stripslashes(trim($existing->dsSTATIC));
 
                             // Handle pre Symphony 2.2.1 Static DS's
+                            // This is deprecated and will be removed in Symphony 3.0.0
                         } else {
                             $fields['static_xml'] = trim($existing->grab());
                         }

--- a/symphony/lib/core/class.cacheable.php
+++ b/symphony/lib/core/class.cacheable.php
@@ -177,6 +177,9 @@ class Cacheable
      */
     public function check($hash)
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('Cacheable::check()', 'Cacheable::read()');
+        }
         return $this->read($hash);
     }
 
@@ -189,6 +192,9 @@ class Cacheable
      */
     public function forceExpiry($hash)
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('Cacheable::forceExpiry()', 'Cacheable::delete()');
+        }
         return $this->delete($hash);
     }
 
@@ -199,6 +205,9 @@ class Cacheable
      */
     public function clean()
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('Cacheable::forceExpiry()', 'Cacheable::delete()');
+        }
         return $this->delete();
     }
 }

--- a/symphony/lib/core/class.log.php
+++ b/symphony/lib/core/class.log.php
@@ -289,6 +289,10 @@ class Log
      *  The sprintf format to apply to $method
      * @param string $opts.alternative-format
      *  The sprintf format to apply to $alternative
+     * @param string $opts.removal-format
+     *  The sprintf format to apply to $opts.removal-version
+     * @param string $opts.removal-version
+     *  The Symphony version at which the removal is planned
      * @param boolean $opts.write-to-log
      *  If set to true, this message will be immediately written to the log. By default
      *  this is set to false, which means that it will only be added to the array ready
@@ -310,6 +314,8 @@ class Log
         $defaults = array(
             'message-format' => __('The method `%s` is deprecated.'),
             'alternative-format' => __('Please use `%s` instead.'),
+            'removal-format' => __('It will be removed in Symphony %s.'),
+            'removal-version' => '3.0.0',
             'write-to-log' => true,
             'addbreak' => true,
             'append' => false,
@@ -318,6 +324,9 @@ class Log
         $opts = array_replace($defaults, $opts);
 
         $message = sprintf($opts['message-format'], $method);
+        if (!empty($opts['removal-version'])) {
+            $message .= ' ' . sprintf($opts['removal-format'], $opts['removal-version']);
+        }
         if (!empty($alternative)) {
             $message .= ' ' . sprintf($opts['alternative-format'], $alternative);
         }

--- a/symphony/lib/core/class.log.php
+++ b/symphony/lib/core/class.log.php
@@ -299,6 +299,8 @@ class Log
      * @param boolean $opts.append
      *  If set to true, the given `$message` will be append to the previous log
      *  message found in the `$_log` array
+     * @param boolean $opts.addtrace
+     *  If set to true, the caller of the function will be added. Defaults to true.
      * @return boolean|null
      *  If `$writeToLog` is passed, this function will return boolean, otherwise
      *  void
@@ -311,12 +313,21 @@ class Log
             'write-to-log' => true,
             'addbreak' => true,
             'append' => false,
+            'addtrace' => true,
         );
         $opts = array_replace($defaults, $opts);
 
         $message = sprintf($opts['message-format'], $method);
         if (!empty($alternative)) {
             $message .= ' ' . sprintf($opts['alternative-format'], $alternative);
+        }
+        if ($opts['addtrace'] === true) {
+            $trace = debug_backtrace(0, 3);
+            $index = isset($trace[2]['class']) ? 2 : 1;
+            $caller = $trace[$index]['class'] . '::' . $trace[$index]['function'] . '()';
+            $file = basename($trace[$index - 1]['file']);
+            $line = $trace[$index - 1]['line'];
+            $message .= " Called from `$caller` in $file at line $line";
         }
 
         return $this->pushToLog($message, E_DEPRECATED, $opts['write-to-log'], $opts['addbreak'], $opts['append']);

--- a/symphony/lib/core/class.log.php
+++ b/symphony/lib/core/class.log.php
@@ -275,6 +275,54 @@ class Log
     }
 
     /**
+     * Given an method name, this function will properly format a message
+     * and pass it down to `pushToLog()`
+     *
+     * @see Log::pushToLog()
+     * @since Symphony 2.7.0
+     * @param string $method
+     *  The name of the deprecated call
+     * @param string $alternative
+     *  The name of the new method to use
+     * @param array $opts (optional)
+     * @param string $opts.message-format
+     *  The sprintf format to apply to $method
+     * @param string $opts.alternative-format
+     *  The sprintf format to apply to $alternative
+     * @param boolean $opts.write-to-log
+     *  If set to true, this message will be immediately written to the log. By default
+     *  this is set to false, which means that it will only be added to the array ready
+     *  for writing
+     * @param boolean $opts.addbreak
+     *  To be used in conjunction with `$opts.write-to-log`, this will add a line break
+     *  before writing this message in the log file. Defaults to true.
+     * @param boolean $opts.append
+     *  If set to true, the given `$message` will be append to the previous log
+     *  message found in the `$_log` array
+     * @return boolean|null
+     *  If `$writeToLog` is passed, this function will return boolean, otherwise
+     *  void
+     */
+    public function pushDeprecateWarningToLog($method, $alternative = null, array $opts = array())
+    {
+        $defaults = array(
+            'message-format' => __('The method `%s` is deprecated.'),
+            'alternative-format' => __('Please use `%s` instead.'),
+            'write-to-log' => true,
+            'addbreak' => true,
+            'append' => false,
+        );
+        $opts = array_replace($defaults, $opts);
+
+        $message = sprintf($opts['message-format'], $method);
+        if (!empty($alternative)) {
+            $message .= ' ' . sprintf($opts['alternative-format'], $alternative);
+        }
+
+        return $this->pushToLog($message, E_DEPRECATED, $opts['write-to-log'], $opts['addbreak'], $opts['append']);
+    }
+
+    /**
      * The function handles the rotation of the log files. By default it will open
      * the current log file, 'main', which is written to `$_log_path` and
      * check it's file size doesn't exceed `$_max_size`. If it does, the log

--- a/symphony/lib/toolkit/class.ajaxpage.php
+++ b/symphony/lib/toolkit/class.ajaxpage.php
@@ -14,4 +14,11 @@
  */
 abstract class AjaxPage extends XMLPage
 {
+    public function __construct()
+    {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('new AjaxPage()', 'new XMLPage()');
+        }
+        parent::__construct();
+    }
 }

--- a/symphony/lib/toolkit/class.datasource.php
+++ b/symphony/lib/toolkit/class.datasource.php
@@ -161,6 +161,9 @@ class Datasource
      */
     public function grab(array &$param_pool = null)
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('Datasource::grab()', 'Datasource::execute()');
+        }
         return $this->execute($param_pool);
     }
 
@@ -553,6 +556,9 @@ class Datasource
      */
     public function __determineFilterType($value)
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('Datasource::__determineFilterType()', 'Datasource::determineFilterType()');
+        }
         return self::determineFilterType($value);
     }
 }

--- a/symphony/lib/toolkit/class.field.php
+++ b/symphony/lib/toolkit/class.field.php
@@ -1845,6 +1845,9 @@ class Field
      */
     public function fetchAssociatedEntryIDs($value)
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('Field::fetchAssociatedEntryIDs()', 'Field::findRelatedEntries()` or Field::findParentRelatedEntries()`');
+        }
     }
 
     /**

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -891,7 +891,7 @@ class FrontendPage extends XSLTPage
             ));
 
             // if the XML is still null, an extension has not run the data source, so run normally
-            // This is deprecated and will be removed in Symphony 3.0.0
+            // This is deprecated and will be replaced by execute in Symphony 3.0.0
             if (is_null($xml)) {
                 $xml = $ds->grab($this->_env['pool']);
             }

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -891,6 +891,7 @@ class FrontendPage extends XSLTPage
             ));
 
             // if the XML is still null, an extension has not run the data source, so run normally
+            // This is deprecated and will be removed in Symphony 3.0.0
             if (is_null($xml)) {
                 $xml = $ds->grab($this->_env['pool']);
             }

--- a/symphony/lib/toolkit/class.general.php
+++ b/symphony/lib/toolkit/class.general.php
@@ -989,6 +989,9 @@ class General
      */
     public static function checkFile($file)
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('General::checkFile()', '`General::checkFileWritable()');
+        }
         clearstatcache();
         $dir = dirname($file);
 

--- a/symphony/lib/toolkit/class.section.php
+++ b/symphony/lib/toolkit/class.section.php
@@ -157,7 +157,7 @@ class Section
      * section, but the field that links these sections has hidden this association
      * so an Articles column will not appear on the Author's Publish Index
      *
-     * @deprecated This function will be removed in Symphony 3.0. Use `fetchChildAssociations` instead.
+     * @deprecated This function will be removed in Symphony 3.0. Use `SectionManager::fetchChildAssociations` instead.
      * @param boolean $respect_visibility
      *  Whether to return all the section associations regardless of if they
      *  are deemed visible or not. Defaults to false, which will return all
@@ -166,6 +166,9 @@ class Section
      */
     public function fetchAssociatedSections($respect_visibility = false)
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('Section::fetchAssociatedSections()', 'SectionManager::fetchChildAssociations()');
+        }
         return SectionManager::fetchChildAssociations($this->get('id'), $respect_visibility);
     }
 

--- a/symphony/lib/toolkit/class.sectionmanager.php
+++ b/symphony/lib/toolkit/class.sectionmanager.php
@@ -336,6 +336,9 @@ class SectionManager
      */
     public static function fetchAssociatedSections($section_id, $respect_visibility = false)
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('SectionManager::fetchAssociatedSections()', 'SectionManager::fetchChildAssociations()');
+        }
         self::fetchChildAssociations($section_id, $respect_visibility);
     }
 

--- a/symphony/lib/toolkit/class.xsrf.php
+++ b/symphony/lib/toolkit/class.xsrf.php
@@ -218,6 +218,9 @@ class XSRF
      */
     public static function getSession()
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('XSRF::getSession()', 'XSRF::getSessionToken()');
+        }
         return self::getSessionToken();
     }
 }

--- a/symphony/lib/toolkit/cryptography/class.md5.php
+++ b/symphony/lib/toolkit/cryptography/class.md5.php
@@ -23,7 +23,11 @@ class MD5 extends Cryptography
      */
     public static function hash($input)
     {
-        Symphony::Log()->pushToLog('The use of MD5::hash() is discouraged due to severe security flaws.', E_DEPRECATED, true);
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('MD5::hash()', 'PBKDF2::hash()', array(
+                'message-format' => __('The use of `%s` is strongly discouraged due to severe security flaws.'),
+            ));
+        }
         return md5($input);
     }
 
@@ -37,6 +41,11 @@ class MD5 extends Cryptography
      */
     public static function file($input)
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('MD5::file()', 'PBKDF2::hash()', array(
+                'message-format' => __('The use of `%s` is strongly discouraged due to severe security flaws.'),
+            ));
+        }
         return md5_file($input);
     }
 
@@ -53,6 +62,11 @@ class MD5 extends Cryptography
      */
     public static function compare($input, $hash, $isHash = false)
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('MD5::compare()', 'PBKDF2::compare()', array(
+                'message-format' => __('The use of `%s` is strongly discouraged due to severe security flaws.'),
+            ));
+        }
         return ($hash == self::hash($input));
     }
 }

--- a/symphony/lib/toolkit/cryptography/class.sha1.php
+++ b/symphony/lib/toolkit/cryptography/class.sha1.php
@@ -23,6 +23,11 @@ class SHA1 extends Cryptography
      */
     public static function hash($input)
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('SHA1::hash()', 'PBKDF2::hash()', array(
+                'message-format' => __('The use of `%s` is strongly discouraged due to severe security flaws.'),
+            ));
+        }
         return sha1($input);
     }
 
@@ -36,6 +41,11 @@ class SHA1 extends Cryptography
      */
     public static function file($input)
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('SHA1::file()', 'PBKDF2::hash()', array(
+                'message-format' => __('The use of `%s` is strongly discouraged due to severe security flaws.'),
+            ));
+        }
         return sha1_file($input);
     }
 
@@ -52,6 +62,11 @@ class SHA1 extends Cryptography
      */
     public static function compare($input, $hash, $isHash = false)
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('SHA1::compare()', 'PBKDF2::compare()', array(
+                'message-format' => __('The use of `%s` is strongly discouraged due to severe security flaws.'),
+            ));
+        }
         return ($hash == self::hash($input));
     }
 }

--- a/symphony/lib/toolkit/data-sources/class.datasource.dynamic_xml.php
+++ b/symphony/lib/toolkit/data-sources/class.datasource.dynamic_xml.php
@@ -22,6 +22,16 @@ require_once CORE . '/class.cacheable.php';
 
 class DynamicXMLDatasource extends Datasource
 {
+    public function __construct($env = null, $process_params = true)
+    {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('new DynamicXMLDatasource()', 'new RemoteDatasource()', array(
+                'alternative-format' => __('Please install the Remote Datasource extension and use `%s` instead.'),
+            ));
+        }
+        parent::__construct($env, $process_params);
+    }
+
     public function execute(array &$param_pool = null)
     {
         $result = new XMLElement($this->dsParamROOTELEMENT);

--- a/symphony/lib/toolkit/data-sources/class.datasource.section.php
+++ b/symphony/lib/toolkit/data-sources/class.datasource.section.php
@@ -170,7 +170,13 @@ class SectionDatasource extends Datasource
             return true;
         }
 
+        // This is deprecated and will be removed in Symphony 3.0.0
         if (in_array('system:date', $this->dsParamINCLUDEDELEMENTS)) {
+            if (Symphony::Log()) {
+                Symphony::Log()->pushDeprecateWarningToLog('system:date', 'system:creation-date` or `system:modification-date', array(
+                    'message-format' => __('The `%s` data-source field is deprecated.')
+                ));
+            }
             $xDate = new XMLElement('system-date');
             $xDate->appendChild(
                 General::createXMLDateObject(
@@ -232,8 +238,9 @@ class SectionDatasource extends Datasource
     /**
      * Given an Entry object, this function will iterate over the `dsParamPARAMOUTPUT`
      * setting to see any of the Symphony system parameters need to be set.
-     * The current system parameters supported are `system:id`, `system:author`
-     * and `system:date`. If these parameters are found, the result is added
+     * The current system parameters supported are `system:id`, `system:author`,
+     * `system:creation-date` and `system:modification-date`.
+     * If these parameters are found, the result is added
      * to the `$param_pool` array using the key, `ds-datasource-handle.parameter-name`
      * For the moment, this function also supports the pre Symphony 2.3 syntax,
      * `ds-datasource-handle` which did not support multiple parameters.
@@ -269,6 +276,11 @@ class SectionDatasource extends Datasource
                     $this->_param_pool[$key][] = $entry->get('author_id');
                 }
             } elseif ($param === 'system:creation-date' || $param === 'system:date') {
+                if ($param === 'system:date' && Symphony::Log()) {
+                    Symphony::Log()->pushDeprecateWarningToLog('system:date', 'system:creation-date', array(
+                        'message-format' => __('The `%s` data-source output parameter is deprecated.')
+                    ));
+                }
                 $this->_param_pool[$param_key][] = $entry->get('creation_date');
 
                 if ($singleParam) {
@@ -432,6 +444,11 @@ class SectionDatasource extends Datasource
                     }
                 }
             } elseif ($field_id === 'system:creation-date' || $field_id === 'system:modification-date' || $field_id === 'system:date') {
+                if ($field_id === 'system:date' && Symphony::Log()) {
+                    Symphony::Log()->pushDeprecateWarningToLog('system:date', 'system:creation-date` or `system:modification-date', array(
+                        'message-format' => __('The `%s` data-source filter is deprecated.')
+                    ));
+                }
                 $date_joins = '';
                 $date_where = '';
                 $date = new FieldDate();
@@ -521,6 +538,11 @@ class SectionDatasource extends Datasource
         if ($this->dsParamSORT == 'system:id') {
             EntryManager::setFetchSorting('system:id', $this->dsParamORDER);
         } elseif ($this->dsParamSORT == 'system:date' || $this->dsParamSORT == 'system:creation-date') {
+            if ($this->dsParamSORT === 'system:date' && Symphony::Log()) {
+                Symphony::Log()->pushDeprecateWarningToLog('system:date', 'system:creation-date', array(
+                    'message-format' => __('The `%s` data-source sort is deprecated.')
+                ));
+            }
             EntryManager::setFetchSorting('system:creation-date', $this->dsParamORDER);
         } elseif ($this->dsParamSORT == 'system:modification-date') {
             EntryManager::setFetchSorting('system:modification-date', $this->dsParamORDER);

--- a/symphony/lib/toolkit/fields/field.taglist.php
+++ b/symphony/lib/toolkit/fields/field.taglist.php
@@ -190,6 +190,9 @@ class FieldTagList extends Field implements ExportableField, ImportableField
      */
     public function findAllTags()
     {
+        if (Symphony::Log()) {
+            Symphony::Log()->pushDeprecateWarningToLog('FieldTagList::findAllTags()', 'FieldTagList::getToggleStates()');
+        }
         $this->getToggleStates();
     }
 


### PR DESCRIPTION
I've logged all method calls. Defines are pretty hard to catch, so it's
a can't do. I've also fixed some docs along the way.

Fixes #2693 

It also adds stack trace info in deprecate message