### PR TITLE
Fix optional values for upload field

### DIFF
--- a/symphony/lib/toolkit/class.entrymanager.php
+++ b/symphony/lib/toolkit/class.entrymanager.php
@@ -115,9 +115,9 @@ class EntryManager
             return;
         }
 
-        // Ignore when not an array
+        // Ignore parameter when not an array
         if (!is_array($field)) {
-            return;
+            $field = array();
         }
 
         $did_lock = false;


### PR DESCRIPTION
*Some* fields, like the upload field, return false when the data
is deleted instead of an empty array. The patch introduced in #2744 did
not account for that: It removes the fast return only for empty
variables but not for non-arrays.

In 2.6.x, both empty values and non-arrays would still issue the delete,
hence we need to continue. We can ignore the passed value and just
continue with an empty array.

Re #2744
Fixes #2733 properly

cc @wdebusschere