### PR TITLE
Remove session.save_handler from php settings

### DIFF
--- a/symphony/lib/core/class.session.php
+++ b/symphony/lib/core/class.session.php
@@ -57,7 +57,6 @@ class Session
             }
 
             if (session_id() == '') {
-                ini_set('session.save_handler', 'user');
                 ini_set('session.use_trans_sid', '0');
                 ini_set('session.use_strict_mode', '1');
                 ini_set('session.use_only_cookies', '1');


### PR DESCRIPTION
This has never been required in PHP 5.6 and causes a fatal crash with PHP 7.2

Fixes #2783