### PR TITLE
Prepopulate fields that supports it

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -1017,7 +1017,8 @@ class contentPublish extends AdministrationPage
                 ));
 
                 // The actual pre-populating should only happen if there is not existing fields post data
-                if (!isset($_POST['fields']) && $field = FieldManager::fetch($field_id)) {
+                // and if the field allows it
+                if (!isset($_POST['fields']) && ($field = FieldManager::fetch($field_id)) && $field->canPrePopulate()) {
                     $entry->setData(
                         $field->get('id'),
                         $field->processRawFieldData($value, $error, $message, true)


### PR DESCRIPTION
When prepopulating the field, we only checked if there was no POST
data for the field. But we also need to make sure the field supports
prepoluation. If not, it can create bugs.