### PR TITLE
Add a default security.txt file

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,4 @@
+# Please contact us for security related issues
+Contact: team@getsymphony.com
+Encryption: https://www.getsymphony.com/.well-known/pgp.txt
+Policy: https://github.com/symphonycms/symphony-2/wiki/Security-Bug-Disclosure


### PR DESCRIPTION
This file allows security researchers to find us quickly if they find a
security related problem.

See https://securitytxt.org

Fixes #2807