### PR TITLE
Use the full width when the primary col is empty

### DIFF
--- a/symphony/assets/css/src/symphony.grids.css
+++ b/symphony/assets/css/src/symphony.grids.css
@@ -61,7 +61,8 @@ form.columns {
 	padding: 1rem 1.8rem 0;
 }
 
-form.columns .column.primary {
+form.columns .column.primary,
+form.columns .column.secondary:first-of-type {
 	width: 100%;
 	padding: 0;
 }


### PR DESCRIPTION
If a developer creates a section with fields only in the sidebar, the
fields won't have any size since they are float. This yeiled bad UX.

This commits adds a CSS selector for secondary columns that are not preceded
by a primary column.
