### PR TITLE
Fixes a breaking change in a hotfix

### DIFF
--- a/symphony/content/content.blueprintssections.php
+++ b/symphony/content/content.blueprintssections.php
@@ -892,6 +892,8 @@ class contentBlueprintsSections extends AdministrationPage
             $canProceed = $this->validateTimestamp($section_id);
 
             if ($canProceed) {
+                $section_ids = array($section_id);
+
                 /**
                  * Just prior to calling the Section Manager's delete function
                  *
@@ -902,9 +904,11 @@ class contentBlueprintsSections extends AdministrationPage
                  * @param array $section_ids
                  *  An array of Section ID's passed by reference
                  */
-                Symphony::ExtensionManager()->notifyMembers('SectionPreDelete', '/blueprints/sections/', array('section_ids' => array(&$section_id)));
+                Symphony::ExtensionManager()->notifyMembers('SectionPreDelete', '/blueprints/sections/', array('section_ids' => &$section_ids));
 
-                SectionManager::delete($section_id);
+                foreach ($section_ids as $section) {
+                    SectionManager::delete($section);
+                }
 
                 redirect(SYMPHONY_URL . '/blueprints/sections/');
             } else {

--- a/symphony/content/content.blueprintssections.php
+++ b/symphony/content/content.blueprintssections.php
@@ -891,33 +891,34 @@ class contentBlueprintsSections extends AdministrationPage
             $section_id = $this->_context[1];
             $canProceed = $this->validateTimestamp($section_id);
 
-            if ($canProceed) {
-                $section_ids = array($section_id);
-
-                /**
-                 * Just prior to calling the Section Manager's delete function
-                 *
-                 * @delegate SectionPreDelete
-                 * @since Symphony 2.2
-                 * @param string $context
-                 * '/blueprints/sections/'
-                 * @param array $section_ids
-                 *  An array of Section ID's passed by reference
-                 */
-                Symphony::ExtensionManager()->notifyMembers('SectionPreDelete', '/blueprints/sections/', array('section_ids' => &$section_ids));
-
-                foreach ($section_ids as $section) {
-                    SectionManager::delete($section);
-                }
-
-                redirect(SYMPHONY_URL . '/blueprints/sections/');
-            } else {
+            if (!$canProceed) {
                 $this->addTimestampValidationPageAlert(
                     $this->_errors['timestamp'],
                     SectionManager::fetch($section_id),
                     'delete'
                 );
+                return;
             }
+
+            $section_ids = array($section_id);
+
+            /**
+             * Just prior to calling the Section Manager's delete function
+             *
+             * @delegate SectionPreDelete
+             * @since Symphony 2.2
+             * @param string $context
+             * '/blueprints/sections/'
+             * @param array $section_ids
+             *  An array of Section ID's passed by reference
+             */
+            Symphony::ExtensionManager()->notifyMembers('SectionPreDelete', '/blueprints/sections/', array('section_ids' => &$section_ids));
+
+            foreach ($section_ids as $section) {
+                SectionManager::delete($section);
+            }
+
+            redirect(SYMPHONY_URL . '/blueprints/sections/');
         }
     }
 


### PR DESCRIPTION
Fix for #2742

@nitriques 

Apparently you already fixed #2742. There wasn’t an issue for it, so I only discovered the fix after rebasing my own `2.7.0`-based hotfix on `2.7.x`. However, I think that your fix introduces a breaking change, so I’m submitting my original hotfix as well.

In `2.7.0`, we pass an array to the delegate by reference, which means that the array can be manipulated by the delegate. Your fix only passes the array value by reference, which is not the same, at least from my understanding.

For example, the delegate could decide to remove the section from the array in `2.7.0`, which would then not delete the section. Or add another section, which would then delete this section as well. I think that your proposed fix basically just bypasses the manipulation that could happen in the delegate.