### PR TITLE
Data Sources: Allow to output system IDs only

### DIFF
--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -805,6 +805,11 @@ class contentBlueprintsDatasources extends ResourcesPage
                 'data-label' => 'section-' . $section_data['section']->get('id'),
                 'options' => array(
                     array(
+                        'system:id',
+                        ($fields['source'] == $section_id && in_array('system:id', $fields['xml_elements'])),
+                        'system: id'
+                    ),
+                    array(
                         'system:pagination',
                         ($fields['source'] == $section_id && in_array('system:pagination', $fields['xml_elements'])),
                         'system: pagination'


### PR DESCRIPTION
As discussed in #784, it may be useful to output system IDs only (i.e. without the need to add a field to DS output).