### PR TITLE
Fixes an issue where creating a new entry while using prepopulate throws a PHP error

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -1778,9 +1778,10 @@ class contentPublish extends AdministrationPage
                     $header = new XMLElement('header');
 
                     // Get the search value for filters and prepopulate
-                    $filter      = '';
+                    $filter = '';
                     $prepopulate = '';
-                    if ($entry = current(EntryManager::fetch($entry_id))) {
+                    $entry = current(EntryManager::fetch($entry_id));
+                    if ($entry) {
                         $search_value = $relation_field->fetchAssociatedEntrySearchValue(
                             $entry->getData($as['parent_section_field_id']),
                             $as['parent_section_field_id'],
@@ -1789,7 +1790,7 @@ class contentPublish extends AdministrationPage
                         if (is_array($search_value)) {
                             $search_value = $entry_id;
                         }
-                        $filter      = '?filter[' . $relation_field->get('element_name') . ']=' . $search_value;
+                        $filter = '?filter[' . $relation_field->get('element_name') . ']=' . $search_value;
                         $prepopulate = '?prepopulate[' . $as['child_section_field_id'] . ']=' . $search_value;
                     }
 

--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -1189,7 +1189,8 @@ class contentPublish extends AdministrationPage
 
         EntryManager::setFetchSorting('id', 'DESC');
 
-        if (!$existingEntry = EntryManager::fetch($entry_id)) {
+        $existingEntry = EntryManager::fetch($entry_id);
+        if (empty($existingEntry)) {
             Administration::instance()->throwCustomError(
                 __('Unknown Entry'),
                 __('The Entry, %s, could not be found.', array($entry_id)),
@@ -1397,7 +1398,8 @@ class contentPublish extends AdministrationPage
         $entry_id = intval($this->_context['entry_id']);
 
         if (is_array($_POST['action']) && (array_key_exists('save', $_POST['action']) || array_key_exists('done', $_POST['action']))) {
-            if (!$ret = EntryManager::fetch($entry_id)) {
+            $ret = EntryManager::fetch($entry_id);
+            if (empty($ret)) {
                 Administration::instance()->throwCustomError(
                     __('The Entry, %s, could not be found.', array($entry_id)),
                     __('Unknown Entry'),
@@ -1504,7 +1506,8 @@ class contentPublish extends AdministrationPage
 
                 redirect(SYMPHONY_URL . '/publish/'.$this->_context['section_handle'].'/');
             } else {
-                if (is_array($ret = EntryManager::fetch($entry_id))) {
+                $ret = EntryManager::fetch($entry_id);
+                if (!empty($ret)) {
                     $entry = $ret[0];
                     $this->addTimestampValidationPageAlert($this->_errors['timestamp'], $entry, 'delete');
                 }
@@ -1775,18 +1778,20 @@ class contentPublish extends AdministrationPage
                     $header = new XMLElement('header');
 
                     // Get the search value for filters and prepopulate
-                    $entry = current(EntryManager::fetch($entry_id));
-                    $search_value = $relation_field->fetchAssociatedEntrySearchValue(
-                        $entry->getData($as['parent_section_field_id']),
-                        $as['parent_section_field_id'],
-                        $entry_id
-                    );
-                    if (is_array($search_value)) {
-                        $search_value = $entry_id;
+                    $filter      = '';
+                    $prepopulate = '';
+                    if ($entry = current(EntryManager::fetch($entry_id))) {
+                        $search_value = $relation_field->fetchAssociatedEntrySearchValue(
+                            $entry->getData($as['parent_section_field_id']),
+                            $as['parent_section_field_id'],
+                            $entry_id
+                        );
+                        if (is_array($search_value)) {
+                            $search_value = $entry_id;
+                        }
+                        $filter      = '?filter[' . $relation_field->get('element_name') . ']=' . $search_value;
+                        $prepopulate = '?prepopulate[' . $as['child_section_field_id'] . ']=' . $search_value;
                     }
-
-                    $filter = '?filter[' . $relation_field->get('element_name') . ']=' . $search_value;
-                    $prepopulate = '?prepopulate[' . $as['child_section_field_id'] . ']=' . $search_value;
 
                     // Create link with filter or prepopulate
                     $link = SYMPHONY_URL . '/publish/' . $as['handle'] . '/' . $filter;

--- a/symphony/lib/toolkit/class.entrymanager.php
+++ b/symphony/lib/toolkit/class.entrymanager.php
@@ -382,7 +382,7 @@ class EntryManager
         $sortSelectClause = null;
 
         if (!$entry_id && !$section_id) {
-            return false;
+            return array();
         }
 
         if (!$section_id) {
@@ -391,7 +391,7 @@ class EntryManager
 
         $section = SectionManager::fetch($section_id);
         if (!is_object($section)) {
-            return false;
+            return array();
         }
 
         // SORTING


### PR DESCRIPTION
Fix for #2737 

[EntryManager::fetch()][1] is expected to [return an array][2], but instead [returns a boolean][3] in some cases. I changed the method to always return an array as documented. Also adapted the handling of the return value in all places.

[1]: https://github.com/symphonycms/symphony-2/blob/2f9dc2dcf345fa6b0859f4c18931a86475f7cb1c/symphony/lib/toolkit/class.entrymanager.php#L379
[2]: https://github.com/symphonycms/symphony-2/blob/2f9dc2dcf345fa6b0859f4c18931a86475f7cb1c/symphony/lib/toolkit/class.entrymanager.php#L375
[3]: https://github.com/symphonycms/symphony-2/blob/2f9dc2dcf345fa6b0859f4c18931a86475f7cb1c/symphony/lib/toolkit/class.entrymanager.php#L385

The change makes sure that the method actually works as expected and documented, so I’d consider this to be a bugfix and not a breaking change.