### PR TITLE
Remove Access-Control-Allow-Origin header

### DIFF
--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -630,6 +630,15 @@ class AdministrationPage extends HTMLPage
         $this->__appendBodyId();
         $this->__appendBodyClass($this->_context);
 
+        /**
+         * This is just prior to the page headers being rendered, and is suitable for changing them
+         * @delegate PreRenderHeaders
+         * @since Symphony 2.7.0
+         * @param string $context
+         * '/backend/'
+         */
+        Symphony::ExtensionManager()->notifyMembers('PreRenderHeaders', '/backend/');
+
         return parent::generate($page);
     }
 

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -451,10 +451,6 @@ class AdministrationPage extends HTMLPage
             $this->addHeaderToPage('X-XSS-Protection', '1; mode=block');
         }
 
-        if (!array_key_exists('access-control-allow-origin', $this->headers())) {
-            $this->addHeaderToPage('Access-Control-Allow-Origin', URL);
-        }
-
         if (!array_key_exists('referrer-policy', $this->headers())) {
             $this->addHeaderToPage('Referrer-Policy', 'same-origin');
         }

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -231,7 +231,6 @@ class FrontendPage extends XSLTPage
             // Lock down the frontend first so that extensions can easily remove these
             // headers if desired. RE: #2480
             $this->addHeaderToPage('X-Frame-Options', 'SAMEORIGIN');
-            $this->addHeaderToPage('Access-Control-Allow-Origin', URL);
             // Add more http security headers, RE: #2248
             $this->addHeaderToPage('X-Content-Type-Options', 'nosniff');
             $this->addHeaderToPage('X-XSS-Protection', '1; mode=block');


### PR DESCRIPTION
The goal was to limit CORS, by setting only the origin has allowed. This
policy is already configured in browser and does not need to be set. As
per Mozilla and OWASP recommendations, we should remove it.

Fixes #2699
Re #2480 

Add PreRenderHeaders delegate  …
Analogous to FrontendPreRenderHeaders, allows extension developer to
remove default values of Symphony instead of setting them to empty
values to prevent the default from being applied