### PR TITLE
Remove duplicated file_exists checks

### DIFF
--- a/symphony/lib/core/class.log.php
+++ b/symphony/lib/core/class.log.php
@@ -396,9 +396,7 @@ class Log
         }
 
         if ($flag == self::OVERWRITE) {
-            if (file_exists($this->_log_path) && is_writable($this->_log_path)) {
-                General::deleteFile($this->_log_path);
-            }
+            General::deleteFile($this->_log_path);
 
             $this->writeToLog('============================================', true);
             $this->writeToLog('Log Created: ' . DateTimeObj::get('c'), true);

--- a/symphony/lib/toolkit/class.pagemanager.php
+++ b/symphony/lib/toolkit/class.pagemanager.php
@@ -193,9 +193,7 @@ class PageManager
 
         if (PageManager::writePageFiles($new, $data)) {
             // Remove the old file, in the case of a rename
-            if (file_exists($old)) {
-                General::deleteFile($old);
-            }
+            General::deleteFile($old);
 
             /**
              * Just after a Page Template is saved after been created.


### PR DESCRIPTION
General::deleteFile() always calls General::checkFileDeletable() to make
sure it can acts on the file. There are not need to check it twice.
