### PR TITLE
Restore the 2.6.x field behaviour for empty arrays

### DIFF
--- a/symphony/lib/toolkit/class.entrymanager.php
+++ b/symphony/lib/toolkit/class.entrymanager.php
@@ -115,8 +115,8 @@ class EntryManager
             return;
         }
 
-        // Check if we have field data
-        if (!is_array($field) || empty($field)) {
+        // Ignore when not an array
+        if (!is_array($field)) {
             return;
         }
 
@@ -158,7 +158,10 @@ class EntryManager
                 $fields[$index] = array_merge($data, $field_data);
             }
 
-            Symphony::Database()->insert($fields, $table_name);
+            // Insert only if we have field data
+            if (!empty($fields)) {
+                Symphony::Database()->insert($fields, $table_name);
+            }
         } catch (Exception $ex) {
             Symphony::Log()->pushExceptionToLog($ex, true);
         }


### PR DESCRIPTION
Symphony always treated empty arrays as being null values, i.e. deleting
old data without doing an insert statement afterwards.

The refactor made in 2.7.x used the code for new as the base, instead of
edit. new never had to deal with old data and simply did not produce a
DELETE statement, but edit did.

I think it is safe to change both, to always issue a DELETE statement
and produce an INSERT when needed.

Fixes #2733