### PR TITLE
Add configurable log filtering

### DIFF
--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -31,6 +31,7 @@
         'log' => array(
             'archive' => '1',
             'maxsize' => '102400',
+            'filter' => E_ALL ^ E_DEPRECATED,
         ),
         ########
 

--- a/symphony/lib/core/class.symphony.php
+++ b/symphony/lib/core/class.symphony.php
@@ -228,7 +228,8 @@ abstract class Symphony implements Singleton
 
         self::$Log = new Log($filename);
         self::$Log->setArchive((self::Configuration()->get('archive', 'log') == '1' ? true : false));
-        self::$Log->setMaxSize(intval(self::Configuration()->get('maxsize', 'log')));
+        self::$Log->setMaxSize(self::Configuration()->get('maxsize', 'log'));
+        self::$Log->setFilter(self::Configuration()->get('filter', 'log'));
         self::$Log->setDateTimeFormat(__SYM_DATETIME_FORMAT__);
 
         if (self::$Log->open(Log::APPEND, self::Configuration()->get('write_mode', 'file')) == '1') {


### PR DESCRIPTION
Since this is a LTS version, it seem counter intuitive to log deprecated
calls. We do need the possibility to log them, to help migration
efforts. But since there are a lot of deprecated calls, it then becomes
as performance issue.

Re #2711