### PR TITLE
Do not hide exceptions thrown by the database

### DIFF
--- a/symphony/lib/toolkit/class.entrymanager.php
+++ b/symphony/lib/toolkit/class.entrymanager.php
@@ -121,6 +121,7 @@ class EntryManager
         }
 
         $did_lock = false;
+        $exception = null;
         try {
 
             // Check if table exists
@@ -163,11 +164,16 @@ class EntryManager
                 Symphony::Database()->insert($fields, $table_name);
             }
         } catch (Exception $ex) {
+            $exception = $ex;
             Symphony::Log()->pushExceptionToLog($ex, true);
         }
 
         if ($did_lock) {
             Symphony::Database()->query('UNLOCK TABLES');
+        }
+
+        if ($exception) {
+            throw $exception;
         }
     }
 


### PR DESCRIPTION
If there was a problem with a SQL statement, the current code you log
the exception, but silence it, resulting in a weird user experience.

This commits make sure to throw any errors that would occur during the
saving process.

Fixes #2752
