### PR TITLE
Remove click listener for actions select

### DIFF
--- a/symphony/assets/js/src/backend.views.js
+++ b/symphony/assets/js/src/backend.views.js
@@ -856,7 +856,7 @@ Symphony.View.add('/system/extensions/:context*:', function() {
 	});
 
 	// Update controls contextually
-	Symphony.Elements.contents.find('.actions select').on('click.admin focus.admin', function(event) {
+	Symphony.Elements.contents.find('.actions select').on('focus.admin', function(event) {
 		var selected = Symphony.Elements.contents.find('tr.selected'),
 			canUpdate = selected.filter('.extension-can-update').length,
 			canInstall = selected.filter('.extension-can-install').length,


### PR DESCRIPTION
On macOs Sierra and High Sierra, it seems like we are no longer
able to change the select's content in click handlers:
upon DOM modification, the select automatically closes,
rendering it unusable.

This change simply removes the click event, which should have no effect on
functionality because our computation remains valid for all other
clicks.

Fixes #2786

NB: Make sure to run `grunt` to test the code !

cc @wdebusschere