### PR TITLE
Fix createHandle + limitWords to work for non-space breaking characters

### DIFF
--- a/symphony/lib/toolkit/class.general.php
+++ b/symphony/lib/toolkit/class.general.php
@@ -318,7 +318,7 @@ class General
 
         // Trim it
         if ($max_length > 0) {
-            $string = General::limitWords($string, $max_length);
+            $string = General::limitWords($string, $max_length,null,'-');
         }
 
         // Replace spaces (tab, newline etc) with the delimiter
@@ -1388,11 +1388,14 @@ class General
      *  true if the ellipses should be appended to the result in circumstances
      *  where the result is shorter than the input string. false otherwise. this
      *  defaults to false.
+     * @param string $character (optional)
+     *  Character you want to replace, defaults to space. 
+     *  Should be `-` when using limit words on a handle
      * @return null|string
      *  if the resulting string contains only spaces then null is returned. otherwise
      *  a string that satisfies the input constraints.
      */
-    public static function limitWords($string, $maxChars = 200, $appendHellip = false)
+    public static function limitWords($string, $maxChars = 200, $appendHellip = false, $character = ' ')
     {
         if ($appendHellip) {
             $maxChars -= 1;
@@ -1408,7 +1411,7 @@ class General
         }
 
         // Find the last space before the the maxChars limit is hit.
-        $last_word_break = strrpos($string, ' ', $maxChars - $original_length);
+        $last_word_break = strrpos($string, $character, $maxChars - $original_length);
         $result = substr($string, 0, $last_word_break);
 
         if ($appendHellip) {


### PR DESCRIPTION
General::createHandle was broken with the release of symphony 2.7.x and this is an attempt to fix the issue. @brendo & @nitriques made a nice job in having words cut out at the right place, except we forgot one use case; this was also used to trim handles.

I'm suggesting to add a character variable which is by default a space but could be replaced, for example with a `-` to be used for handles. 

In most cases this was hard to find/spot; as most handles used are at 255 characters and most use-cases are indeed shorter. For easier testing; I suggest checking with lower limits - the current behaviour completely trims the string out to leave an empty string `""` so releasing this fix should be somewhat of a priority. 