### PR TITLE
Actually make auth tokens longer (40 chars)

### DIFF
--- a/install/includes/install.sql
+++ b/install/includes/install.sql
@@ -11,11 +11,12 @@ CREATE TABLE `tbl_authors` (
   `user_type` enum('author','manager','developer') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'author',
   `primary` enum('yes','no') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'no',
   `default_area` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `auth_token_active` enum('yes','no') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'no',
+  `auth_token` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `language` varchar(15) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`),
-  UNIQUE KEY `email` (`email`(191))
+  UNIQUE KEY `email` (`email`(191)),
+  KEY `auth_token` (`auth_token`(191))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- *** STRUCTURE: `tbl_cache` ***
@@ -190,9 +191,10 @@ CREATE TABLE `tbl_fields_upload` (
 DROP TABLE IF EXISTS `tbl_forgotpass`;
 CREATE TABLE `tbl_forgotpass` (
   `author_id` int(11) unsigned NOT NULL DEFAULT '0',
-  `token` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `token` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `expiry` varchar(25) COLLATE utf8mb4_unicode_ci NOT NULL,
-  PRIMARY KEY (`author_id`)
+  PRIMARY KEY (`author_id`),
+  KEY `token` (`token`(191))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- *** STRUCTURE: `tbl_pages` ***

--- a/install/lib/class.installer.php
+++ b/install/lib/class.installer.php
@@ -513,7 +513,7 @@ class Installer extends Administration
                 'user_type'             => 'developer',
                 'primary'               => 'yes',
                 'default_area'          => '/blueprints/sections/',
-                'auth_token_active'     => 'no'
+                'auth_token'            => null,
             ])->execute();
         } catch (DatabaseException $e) {
             $this->abort(

--- a/install/migrations/3.0.0.php
+++ b/install/migrations/3.0.0.php
@@ -216,7 +216,7 @@ final class migration_300 extends Migration
             // Create tokens for active users
             foreach ($activeTokenAuthors as $ata) {
                 unset($ata['auth_token_active']);
-                $ata->set('auth_token', Cryptography::randomBytes(40));
+                $ata->set('auth_token', Cryptography::randomBytes());
                 $ata->commit();
             }
             unset($activeTokenAuthors);

--- a/install/migrations/3.0.0.php
+++ b/install/migrations/3.0.0.php
@@ -97,7 +97,7 @@ final class migration_300 extends Migration
         // Make extensions id unsigned
         Symphony::Database()
             ->alter('tbl_extensions')
-            ->change('id', ['id' => [
+            ->modify(['id' => [
                 'type' => 'int(11)',
                 'signed' => false,
             ]])
@@ -107,7 +107,7 @@ final class migration_300 extends Migration
         // and add the order column
         $edStm = Symphony::Database()
             ->alter('tbl_extensions_delegates')
-            ->change('extension_id', ['extension_id' => [
+            ->modify(['extension_id' => [
                 'type' => 'int(11)',
                 'signed' => false,
             ]]);
@@ -132,11 +132,11 @@ final class migration_300 extends Migration
         // Make parent_section unsigned and sortorder signed
         Symphony::Database()
             ->alter('tbl_fields')
-            ->change('parent_section', ['parent_section' => [
+            ->modify( ['parent_section' => [
                 'type' => 'int(11)',
                 'signed' => false,
             ]])
-            ->change('sortorder', ['sortorder' => [
+            ->modify(['sortorder' => [
                 'type' => 'int(11)',
                 'signed' => true,
             ]])
@@ -145,22 +145,29 @@ final class migration_300 extends Migration
         // Make author id unsigned
         Symphony::Database()
             ->alter('tbl_forgotpass')
-            ->change('author_id', ['author_id' => [
-                'type' => 'int(11)',
-                'signed' => false,
-            ]])
+            ->modify([
+                'author_id' => [
+                    'type' => 'int(11)',
+                    'signed' => false,
+                ],
+                'token' => [
+                    'type' => 'varchar(255)',
+                ]
+            ])
             ->execute();
 
         // Make parent unsigned and sortorder signed
         Symphony::Database()
             ->alter('tbl_pages')
-            ->change('parent', ['parent' => [
+            ->modify(['parent' => [
                 'type' => 'int(11)',
                 'signed' => false,
+                'null' => true,
             ]])
-            ->change('sortorder', ['sortorder' => [
+            ->modify(['sortorder' => [
                 'type' => 'int(11)',
                 'signed' => true,
+                'null' => true,
             ]])
             ->execute();
 
@@ -179,6 +186,40 @@ final class migration_300 extends Migration
                 ->alter("tbl_entries_data_$dateFieldId")
                 ->drop('date')
                 ->execute();
+        }
+        unset($dateFields);
+
+        // Change auth_token_active to auth_token
+        if (Symphony::Database()
+            ->showColumns()
+            ->from('tbl_authors')
+            ->like('auth_token_active')
+            ->execute()
+            ->next()) {
+            // Get active tokens
+            $activeTokenAuthors = (new AuthorManager)
+                ->select()
+                ->where(['auth_token_active' => 'yes'])
+                ->execute()
+                ->rows();
+            // Drop and add
+            Symphony::Database()
+                ->alter('tbl_authors')
+                ->drop('auth_token_active')
+                ->add([
+                    'auth_token' => [
+                        'type' => 'varchar(255)',
+                        'null' => true,
+                    ]
+                ])
+                ->execute();
+            // Create tokens for active users
+            foreach ($activeTokenAuthors as $ata) {
+                unset($ata['auth_token_active']);
+                $ata->set('auth_token', Cryptography::randomBytes(40));
+                $ata->commit();
+            }
+            unset($activeTokenAuthors);
         }
 
         // Update the version information

--- a/symphony/content/content.login.php
+++ b/symphony/content/content.login.php
@@ -61,11 +61,18 @@ class contentLogin extends HTMLPage
 
     public function view()
     {
-        if (isset($this->_context[0]) && in_array(strlen($this->_context[0]), array(6, 8, 16))) {
-            if (!$this->__loginFromToken($this->_context[0])) {
+        if (isset($this->_context[1]) && $this->_context[0] === 'reset-password') {
+            if (Administration::instance()->loginFromToken($this->_context[1])) {
                 if (Administration::instance()->isLoggedIn()) {
                     // Redirect to the Author's profile. RE: #1801
                     redirect(SYMPHONY_URL . '/system/authors/edit/' . Symphony::Author()->get('id') . '/reset-password/');
+                }
+            }
+        } elseif (isset($this->_context[0])) {
+            if (Administration::instance()->loginFromToken($this->_context[0])) {
+                if (Administration::instance()->isLoggedIn()) {
+                    // Regular token-based login
+                    redirect(SYMPHONY_URL . '/');
                 }
             }
         }
@@ -248,14 +255,7 @@ class contentLogin extends HTMLPage
                         ->variable('token');
 
                     if (!$token) {
-                        // More secure password token generation
-                        if (function_exists('openssl_random_pseudo_bytes')) {
-                            $seed = openssl_random_pseudo_bytes(16);
-                        } else {
-                            $seed = mt_rand();
-                        }
-
-                        $token = substr(SHA1::hash($seed), 0, 16);
+                        $token = Cryptography::randomBytes(40);
 
                         Symphony::Database()
                             ->insert('tbl_forgotpass')->values([
@@ -273,7 +273,7 @@ class contentLogin extends HTMLPage
                         $email->subject = __('New Symphony Account Password');
                         $email->text_plain = __('Hi %s,', array($author['first_name'])) . PHP_EOL .
                                 __('A new password has been requested for your account. Login using the following link, and change your password via the Authors area:') . PHP_EOL .
-                                PHP_EOL . '    ' . SYMPHONY_URL . "/login/{$token}/" . PHP_EOL . PHP_EOL .
+                                PHP_EOL . '    ' . SYMPHONY_URL . "/login/reset-password/{$token}/" . PHP_EOL . PHP_EOL .
                                 __('It will expire in 2 hours. If you did not ask for a new password, please disregard this email.') . PHP_EOL . PHP_EOL .
                                 __('Best Regards,') . PHP_EOL .
                                 __('The Symphony Team');
@@ -317,20 +317,5 @@ class contentLogin extends HTMLPage
                 }
             }
         }
-    }
-
-    public function __loginFromToken($token)
-    {
-        // If token is invalid, return to login page
-        if (!Administration::instance()->loginFromToken($token)) {
-            return false;
-        }
-
-        // If token is valid and is an 8 char shortcut
-        if (!in_array(strlen($token), array(6, 16))) {
-            redirect(SYMPHONY_URL . '/'); // Regular token-based login
-        }
-
-        return false;
     }
 }

--- a/symphony/content/content.login.php
+++ b/symphony/content/content.login.php
@@ -255,7 +255,7 @@ class contentLogin extends HTMLPage
                         ->variable('token');
 
                     if (!$token) {
-                        $token = Cryptography::randomBytes(40);
+                        $token = Cryptography::randomBytes();
 
                         Symphony::Database()
                             ->insert('tbl_forgotpass')->values([

--- a/symphony/content/content.systemauthors.php
+++ b/symphony/content/content.systemauthors.php
@@ -615,7 +615,7 @@ class contentSystemAuthors extends AdministrationPage
             $this->_Author->set('password', (trim($fields['password']) == '' ? '' : Cryptography::hash($fields['password'])));
             $this->_Author->set('default_area', $fields['default_area']);
             if ($this->isRemoteLoginActionChecked() && !$this->_Author->isTokenActive()) {
-                $this->_Author->set('auth_token', Cryptography::randomBytes(40));
+                $this->_Author->set('auth_token', Cryptography::randomBytes());
             } elseif (!$this->isRemoteLoginActionChecked()) {
                 $this->_Author->set('auth_token', null);
             }
@@ -779,7 +779,7 @@ class contentSystemAuthors extends AdministrationPage
             }
 
             if ($authenticated && $this->isRemoteLoginActionChecked() && !$this->_Author->isTokenActive()) {
-                $this->_Author->set('auth_token', Cryptography::randomBytes(40));
+                $this->_Author->set('auth_token', Cryptography::randomBytes());
             } elseif (!$this->isRemoteLoginActionChecked()) {
                 $this->_Author->set('auth_token', null);
             }

--- a/symphony/content/content.systemauthors.php
+++ b/symphony/content/content.systemauthors.php
@@ -29,6 +29,13 @@ class contentSystemAuthors extends AdministrationPage
         return $authorQuery->execute()->rows();
     }
 
+    public function isRemoteLoginActionChecked()
+    {
+        return is_array($_POST['action']) &&
+            array_key_exists('remote_login', $_POST['action']) &&
+            $_POST['action']['remote_login'] === 'yes';
+    }
+
     public function __viewIndex()
     {
         $this->setPageType('table');
@@ -409,17 +416,24 @@ class contentSystemAuthors extends AdministrationPage
         $group->appendChild($fieldset);
 
         // Auth token
-        if (Symphony::Author()->isDeveloper() || Symphony::Author()->isManager()) {
+        if (Symphony::Author()->isDeveloper() || Symphony::Author()->isManager() || $isOwner) {
             $label = Widget::Label();
-            $group->appendChild(Widget::Input('fields[auth_token_active]', 'no', 'hidden'));
-            $input = Widget::Input('fields[auth_token_active]', 'yes', 'checkbox');
+            $group->appendChild(Widget::Input('action[remote_login]', 'no', 'hidden'));
+            $input = Widget::Input('action[remote_login]', 'yes', 'checkbox');
 
             if ($author->isTokenActive()) {
                 $input->setAttribute('checked', 'checked');
+                $tokenUrl = SYMPHONY_URL . '/login/' . $author->getAuthToken() . '/';
+                $label->setValue(__('%s Remote login with the token %s is enabled.', [
+                     $input->generate(),
+                     '<a href="' . $tokenUrl . '">' . $author->getAuthToken() . '</a>',
+                ]));
+            } else {
+                $label->setValue(__('%s Remote login is currently disabled.', [
+                    $input->generate(),
+                ]) . ' ' . __('Check the box to generate a new token.'));
             }
 
-            $temp = SYMPHONY_URL . '/login/' . $author->createAuthToken() . '/';
-            $label->setValue(__('%s Allow remote login via', array($input->generate())) . ' <a href="' . $temp . '">' . $temp . '</a>');
             $group->appendChild($label);
         }
 
@@ -576,7 +590,6 @@ class contentSystemAuthors extends AdministrationPage
     {
         if (is_array($_POST['action']) && array_key_exists('save', $_POST['action'])) {
             $fields = $_POST['fields'];
-
             $canCreate = Symphony::Author()->isDeveloper() || Symphony::Author()->isManager();
 
             if (!$canCreate) {
@@ -601,7 +614,11 @@ class contentSystemAuthors extends AdministrationPage
             $this->_Author->set('last_seen', null);
             $this->_Author->set('password', (trim($fields['password']) == '' ? '' : Cryptography::hash($fields['password'])));
             $this->_Author->set('default_area', $fields['default_area']);
-            $this->_Author->set('auth_token_active', ($fields['auth_token_active'] ? $fields['auth_token_active'] : 'no'));
+            if ($this->isRemoteLoginActionChecked() && !$this->_Author->isTokenActive()) {
+                $this->_Author->set('auth_token', Cryptography::randomBytes(40));
+            } elseif (!$this->isRemoteLoginActionChecked()) {
+                $this->_Author->set('auth_token', null);
+            }
             $this->_Author->set('language', isset($fields['language']) ? $fields['language'] : null);
 
             /**
@@ -695,16 +712,16 @@ class contentSystemAuthors extends AdministrationPage
                 // but not the primary account
                 || (Symphony::Author()->isDeveloper() && $this->_Author->isPrimaryAccount() === false);
 
+        if (!$isOwner && !$canEdit) {
+            Administration::instance()->throwCustomError(
+                __('You are not authorised to modify this author.'),
+                __('Access Denied'),
+                Page::HTTP_STATUS_UNAUTHORIZED
+            );
+        }
+
         if (is_array($_POST['action']) && array_key_exists('save', $_POST['action'])) {
             $authenticated = $changing_password = $changing_email = false;
-
-            if (!$isOwner && !$canEdit) {
-                Administration::instance()->throwCustomError(
-                    __('You are not authorised to modify this author.'),
-                    __('Access Denied'),
-                    Page::HTTP_STATUS_UNAUTHORIZED
-                );
-            }
 
             if ($fields['email'] != $this->_Author->get('email')) {
                 $changing_email = true;
@@ -761,7 +778,11 @@ class contentSystemAuthors extends AdministrationPage
                 $this->_Author->set('default_area', $fields['default_area']);
             }
 
-            $this->_Author->set('auth_token_active', ($fields['auth_token_active'] ? $fields['auth_token_active'] : 'no'));
+            if ($authenticated && $this->isRemoteLoginActionChecked() && !$this->_Author->isTokenActive()) {
+                $this->_Author->set('auth_token', Cryptography::randomBytes(40));
+            } elseif (!$this->isRemoteLoginActionChecked()) {
+                $this->_Author->set('auth_token', null);
+            }
 
             /**
              * Before editing an author, provided with the Author object

--- a/symphony/lib/core/class.administration.php
+++ b/symphony/lib/core/class.administration.php
@@ -84,20 +84,18 @@ class Administration extends Symphony
      * Overrides the Symphony isLoggedIn function to allow Authors
      * to become logged into the backend when `$_REQUEST['auth-token']`
      * is present. This logs an Author in using the loginFromToken function.
-     * A token may be 6 or 8 characters in length in the backend. A 6 or 16 character token
-     * is used for forget password requests, whereas the 8 character token is used to login
-     * an Author into the page
      *
-     * @see core.Symphony#loginFromToken()
+     * @uses Symphony::loginFromToken()
+     * @uses Symphony::isLoggedIn()
      * @return boolean
      */
     public static function isLoggedIn()
     {
-        if (isset($_REQUEST['auth-token']) && $_REQUEST['auth-token'] && in_array(strlen($_REQUEST['auth-token']), array(6, 8, 16))) {
+        if (isset($_REQUEST['auth-token']) && $_REQUEST['auth-token']) {
             return self::loginFromToken($_REQUEST['auth-token']);
         }
 
-        return parent::isLoggedIn();
+        return Symphony::isLoggedIn();
     }
 
     /**
@@ -173,7 +171,7 @@ class Administration extends Symphony
             if ($page === '/publish/') {
                 $sections = (new SectionManager)->select()->sort('sortorder')->execute()->rows();
                 $section = current($sections);
-                redirect(SYMPHONY_URL . '/publish/' . $section->get('handle'));
+                redirect(SYMPHONY_URL . '/publish/' . $section->get('handle') . '/');
             } else {
                 $this->errorPageNotFound();
             }

--- a/symphony/lib/core/class.frontend.php
+++ b/symphony/lib/core/class.frontend.php
@@ -58,17 +58,18 @@ class Frontend extends Symphony
     /**
      * Overrides the Symphony `isLoggedIn()` function to allow Authors
      * to become logged into the frontend when `$_REQUEST['auth-token']`
-     * is present. This logs an Author in using the loginFromToken function.
+     * is present.
+     * This logs an Author in using the loginFromToken function.
      * This function allows the use of 'admin' type pages, where a Frontend
-     * page requires that the viewer be a Symphony Author
+     * page requires that the viewer be a Symphony Author.
      *
-     * @see core.Symphony#loginFromToken()
-     * @see core.Symphony#isLoggedIn()
+     * @uses Symphony::loginFromToken()
+     * @uses Symphony::isLoggedIn()
      * @return boolean
      */
     public static function isLoggedIn()
     {
-        if (isset($_REQUEST['auth-token']) && $_REQUEST['auth-token'] && strlen($_REQUEST['auth-token']) == 8) {
+        if (isset($_REQUEST['auth-token']) && $_REQUEST['auth-token']) {
             return self::loginFromToken($_REQUEST['auth-token']);
         }
 

--- a/symphony/lib/toolkit/class.author.php
+++ b/symphony/lib/toolkit/class.author.php
@@ -178,14 +178,24 @@ class Author implements ArrayAccess
     }
 
     /**
-     * Returns boolean if the current Author's authentication token
-     * is active or not.
+     * Returns boolean if the current Author's authentication token is valid.
      *
      * @return boolean
      */
     public function isTokenActive()
     {
-        return ($this->get('auth_token_active') === 'yes' ? true : false);
+        return !empty($this->get('auth_token'));
+    }
+
+    /**
+     * Returns the current Author's auth token.
+     *
+     * @return mixed
+     *  The auth token or null
+     */
+    public function getAuthToken()
+    {
+        return $this->get('auth_token');
     }
 
     /**
@@ -196,21 +206,6 @@ class Author implements ArrayAccess
     public function getFullName()
     {
         return $this->get('first_name') . ' ' . $this->get('last_name');
-    }
-
-    /**
-     * Creates an author token using the `Cryptography::hash` function and the
-     * current Author's username and password. The default hash function
-     * is SHA1
-     *
-     * @see toolkit.Cryptography#hash()
-     * @see toolkit.General#substrmin()
-     *
-     * @return string
-     */
-    public function createAuthToken()
-    {
-        return General::substrmin(sha1($this->get('username') . $this->get('password')), 8);
     }
 
     /**
@@ -334,8 +329,8 @@ class Author implements ArrayAccess
      * existing user is determined by if an ID is already set.
      * When the database is updated successfully, the id of the author is set.
      *
-     * @see toolkit.AuthorManager#add()
-     * @see toolkit.AuthorManager#edit()
+     * @uses AuthorManager::add()
+     * @uses AuthorManager::edit()
      * @return integer|boolean
      *  When a new Author is added or updated, an integer of the Author ID
      *  will be returned, otherwise false will be returned for a failed update.

--- a/symphony/lib/toolkit/class.authormanager.php
+++ b/symphony/lib/toolkit/class.authormanager.php
@@ -82,6 +82,43 @@ class AuthorManager
     }
 
     /**
+     * Undocumented function
+     *
+     * @param [type] $token
+     * @return void
+     */
+    public function fetchByPasswordResetToken($token)
+    {
+        if (!$token) {
+            return null;
+        }
+        return $this->select()
+            ->innerjoin('tbl_forgotpass')->alias('f')
+            ->on(['a.id' => '$f.author_id'])
+            ->where(['f.expiry' => ['>' => DateTimeObj::getGMT('c')]])
+            ->where(['f.token' => $token])
+            ->execute()
+            ->next();
+    }
+
+    /**
+     * Undocumented function
+     *
+     * @param [type] $token
+     * @return void
+     */
+    public function fetchByAuthToken($token)
+    {
+        if (!$token) {
+            return null;
+        }
+        return $this->select()
+            ->where(['a.auth_token' => $token])
+            ->execute()
+            ->next();
+    }
+
+    /**
      * The fetch method returns all Authors from Symphony with the option to sort
      * or limit the output. This method returns an array of Author objects.
      *
@@ -232,52 +269,6 @@ class AuthorManager
         }
 
         return self::$_pool[$username];
-    }
-
-    /**
-     * This function will allow an Author to sign into Symphony by using their
-     * authentication token as well as username/password.
-     *
-     * @param integer $author_id
-     *  The Author ID to allow to use their authentication token.
-     * @throws DatabaseException
-     * @return boolean
-     */
-    public static function activateAuthToken($author_id)
-    {
-        if (!is_int($author_id)) {
-            return false;
-        }
-
-        return Symphony::Database()
-            ->update('tbl_authors')
-            ->set(['auth_token_active' => 'yes'])
-            ->where(['id' => $author_id])
-            ->execute()
-            ->success();
-    }
-
-    /**
-     * This function will remove the ability for an Author to sign into Symphony
-     * by using their authentication token
-     *
-     * @param integer $author_id
-     *  The Author ID to allow to use their authentication token.
-     * @throws DatabaseException
-     * @return boolean
-     */
-    public static function deactivateAuthToken($author_id)
-    {
-        if (!is_int($author_id)) {
-            return false;
-        }
-
-        return Symphony::Database()
-            ->update('tbl_authors')
-            ->set(['auth_token_active' => 'no'])
-            ->where(['id' => $author_id])
-            ->execute()
-            ->success();
     }
 
     /**

--- a/symphony/lib/toolkit/class.authormanager.php
+++ b/symphony/lib/toolkit/class.authormanager.php
@@ -82,38 +82,50 @@ class AuthorManager
     }
 
     /**
-     * Undocumented function
+     * Fetch a single author by its reset password token
      *
-     * @param [type] $token
-     * @return void
+     * @param string $token
+     * @return Author
+     * @throws Exception
+     *  If the token is not a string
      */
     public function fetchByPasswordResetToken($token)
     {
         if (!$token) {
             return null;
         }
+        General::ensureType([
+            'token' => ['var' => $token, 'type' => 'string'],
+        ]);
         return $this->select()
-            ->innerjoin('tbl_forgotpass')->alias('f')
+            ->innerJoin('tbl_forgotpass')->alias('f')
             ->on(['a.id' => '$f.author_id'])
             ->where(['f.expiry' => ['>' => DateTimeObj::getGMT('c')]])
             ->where(['f.token' => $token])
+            ->limit(1)
             ->execute()
             ->next();
     }
 
     /**
-     * Undocumented function
+     * Fetch a single author by its auth token
      *
-     * @param [type] $token
-     * @return void
+     * @param string $token
+     * @return Author
+     * @throws Exception
+     *  If the token is not a string
      */
     public function fetchByAuthToken($token)
     {
         if (!$token) {
             return null;
         }
+        General::ensureType([
+            'token' => ['var' => $token, 'type' => 'string'],
+        ]);
         return $this->select()
             ->where(['a.auth_token' => $token])
+            ->limit(1)
             ->execute()
             ->next();
     }

--- a/symphony/lib/toolkit/class.cryptography.php
+++ b/symphony/lib/toolkit/class.cryptography.php
@@ -106,12 +106,14 @@ class Cryptography
      *
      * @uses Cryptography::generateSalt()
      * @param integer $length
-     *  The number of random bytes to get. The minimum is 16. Defaults to 20.
+     *  The number of random bytes to get.
+     *  The minimum is 16.
+     *  Defaults to 40, which is 160 bits of entropy.
      * @return string
      * @throws Exception
      *  If the requested length is smaller than 16.
      */
-    public static function randomBytes($length = 20)
+    public static function randomBytes($length = 40)
     {
         if ($length < 16) {
             throw new Exception('Can not generate less than 16 random bytes');

--- a/symphony/lib/toolkit/class.cryptography.php
+++ b/symphony/lib/toolkit/class.cryptography.php
@@ -96,4 +96,31 @@ class Cryptography
         mt_srand(intval(microtime(true)*100000 + memory_get_usage(true)));
         return substr(sha1(uniqid(mt_rand(), true)), 0, $length);
     }
+
+    /**
+     * Returns a string generated from random bytes.
+     * It requires a minimum length of 16.
+     * It first tries to call PHP's random_byte.
+     * If not available, it will try openssl_random_pseudo_bytes.
+     * If not available, it will revert to `Cryptography::generateSalt()`.
+     *
+     * @uses Cryptography::generateSalt()
+     * @param integer $length
+     *  The number of random bytes to get. The minimum is 16. Defaults to 20.
+     * @return string
+     * @throws Exception
+     *  If the requested length is smaller than 16.
+     */
+    public static function randomBytes($length = 20)
+    {
+        if ($length < 16) {
+            throw new Exception('Can not generate less than 16 random bytes');
+        }
+        if (function_exists('random_bytes')) {
+            return bin2hex(random_bytes($length / 2));
+        } elseif (function_exists('openssl_random_pseudo_bytes')) {
+            return bin2hex(openssl_random_pseudo_bytes($length / 2));
+        }
+        return self::generateSalt($length);
+    }
 }

--- a/tests/lib/toolkit/CryptographyTest.php
+++ b/tests/lib/toolkit/CryptographyTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Symphony\Crypto\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Cryptography
+ */
+final class CryptographyTest extends TestCase
+{
+    public function testDefaultRandomBytes()
+    {
+        $r1 = \Cryptography::randomBytes();
+        $r2 = \Cryptography::randomBytes();
+        $this->assertEquals(20, strlen($r1));
+        $this->assertEquals(20, strlen($r2));
+        $this->assertNotEquals($r1, $r2);
+    }
+
+    public function test32RandomBytes()
+    {
+        $length = 32;
+        $r1 = \Cryptography::randomBytes($length);
+        $r2 = \Cryptography::randomBytes($length);
+        $this->assertEquals($length, strlen($r1));
+        $this->assertEquals($length, strlen($r2));
+        $this->assertNotEquals($r1, $r2);
+    }
+
+    public function testGenerateSalt()
+    {
+        $length = 32;
+        $r1 = \Cryptography::generateSalt($length);
+        $r2 = \Cryptography::generateSalt($length);
+        $this->assertEquals($length, strlen($r1));
+        $this->assertEquals($length, strlen($r2));
+        $this->assertNotEquals($r1, $r2);
+    }
+}

--- a/tests/lib/toolkit/CryptographyTest.php
+++ b/tests/lib/toolkit/CryptographyTest.php
@@ -13,8 +13,18 @@ final class CryptographyTest extends TestCase
     {
         $r1 = \Cryptography::randomBytes();
         $r2 = \Cryptography::randomBytes();
-        $this->assertEquals(20, strlen($r1));
-        $this->assertEquals(20, strlen($r2));
+        $this->assertEquals(40, strlen($r1));
+        $this->assertEquals(40, strlen($r2));
+        $this->assertNotEquals($r1, $r2);
+    }
+
+    public function test16RandomBytes()
+    {
+        $length = 16;
+        $r1 = \Cryptography::randomBytes($length);
+        $r2 = \Cryptography::randomBytes($length);
+        $this->assertEquals($length, strlen($r1));
+        $this->assertEquals($length, strlen($r2));
         $this->assertNotEquals($r1, $r2);
     }
 


### PR DESCRIPTION
Fixes #2724

Both reset password token and auth token are 40 chars long.
Database is changed to take 255 long token (for the future)

Auth token are generated on demand. Deactivating the remote login deletes the token. Renabling it creates a new token.

