### PR TITLE
Use sha1 directly to avoid deprecation

### DIFF
--- a/symphony/lib/toolkit/class.author.php
+++ b/symphony/lib/toolkit/class.author.php
@@ -154,7 +154,7 @@ class Author
      */
     public function createAuthToken()
     {
-        return General::substrmin(SHA1::hash($this->get('username') . $this->get('password')), 8);
+        return General::substrmin(sha1($this->get('username') . $this->get('password')), 8);
     }
 
     /**


### PR DESCRIPTION
SHA1 class will be removed, so it is best not to use it.

Fixes #2711
Re #2724 