### PR TITLE
Issue 2765 for 2.7.x

### DIFF
--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -1168,6 +1168,8 @@ class contentBlueprintsDatasources extends ResourcesPage
             $this->_errors['name'] = __('This is a required field');
         } elseif (strpos($fields['name'], '\\') !== false) {
             $this->_errors['name'] = __('This field contains invalid characters') . ' (\\)';
+        } elseif (!preg_match('/^[a-z]/i', $fields['name'])) {
+            $this->_errors['name'] = __('The name of the data-source must begin with a letter.');
         }
 
         if ($fields['source'] == 'static_xml') {

--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -1169,7 +1169,7 @@ class contentBlueprintsDatasources extends ResourcesPage
         } elseif (strpos($fields['name'], '\\') !== false) {
             $this->_errors['name'] = __('This field contains invalid characters') . ' (\\)';
         } elseif (!preg_match('/^[a-z]/i', $fields['name'])) {
-            $this->_errors['name'] = __('The name of the data-source must begin with a letter.');
+            $this->_errors['name'] = __('The name of the data source must begin with a letter.');
         }
 
         if ($fields['source'] == 'static_xml') {

--- a/symphony/lib/toolkit/data-sources/class.datasource.section.php
+++ b/symphony/lib/toolkit/data-sources/class.datasource.section.php
@@ -223,12 +223,17 @@ class SectionDatasource extends Datasource
                     // For each related field show the count (#2083)
                     foreach ($fields as $field_id => $count) {
                         $field_handle = FieldManager::fetchHandleFromID($field_id);
+                        $section_handle = $section['handle'];
+                        // Make sure attribute does not begin with a digit
+                        if (preg_match('/^[0-9]/', $section_handle)) {
+                            $section_handle = 'x-' . $section_handle;
+                        }
                         if ($field_handle) {
-                            $xEntry->setAttribute($section['handle'] . '-' . $field_handle, (string)$count);
+                            $xEntry->setAttribute($section_handle . '-' . $field_handle, (string)$count);
                         }
 
                         // Backwards compatibility (without field handle)
-                        $xEntry->setAttribute($section['handle'], (string)$count);
+                        $xEntry->setAttribute($section_handle, (string)$count);
                     }
                 }
             }


### PR DESCRIPTION
Fix for #2765
Re #2773

Two things:

- Disallow data source that starts with a digit.
- Prepend `x-` to section names that begins with a digit.

Both situation crashes the whole frontend and are considered a bug fixes.

I think sections name/events beginning with a digit should be avoided and disallowed in 3.0.0