### PR TITLE
Restrict the rights a manager can have and added edit right validation

### DIFF
--- a/symphony/content/content.systemauthors.php
+++ b/symphony/content/content.systemauthors.php
@@ -339,7 +339,7 @@ class contentSystemAuthors extends AdministrationPage
             $label = Widget::Label(__('User Type'), null, 'column');
 
             $options = array(
-                array('author', false, __('Author'))
+                array('author', false, __('Author')),
             );
 
             if ($isOwner || Symphony::Author()->isDeveloper() || $author->isManager()) {


### PR DESCRIPTION
Fixes #2812

Managers will only be able to create/edit/delete authors the UI has been adjusted in consequence.
I added a right validation before editing authors.