### PR TITLE
Fix Mutex release not deleting lock file - Use new deleteFile method

### DIFF
--- a/symphony/lib/toolkit/class.mutex.php
+++ b/symphony/lib/toolkit/class.mutex.php
@@ -89,11 +89,7 @@ class Mutex
 
         if (!empty(self::$lockFiles[$lockFile])) {
             unset(self::$lockFiles[$lockFile]);
-            if (file_exists($lockFile)) {
-                return unlink($lockFile);
-            } else {
-                return true;
-            }
+            return General::deleteFile($lockFile, false);
         }
 
         return false;


### PR DESCRIPTION
Use the new General::deleteFile method to erase the lockFile when the mutex is released and then avoiding false FileNotFound exception from the php drive cache managed by the new deleteFile method.