### PR TITLE
Add missing Resources delegates

### DIFF
--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -1143,10 +1143,14 @@ class contentBlueprintsDatasources extends ResourcesPage
              * '/blueprints/datasources/'
              * @param string $file
              *  The path to the Datasource file
+             * @param string $handle
+             *  @since Symphony 3.0.0
+             *  The handle of the Datasource
              */
             Symphony::ExtensionManager()->notifyMembers('DatasourcePreDelete', '/blueprints/datasources/', array(
-                'file' => DATASOURCES . "/data." . $this->_context[1] . ".php")
-            );
+                'file' => DATASOURCES . "/data." . $this->_context[1] . ".php",
+                'handle' => $this->_context[1],
+            ));
 
             if (!General::deleteFile(DATASOURCES . '/data.' . $this->_context[1] . '.php')) {
                 $this->pageAlert(
@@ -1160,6 +1164,23 @@ class contentBlueprintsDatasources extends ResourcesPage
                 foreach ($pages as $page) {
                     ResourceManager::detach(ResourceManager::RESOURCE_TYPE_DS, $this->_context[1], $page['id']);
                 }
+
+                /**
+                 * After deleting the Datasource file. Target file path is provided.
+                 *
+                 * @delegate DatasourcePostDelete
+                 * @since Symphony 3.0.0
+                 * @param string $context
+                 * '/blueprints/datasources/'
+                 * @param string $file
+                 *  The path to the Datasource file
+                 * @param string $handle
+                 *  The handle of the Datasource
+                 */
+                Symphony::ExtensionManager()->notifyMembers('DatasourcePostDelete', '/blueprints/datasources/', array(
+                    'file' => DATASOURCES . "/data." . $this->_context[1] . ".php",
+                    'handle' => $this->_context[1],
+                ));
 
                 redirect(SYMPHONY_URL . '/blueprints/datasources/');
             }

--- a/symphony/content/content.blueprintsevents.php
+++ b/symphony/content/content.blueprintsevents.php
@@ -375,8 +375,14 @@ class contentBlueprintsEvents extends ResourcesPage
              * '/blueprints/events/'
              * @param string $file
              *  The path to the Event file
+             * @param string $handle
+             *  @since Symphony 3.0.0
+             *  The handle of the Event
              */
-            Symphony::ExtensionManager()->notifyMembers('EventPreDelete', '/blueprints/events/', array('file' => EVENTS . "/event." . $this->_context[1] . ".php"));
+            Symphony::ExtensionManager()->notifyMembers('EventPreDelete', '/blueprints/events/', array(
+                'file' => EVENTS . "/event." . $this->_context[1] . ".php",
+                'handle' => $this->_context[1],
+            ));
 
             if (!General::deleteFile(EVENTS . '/event.' . $this->_context[1] . '.php')) {
                 $this->pageAlert(
@@ -390,6 +396,23 @@ class contentBlueprintsEvents extends ResourcesPage
                 foreach ($pages as $page) {
                     ResourceManager::detach(ResourceManager::RESOURCE_TYPE_EVENT, $this->_context[1], $page['id']);
                 }
+
+                /**
+                 * After deleting the Event file. Target file path is provided.
+                 *
+                 * @delegate EventPostDelete
+                 * @since Symphony 3.0.0
+                 * @param string $context
+                 * '/blueprints/events/'
+                 * @param string $file
+                 *  The path to the Event file
+                 * @param string $handle
+                 *  The handle of the Event
+                 */
+                Symphony::ExtensionManager()->notifyMembers('EventPostDelete', '/blueprints/events/', array(
+                    'file' => EVENTS . "/event." . $this->_context[1] . ".php",
+                    'handle' => $this->_context[1],
+                ));
 
                 redirect(SYMPHONY_URL . '/blueprints/events/');
             }


### PR DESCRIPTION
Both events and data sources were missing the PostDelete delegates.

No delegates were fired when the resources were deleted from the index
page.

The handle of the resource is added to PreDelete also.

Re https://github.com/symphonists/globalresourceloader/issues/13