### PR TITLE
Make the default max log size to 10Mb

### DIFF
--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -30,7 +30,7 @@
         ###### LOG ######
         'log' => array(
             'archive' => '1',
-            'maxsize' => '102400',
+            'maxsize' => '10485760',
             'filter' => E_ALL ^ E_DEPRECATED,
         ),
         ########


### PR DESCRIPTION
This is to prevent over rotating the logs

Fixes #2757

---

Should we update the value if the default is configured when updating ?