### PR TITLE
Group 404 checkboxes and shorten their labels

### DIFF
--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -324,8 +324,15 @@ class contentBlueprintsDatasources extends ResourcesPage
 
         $fieldset->appendChild($group);
 
+        $this->Form->appendChild($fieldset);
+
+        $fieldset = new XMLElement('fieldset');
+        $this->setContext($fieldset, array('sections', 'system'));
+        $fieldset->appendChild(new XMLElement('legend', __('Page not found')));
+        $p = new XMLElement('p', __('Redirect to 404 page by enabling those criteria.'));
+        $p->setAttribute('class', 'help');
+        $fieldset->appendChild($p);
         $group = new XMLElement('div');
-        $group->appendChild(new XMLElement('label', __('Redirect to 404 page when:')));
 
         $label = Widget::Checkbox('fields[redirect_on_required]', $fields['redirect_on_required'], __('The required parameter is missing'));
         $group->appendChild($label);

--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -292,7 +292,7 @@ class contentBlueprintsDatasources extends ResourcesPage
         // Conditions
         $fieldset = new XMLElement('fieldset');
         $this->setContext($fieldset, array('sections', 'system'));
-        $fieldset->appendChild(new XMLElement('legend', __('Conditions')));
+        $fieldset->appendChild(new XMLElement('legend', __('Execution Rules')));
         $p = new XMLElement('p', __('Leaving these fields empty will always execute the data source.'));
         $p->setAttribute('class', 'help');
         $fieldset->appendChild($p);
@@ -328,8 +328,8 @@ class contentBlueprintsDatasources extends ResourcesPage
 
         $fieldset = new XMLElement('fieldset');
         $this->setContext($fieldset, array('sections', 'system'));
-        $fieldset->appendChild(new XMLElement('legend', __('Page not found')));
-        $p = new XMLElement('p', __('Redirect to 404 page by enabling those criteria.'));
+        $fieldset->appendChild(new XMLElement('legend', __('Error Rules')));
+        $p = new XMLElement('p', __('Enabling these conditions will send a <code>404 page not found</code> error.'));
         $p->setAttribute('class', 'help');
         $fieldset->appendChild($p);
         $group = new XMLElement('div');

--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -292,7 +292,7 @@ class contentBlueprintsDatasources extends ResourcesPage
         // Conditions
         $fieldset = new XMLElement('fieldset');
         $this->setContext($fieldset, array('sections', 'system'));
-        $fieldset->appendChild(new XMLElement('legend', __('Execution Rules')));
+        $fieldset->appendChild(new XMLElement('legend', __('Execution Conditions')));
         $p = new XMLElement('p', __('Leaving these fields empty will always execute the data source.'));
         $p->setAttribute('class', 'help');
         $fieldset->appendChild($p);
@@ -328,7 +328,7 @@ class contentBlueprintsDatasources extends ResourcesPage
 
         $fieldset = new XMLElement('fieldset');
         $this->setContext($fieldset, array('sections', 'system'));
-        $fieldset->appendChild(new XMLElement('legend', __('Error Rules')));
+        $fieldset->appendChild(new XMLElement('legend', __('Error Conditions')));
         $p = new XMLElement('p', __('Enabling these conditions will send a <code>404 page not found</code> error.'));
         $p->setAttribute('class', 'help');
         $fieldset->appendChild($p);

--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -325,21 +325,18 @@ class contentBlueprintsDatasources extends ResourcesPage
         $fieldset->appendChild($group);
 
         $group = new XMLElement('div');
-        $group->setAttribute('class', 'two columns');
+        $group->appendChild(new XMLElement('label', __('Redirect to 404 page when:')));
 
-        $label = Widget::Checkbox('fields[redirect_on_required]', $fields['redirect_on_required'], __('Redirect to 404 page when the required parameter is not present'));
-        $label->setAttribute('class', 'column');
+        $label = Widget::Checkbox('fields[redirect_on_required]', $fields['redirect_on_required'], __('The required parameter is missing'));
         $group->appendChild($label);
 
-        $label = Widget::Checkbox('fields[redirect_on_forbidden]', $fields['redirect_on_forbidden'], __('Redirect to 404 page when the forbidden parameter is present'));
-        $label->setAttribute('class', 'column');
+        $label = Widget::Checkbox('fields[redirect_on_forbidden]', $fields['redirect_on_forbidden'], __('The forbidden parameter is present'));
+        $group->appendChild($label);
+
+        $label = Widget::Checkbox('fields[redirect_on_empty]', $fields['redirect_on_empty'], __('No results are found'));
         $group->appendChild($label);
 
         $fieldset->appendChild($group);
-
-        $label = Widget::Checkbox('fields[redirect_on_empty]', $fields['redirect_on_empty'], __('Redirect to 404 page when no results are found'));
-        $label->setAttribute('class', 'column');
-        $fieldset->appendChild($label);
 
         $this->Form->appendChild($fieldset);
 


### PR DESCRIPTION
Trying to associate the first 2 checkbox with their respective textbox
while having a unrelated thrid checkbox is confusing. Also, all labels
were are hard to read (length) and cannot be differentiated easily
(similarity)

Fixes #2250