### PR TITLE
Removes empty parent association sections from associations drawer

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -1703,35 +1703,30 @@ class contentPublish extends AdministrationPage
                             'title' => strip_tags($aname),
                         ));
 
+                        if (!$has_entries) {
+                            unset($field);
+                            continue;
+                        }
+
                         $element = new XMLElement('section', null, array('class' => 'association parent'));
                         $header = new XMLElement('header');
+                        $header->appendChild(new XMLElement('p', $a->generate()));
                         $element->appendChild($header);
 
-                        if ($has_entries) {
-                            $element = new XMLElement('section', null, array('class' => 'association parent'));
-                            $header = new XMLElement('header');
-                            $header->appendChild(new XMLElement('p', $a->generate()));
-                            $element->appendChild($header);
+                        $ul = new XMLElement('ul', null, array(
+                            'class' => 'association-links',
+                            'data-section-id' => $as['child_section_id'],
+                            'data-association-ids' => implode(', ', $entry_ids)
+                        ));
 
-                            $ul = new XMLElement('ul', null, array(
-                                'class' => 'association-links',
-                                'data-section-id' => $as['child_section_id'],
-                                'data-association-ids' => implode(', ', $entry_ids)
-                            ));
-
-                            foreach ($entries['records'] as $e) {
-                                // let the field create the mark up
-                                $li = $field->prepareAssociationsDrawerXMLElement($e, $as);
-                                // add it to the unordered list
-                                $ul->appendChild($li);
-                            }
-
-                            $element->appendChild($ul);
-                        // No entries
-                        } else {
-                            $element->setAttribute('class', 'association parent empty');
-                            $header->appendChild(new XMLElement('p', __('No links to %s', array($a->generate()))));
+                        foreach ($entries['records'] as $e) {
+                            // let the field create the mark up
+                            $li = $field->prepareAssociationsDrawerXMLElement($e, $as);
+                            // add it to the unordered list
+                            $ul->appendChild($li);
                         }
+
+                        $element->appendChild($ul);
                         $content->appendChild($element);
                         unset($field);
                     }


### PR DESCRIPTION
I find the empty parent association sections in the redesigned associations drawer quite noisy since the [2.7.0-release][2] (see screenshots). As far as I can tell, they also provide no real value, so I propose to remove them entirely. Not sure if this is something that should be changed in a patch release or better be cherry-picked for the [3.0.x-branch][1], but I’m working with the [2.7.0-code][2] at the moment, therefore submitting this to the [2.7.x-branch][3].

[1]: https://github.com/symphonycms/symphony-2/tree/3.0.x
[2]: https://github.com/symphonycms/symphony-2/tree/2.7.0
[3]: https://github.com/symphonycms/symphony-2/tree/2.7.x 

![screen shot 2017-08-21 at 19 36 08](https://user-images.githubusercontent.com/1640033/29531925-14572536-86ab-11e7-8a01-22cdc6ac34f9.png)

![screen shot 2017-08-21 at 19 36 48](https://user-images.githubusercontent.com/1640033/29531936-1dd87894-86ab-11e7-9b57-a58458e83a40.png)

![screen shot 2017-08-21 at 19 38 08](https://user-images.githubusercontent.com/1640033/29531949-2653ecce-86ab-11e7-9ecf-a7be0142feb0.png)

![screen shot 2017-08-21 at 19 37 57](https://user-images.githubusercontent.com/1640033/29531959-2e9e5504-86ab-11e7-8997-3a22afe4a821.png)
