### PR TITLE
Make __reduceType static

### DIFF
--- a/symphony/lib/toolkit/events/class.event.section.php
+++ b/symphony/lib/toolkit/events/class.event.section.php
@@ -197,7 +197,7 @@ abstract class SectionEvent extends Event
      * @return string
      *  'missing' or 'invalid'
      */
-    public function __reduceType($a, $b)
+    public static function __reduceType($a, $b)
     {
         if (is_array($b)) {
             return array_reduce($b, array('SectionEvent', '__reduceType'));


### PR DESCRIPTION
This fix is for PHP7, which does not allow calling non-static method via
the static operator.

Note that the proper fix would be to use `array($this, '__reduceType')`,
but doing so would be a breacking change.

Fixes #2764