### PR TITLE
Make sure we always have a date and time format

### DIFF
--- a/symphony/lib/core/class.datetimeobj.php
+++ b/symphony/lib/core/class.datetimeobj.php
@@ -17,10 +17,15 @@ class DateTimeObj
      * Holds the various settings for the formats that the `DateTimeObj` should
      * use when parsing input dates.
      *
+     * @since Symphony 2.7.0 it contains default values to prevent the case where
+     * no settings are set
      * @since Symphony 2.2.4
      * @var array
      */
-    private static $settings = array();
+    private static $settings = array(
+        'time_format' => 'g:i a',
+        'date_format' => 'm/d/Y',
+    );
 
     /**
      * Mapping PHP to Moment date formats.
@@ -90,7 +95,7 @@ class DateTimeObj
         // Datetime format
         if (isset($settings['datetime_format'])) {
             self::$settings['datetime_format'] = $settings['datetime_format'];
-        } else {
+        } elseif (!isset(self::$settings['datetime_format'])) {
             self::$settings['datetime_format'] = self::$settings['date_format'] . self::$settings['datetime_separator'] . self::$settings['time_format'];
         }
 
@@ -98,6 +103,11 @@ class DateTimeObj
         if (isset($settings['timezone']) && !empty($settings['timezone'])) {
             self::$settings['timezone'] = $settings['timezone'];
             self::setDefaultTimezone($settings['timezone']);
+        } elseif (!isset(self::$settings['timezone'])) {
+            self::$settings['timezone'] = ini_get('date.timezone');
+            if (empty(self::$settings['timezone'])) {
+                self::$settings['timezone'] = 'UTC';
+            }
         }
     }
 

--- a/symphony/lib/core/class.log.php
+++ b/symphony/lib/core/class.log.php
@@ -132,6 +132,9 @@ class Log
      */
     public function setDateTimeFormat($format)
     {
+        if (empty($format)) {
+            throw new Exception('Datetime format can not be empty');
+        }
         $this->_datetime_format = $format;
     }
 

--- a/symphony/lib/core/class.symphony.php
+++ b/symphony/lib/core/class.symphony.php
@@ -166,10 +166,11 @@ abstract class Symphony implements Singleton
         self::$Configuration->setArray($data);
 
         // Set date format throughout the system
-        define_safe('__SYM_DATE_FORMAT__', self::Configuration()->get('date_format', 'region'));
-        define_safe('__SYM_TIME_FORMAT__', self::Configuration()->get('time_format', 'region'));
-        define_safe('__SYM_DATETIME_FORMAT__', __SYM_DATE_FORMAT__ . self::Configuration()->get('datetime_separator', 'region') . __SYM_TIME_FORMAT__);
-        DateTimeObj::setSettings(self::Configuration()->get('region'));
+        $region = self::Configuration()->get('region');
+        define_safe('__SYM_DATE_FORMAT__', $region['date_format']);
+        define_safe('__SYM_TIME_FORMAT__', $region['time_format']);
+        define_safe('__SYM_DATETIME_FORMAT__', __SYM_DATE_FORMAT__ . $region['datetime_separator'] . __SYM_TIME_FORMAT__);
+        DateTimeObj::setSettings($region);
     }
 
     /**
@@ -228,7 +229,7 @@ abstract class Symphony implements Singleton
         self::$Log = new Log($filename);
         self::$Log->setArchive((self::Configuration()->get('archive', 'log') == '1' ? true : false));
         self::$Log->setMaxSize(intval(self::Configuration()->get('maxsize', 'log')));
-        self::$Log->setDateTimeFormat(self::Configuration()->get('date_format', 'region') . ' ' . self::Configuration()->get('time_format', 'region'));
+        self::$Log->setDateTimeFormat(__SYM_DATETIME_FORMAT__);
 
         if (self::$Log->open(Log::APPEND, self::Configuration()->get('write_mode', 'file')) == '1') {
             self::$Log->initialise('Symphony Log');

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -366,7 +366,7 @@ class AdministrationPage extends HTMLPage
         $this->addStylesheetToHead(ASSETS_URL . '/css/symphony.min.css', 'screen', 2, false);
 
         // Calculate timezone offset from UTC
-        $timezone = new DateTimeZone(Symphony::Configuration()->get('timezone', 'region'));
+        $timezone = new DateTimeZone(DateTimeObj::getSetting('timezone'));
         $datetime = new DateTime('now', $timezone);
         $timezoneOffset = intval($timezone->getOffset($datetime)) / 60;
 
@@ -474,6 +474,20 @@ class AdministrationPage extends HTMLPage
         // Add Breadcrumbs
         $this->Context->prependChild($this->Breadcrumbs);
         $this->Contents->appendChild($this->Form);
+
+        // Validate date time config
+        if (empty(__SYM_DATE_FORMAT__)) {
+            $this->pageAlert(
+                __('Your <code>%s</code> file does not define a date format', array(basename(CONFIG))),
+                Alert::NOTICE
+            );
+        }
+        if (empty(__SYM_TIME_FORMAT__)) {
+            $this->pageAlert(
+                __('Your <code>%s</code> file does not define a time format.', array(basename(CONFIG))),
+                Alert::NOTICE
+            );
+        }
 
         $this->view();
 

--- a/symphony/lib/toolkit/class.general.php
+++ b/symphony/lib/toolkit/class.general.php
@@ -1525,9 +1525,11 @@ class General
      *  the name of the element to append to the namespace of the constructed XML.
      *  this defaults to "date".
      * @param string $date_format (optional)
-     *  the format to apply to the date, defaults to `Y-m-d`
+     *  the format to apply to the date, defaults to `Y-m-d`.
+     *  if empty, uses DateTimeObj settings.
      * @param string $time_format (optional)
-     *  the format to apply to the date, defaults to `H:i`
+     *  the format to apply to the date, defaults to `H:i`.
+     *  if empty, uses DateTimeObj settings.
      * @param string $namespace (optional)
      *  the namespace in which the resulting XML entity will reside. this defaults
      *  to null.
@@ -1539,6 +1541,13 @@ class General
     {
         if (!class_exists('XMLElement')) {
             return false;
+        }
+
+        if (empty($date_format)) {
+            $date_format = DateTimeObj::getSetting('date_format');
+        }
+        if (empty($time_format)) {
+            $time_format = DateTimeObj::getSetting('time_format');
         }
 
         $xDate = new XMLElement(


### PR DESCRIPTION
If, somehow, the date_format or time_format config is missing, Symphony
stops displaying dates. This is problematic as we rely on date
formatting a lot.

This change adds a default values for date_format and time_format
directly in the DateTimeObj class. It also makes sure we have a valid
timezone. If not, the date.timezone php.ini value is used. If it is
still empty, we default to UTC.

This change made is possible to remove Configuration()->get() calls and
replace them with __SYM_DATE_FORMAT__ or __SYM_TIME_FORMAT__ constant
when possible, or uses DateTimeObj::getSetting() which shoulw always
return a value.

Finally, this change also adds page alerts when a missing date_format or
time_format is empty.

Fixes #2704