### PR TITLE
Restrict CSS resize to vertical on <textarea>

### DIFF
--- a/symphony/assets/css/src/symphony.forms.css
+++ b/symphony/assets/css/src/symphony.forms.css
@@ -70,6 +70,10 @@ select[size] {
 	max-height: 10rem;
 }
 
+textarea {
+	resize: vertical;
+}
+
 input[size] {
 	width: auto;
 }


### PR DESCRIPTION
Enabled by default in nearly all browsers, `<textarea>` form fields can be resized.  This rule restricts that resize ability to `vertical`, to help this browser feature play nice with Symphony's column layout.  [CSS resize support](https://caniuse.com/#feat=css-resize) is good, except for IE, naturally!