### PR TITLE
Fix error if extension not found on boot

### DIFF
--- a/symphony/lib/toolkit/class.extensionmanager.php
+++ b/symphony/lib/toolkit/class.extensionmanager.php
@@ -1020,19 +1020,24 @@ class ExtensionManager implements FileResource
             $path = self::__getDriverPath($name);
 
             if (!is_file($path)) {
-                Symphony::Engine()->throwCustomError(
-                    __('Could not find extension %s at location %s.', array(
-                        '<code>' . $name . '</code>',
-                        '<code>' . str_replace(DOCROOT . '/', '', $path) . '</code>'
-                    )),
-                    __('Symphony Extension Missing Error'),
-                    Page::HTTP_STATUS_ERROR,
-                    'missing_extension',
-                    array(
-                        'name' => $name,
-                        'path' => $path
-                    )
-                );
+                $errMsg = __('Could not find extension %s at location %s.', array(
+                    '<code>' . $name . '</code>',
+                    '<code>' . str_replace(DOCROOT . '/', '', $path) . '</code>'
+                ));
+                try {
+                    Symphony::Engine()->throwCustomError(
+                        $errMsg,
+                        __('Symphony Extension Missing Error'),
+                        Page::HTTP_STATUS_ERROR,
+                        'missing_extension',
+                        array(
+                            'name' => $name,
+                            'path' => $path
+                        )
+                    );
+                } catch (Exception $ex) {
+                    throw new Exception($errMsg, 0, $ex);
+                }
             }
 
             if (!class_exists($classname)) {


### PR DESCRIPTION
Before symphony can be properly booted, the extension manager is created
in order to allow extensions to override the launcher.

If there is an extension missing, the user gets a non helpfull message
telling him that Symphony did not boot.

This commit makes sure the user is notified about the error even if a
nice error template can not be displayed.
