### PR TITLE
core patch to avoid checking all instances of fetch function to ensur…

### DIFF
--- a/symphony/lib/toolkit/class.entrymanager.php
+++ b/symphony/lib/toolkit/class.entrymanager.php
@@ -405,7 +405,7 @@ class EntryManager
 
         // SORTING
         // A single $entry_id doesn't need to be sorted on, or if it's explicitly disabled
-        if ((!is_array($entry_id) && !is_null($entry_id) && is_int($entry_id)) || !$enable_sort) {
+        if ((!is_array($entry_id) && !is_null($entry_id) && is_numeric($entry_id)) || !$enable_sort) {
             $sort = null;
 
         // Check for RAND first, since this works independently of any specific field


### PR DESCRIPTION
Changes `is_int` to `is_numeric` to eliminate the addition of sorting to `entry_id` when these are numeric strings not integers. 

If unchanged this may cause some odd scenarios if the join table has no data, specifically when sorting by a datetime field.