### PR TITLE
Properly set and pass the new author's id

### DIFF
--- a/symphony/content/content.systemauthors.php
+++ b/symphony/content/content.systemauthors.php
@@ -615,6 +615,8 @@ class contentSystemAuthors extends AdministrationPage
                      * '/system/authors/'
                      * @param Author $author
                      *  The Author object that has just been created
+                     * @param integer $author_id
+                     *  The ID of Author ID that was just created
                      * @param array $fields
                      *  The POST fields
                      *  This parameter is available @since Symphony 2.7.0
@@ -625,6 +627,7 @@ class contentSystemAuthors extends AdministrationPage
                      */
                     Symphony::ExtensionManager()->notifyMembers('AuthorPostCreate', '/system/authors/', array(
                         'author' => $this->_Author,
+                        'author_id' => $author_id,
                         'field' => $fields,
                         'errors' => &$this->_errors,
                     ));

--- a/symphony/lib/toolkit/class.author.php
+++ b/symphony/lib/toolkit/class.author.php
@@ -272,6 +272,7 @@ class Author
      * `$this->_fields` values and adds them to the database using either the
      * `AuthorManager::edit` or `AuthorManager::add` functions. An
      * existing user is determined by if an ID is already set.
+     * When the database is updated successfully, the id of the author is set.
      *
      * @see toolkit.AuthorManager#add()
      * @see toolkit.AuthorManager#edit()
@@ -292,7 +293,11 @@ class Author
                 return false;
             }
         } else {
-            return AuthorManager::add($this->get());
+            $id = AuthorManager::add($this->get());
+            if ($id) {
+                $this->set('id', $id);
+            }
+            return $id;
         }
     }
 }


### PR DESCRIPTION
When we commit a new author, the new id was not set on the Author
object.
This prevented delegates to run based on the new id in the PostAuthorCreate.

Also, a direct reference to the author id has been added in the context
of the PostAuthorCreate delegate.