### PR TITLE
Some love for XMLElement (bis)

### DIFF
--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -454,7 +454,7 @@ class FrontendPage extends XSLTPage
 
         $xml_build_start = precision_timer();
 
-        $xml = new XMLElement('data');
+        $xml = new XMLDocument('data');
         $xml->renderHeader();
 
         $events = new XMLElement('events');

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -455,7 +455,7 @@ class FrontendPage extends XSLTPage
         $xml_build_start = precision_timer();
 
         $xml = new XMLElement('data');
-        $xml->setIncludeHeader(true);
+        $xml->renderHeader();
 
         $events = new XMLElement('events');
         $this->processEvents($page['events'], $events);

--- a/symphony/lib/toolkit/class.htmlpage.php
+++ b/symphony/lib/toolkit/class.htmlpage.php
@@ -64,11 +64,8 @@ class HTMLPage extends Page
     {
         parent::__construct();
 
-        $this->Html = new XMLElement('html');
-        $this->Html->setIncludeHeader(false);
-
+        $this->Html = (new XMLDocument('html'))->setIncludeHeader(false);
         $this->Head = new XMLElement('head');
-
         $this->Body = new XMLElement('body');
     }
 

--- a/symphony/lib/toolkit/class.xmldocument.php
+++ b/symphony/lib/toolkit/class.xmldocument.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * @package toolkit
+ */
+/**
+ * `XMLDocument` is a class used to simulate PHP's `DOMDocument`
+ * class. Each object is a representation of a XML document
+ * and can store it's children in an array. When an `XMLElement`
+ * is generated, it is output as an XML string.
+ * The `XMLDocument` extends `XMLElement` and adds properties the are specific
+ * to documents.
+ *
+ * @since Symphony 3.0.0
+ */
+
+class XMLDocument extends XMLElement
+{
+    /**
+     * Any processing instructions that the XSLT should know about when a
+     * `XMLElement` is generated
+     * @var array
+     */
+    private $processingInstructions = [];
+
+    /**
+     * The DTD the should be output when a `XMLElement` is generated, defaults to null.
+     * @var string
+     */
+    private $dtd = null;
+
+    /**
+     * The encoding of the `XMLElement`, defaults to 'utf-8'
+     * @var string
+     */
+    private $encoding = 'utf-8';
+
+    /**
+     * The version of the XML that is used for generation, defaults to '1.0'
+     * @var string
+     */
+    private $version = '1.0';
+
+    /**
+     * When set to true this will include the XML declaration will be
+     * output when the `XMLElement` is generated. Defaults to `false`.
+     * @var boolean
+     */
+    private $includeHeader = false;
+
+    /**
+     * Accessor for `$encoding`
+     *
+     * @return string
+     */
+    public function getEncoding()
+    {
+        return $this->encoding;
+    }
+
+    /**
+     * Accessor for `$version`
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * Adds processing instructions to this `XMLElement`
+     *
+     * @param string $pi
+     * @return XMLElement
+     *  The current instance
+     */
+    public function addProcessingInstruction($pi)
+    {
+        $this->processingInstructions[] = $pi;
+        return $this;
+    }
+
+    /**
+     * Sets the DTD for this `XMLElement`
+     *
+     * @param string $dtd
+     * @return XMLElement
+     *  The current instance
+     */
+    public function setDTD($dtd)
+    {
+        $this->dtd = $dtd;
+        return $this;
+    }
+
+    /**
+     * Sets the encoding for this `XMLElement` for when
+     * it's generated.
+     *
+     * @param string $value
+     * @return XMLElement
+     *  The current instance
+     */
+    public function setEncoding($value)
+    {
+        $this->encoding = $value;
+        return $this;
+    }
+
+    /**
+     * Sets the version for the XML declaration of this
+     * `XMLElement`
+     *
+     * @param string $value
+     * @return XMLElement
+     *  The current instance
+     */
+    public function setVersion($value)
+    {
+        $this->version = $value;
+        return $this;
+    }
+
+    /**
+     * Sets whether this `XMLElement` needs to output an
+     * XML declaration or not. This normally is only set to
+     * true for the parent `XMLElement`, eg. 'html'.
+     *
+     * @param bool $value
+     * @return XMLElement
+     *  The current instance
+     */
+    public function setIncludeHeader($value)
+    {
+        $this->includeHeader = $value;
+        return $this;
+    }
+
+    /**
+     * Makes this `XMLElement` output an XML declaration.
+     *
+     * @since Symphony 3.0.0
+     * @uses setIncludeHeader()
+     * @return XMLElement
+     *  The current instance
+     */
+    public function renderHeader()
+    {
+        return $this->setIncludeHeader(true);
+    }
+
+    /**
+     * This function will turn the `XMLDocument` into a string
+     * representing the document as it would appear in the markup.
+     * The result is valid XML.
+     *
+     * @see XMLElement::generate()
+     * @param boolean $indent
+     *  Defaults to false
+     * @param integer $tabDepth
+     *  Defaults to 0, indicates the number of tabs (\t) that this
+     *  element should be indented by in the output string
+     * @return string
+     *  The XML string
+     */
+    public function generate($indent = false, $tabDepth = 0)
+    {
+        $result = null;
+        $newline = ($indent ? PHP_EOL : null);
+
+        if ($this->includeHeader) {
+            $result .= sprintf(
+                '<?xml version="%s" encoding="%s" ?>%s',
+                $this->version,
+                $this->encoding,
+                $newline
+            );
+        }
+
+        if ($this->dtd) {
+            $result .= $this->dtd . $newline;
+        }
+
+        if (!empty($this->processingInstructions)) {
+            $result .= implode($newline, $this->processingInstructions);
+        }
+
+        return $result . parent::generate($indent, $tabDepth);
+    }
+
+    /**
+     * Given a `DOMDocument`, this function will create a new `XMLDocument`
+     * object, copy all attributes and children and return the result.
+     *
+     * @param DOMDocument $doc
+     *  A DOMDocument to copy from
+     * @return XMLDocument
+     *  The new `XMLDocument` derived from `DOMDocument $doc`.
+     */
+    public static function fromDOMDocument(DOMDocument $doc)
+    {
+        $root = new XMLDocument($doc->documentElement->nodeName);
+        static::copyDOMNode($root, $doc->documentElement);
+        return $root;
+    }
+}

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -872,8 +872,8 @@ class XMLElement implements IteratorAggregate
                 $result .= $this->dtd . $newline;
             }
 
-            if (is_array($this->processingInstructions) && !empty($this->processingInstructions)) {
-                $result .= implode(PHP_EOL, $this->processingInstructions);
+            if (!empty($this->processingInstructions)) {
+                $result .= implode($newline, $this->processingInstructions);
             }
         }
 

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -23,13 +23,13 @@ class XMLElement implements IteratorAggregate
      * The name of the HTML Element, eg. 'p'
      * @var string
      */
-    private $_name;
+    private $name;
 
     /**
-     * The value of this `XMLElement` as a string
-     * @var string
+     * The value of this `XMLElement` as an array or a string
+     * @var string|array
      */
-    private $_value = array();
+    private $value = [];
 
     /**
      * Any additional attributes can be included in an associative array
@@ -37,52 +37,52 @@ class XMLElement implements IteratorAggregate
      * attribute.
      * @var array
      */
-    private $_attributes = array();
+    private $attributes = [];
 
     /**
      * Children of this `XMLElement`, which will also be `XMLElement`'s
      * @var array
      */
-    private $_children = array();
+    private $children = [];
 
     /**
      * Any processing instructions that the XSLT should know about when a
      * `XMLElement` is generated
      * @var array
      */
-    private $_processingInstructions = array();
+    private $processingInstructions = [];
 
     /**
      * The DTD the should be output when a `XMLElement` is generated, defaults to null.
      * @var string
      */
-    private $_dtd = null;
+    private $dtd = null;
 
     /**
      * The encoding of the `XMLElement`, defaults to 'utf-8'
      * @var string
      */
-    private $_encoding = 'utf-8';
+    private $encoding = 'utf-8';
 
     /**
      * The version of the XML that is used for generation, defaults to '1.0'
      * @var string
      */
-    private $_version = '1.0';
+    private $version = '1.0';
 
     /**
      * The type of element, defaults to 'xml'. Used when determining the style
      * of end tag for this element when generated
      * @var string
      */
-    private $_elementStyle = 'xml';
+    private $elementStyle = 'xml';
 
     /**
      * When set to true this will include the XML declaration will be
      * output when the `XMLElement` is generated. Defaults to `false`.
      * @var boolean
      */
-    private $_includeHeader = false;
+    private $includeHeader = false;
 
     /**
      * Specifies whether this HTML element has an closing element, or if
@@ -90,7 +90,7 @@ class XMLElement implements IteratorAggregate
      *  eg. `<p></p>` or `<input />`
      * @var boolean
      */
-    private $_selfclosing = true;
+    private $selfclosing = true;
 
     /**
      * Specifies whether attributes need to have a value or if they can
@@ -98,7 +98,7 @@ class XMLElement implements IteratorAggregate
      *  `<option selected>Value</option>`
      * @var boolean
      */
-    private $_allowEmptyAttributes = true;
+    private $allowEmptyAttributes = true;
 
     /**
      * The constructor for the `XMLElement`
@@ -117,7 +117,7 @@ class XMLElement implements IteratorAggregate
      *  Whether this function should convert the `$name` to a handle. Defaults to
      *  `false`.
      */
-    public function __construct($name, $value = null, array $attributes = array(), $createHandle = false)
+    public function __construct($name, $value = null, array $attributes = [], $createHandle = false)
     {
         $this->setName($name, $createHandle);
         $this->setValue($value);
@@ -128,34 +128,34 @@ class XMLElement implements IteratorAggregate
     }
 
     /**
-     * Accessor for `$_name`
+     * Accessor for `$name`
      *
      * @return string
      */
     public function getName()
     {
-        return $this->_name;
+        return $this->name;
     }
 
     /**
-     * Accessor for `$_value`
+     * Accessor for `$value`, converted to a string
      *
-     * @return string|XMLElement
+     * @return string
      */
     public function getValue()
     {
         $value = '';
 
-        if (is_array($this->_value)) {
-            foreach ($this->_value as $v) {
+        if (is_array($this->value)) {
+            foreach ($this->value as $v) {
                 if ($v instanceof XMLElement) {
                     $value .= $v->generate();
                 } else {
                     $value .= $v;
                 }
             }
-        } elseif (!is_null($this->_value)) {
-            $value = $this->_value;
+        } elseif (!is_null($this->value)) {
+            $value = $this->value;
         }
 
         return $value;
@@ -169,21 +169,21 @@ class XMLElement implements IteratorAggregate
      */
     public function getAttribute($name)
     {
-        if (!isset($this->_attributes[$name])) {
+        if (!isset($this->attributes[$name])) {
             return null;
         }
 
-        return $this->_attributes[$name];
+        return $this->attributes[$name];
     }
 
     /**
-     * Accessor for `$this->_attributes`
+     * Accessor for `$this->attributes`
      *
      * @return array
      */
     public function getAttributes()
     {
-        return $this->_attributes;
+        return $this->attributes;
     }
 
     /**
@@ -195,32 +195,32 @@ class XMLElement implements IteratorAggregate
      */
     public function getChild($position)
     {
-        if (!isset($this->_children[$this->getRealIndex($position)])) {
+        if (!isset($this->children[$this->getRealIndex($position)])) {
             return null;
         }
 
-        return $this->_children[$this->getRealIndex($position)];
+        return $this->children[$this->getRealIndex($position)];
     }
 
     /**
-     * Accessor for `$this->_children`
+     * Accessor for `$this->children`
      *
      * @return array
      */
     public function getChildren()
     {
-        return $this->_children;
+        return $this->children;
     }
 
     /**
-     * Accessor for `$this->_children`, returning only `XMLElement` children,
+     * Accessor for `$this->children`, returning only `XMLElement` children,
      * not text nodes.
      *
      * @return XMLElementChildrenFilter
      */
     public function getIterator()
     {
-        return new XMLElementChildrenFilter(new ArrayIterator($this->_children));
+        return new XMLElementChildrenFilter(new ArrayIterator($this->children));
     }
 
     /**
@@ -244,7 +244,7 @@ class XMLElement implements IteratorAggregate
     }
 
     /**
-     * Accessor to return an associative array of all `$this->_children`
+     * Accessor to return an associative array of all `$this->children`
      * whose's name matches the given `$name`. If no children are found,
      * an empty array will be returned.
      *
@@ -252,11 +252,11 @@ class XMLElement implements IteratorAggregate
      * @param string $name
      * @return array
      *  An associative array where the key is the `$index` of the child
-     *  in `$this->_children`
+     *  in `$this->children`
      */
     public function getChildrenByName($name)
     {
-        $result = array();
+        $result = [];
 
         foreach ($this as $i => $child) {
             if ($child->getName() != $name) {
@@ -276,7 +276,7 @@ class XMLElement implements IteratorAggregate
      */
     public function addProcessingInstruction($pi)
     {
-        $this->_processingInstructions[] = $pi;
+        $this->processingInstructions[] = $pi;
     }
 
     /**
@@ -286,7 +286,7 @@ class XMLElement implements IteratorAggregate
      */
     public function setDTD($dtd)
     {
-        $this->_dtd = $dtd;
+        $this->dtd = $dtd;
     }
 
     /**
@@ -297,7 +297,7 @@ class XMLElement implements IteratorAggregate
      */
     public function setEncoding($value)
     {
-        $this->_encoding = $value;
+        $this->encoding = $value;
     }
 
     /**
@@ -308,7 +308,7 @@ class XMLElement implements IteratorAggregate
      */
     public function setVersion($value)
     {
-        $this->_version = $value;
+        $this->version = $value;
     }
 
     /**
@@ -323,7 +323,7 @@ class XMLElement implements IteratorAggregate
      */
     public function setElementStyle($style = 'xml')
     {
-        $this->_elementStyle = $style;
+        $this->elementStyle = $style;
     }
 
     /**
@@ -336,7 +336,7 @@ class XMLElement implements IteratorAggregate
      */
     public function setIncludeHeader($value = false)
     {
-        $this->_includeHeader = $value;
+        $this->includeHeader = $value;
     }
 
     /**
@@ -347,7 +347,7 @@ class XMLElement implements IteratorAggregate
      */
     public function setSelfClosingTag($value = true)
     {
-        $this->_selfclosing = $value;
+        $this->selfclosing = $value;
     }
 
     /**
@@ -359,7 +359,7 @@ class XMLElement implements IteratorAggregate
      */
     public function setAllowEmptyAttributes($value = true)
     {
-        $this->_allowEmptyAttributes = $value;
+        $this->allowEmptyAttributes = $value;
     }
 
     /**
@@ -374,7 +374,7 @@ class XMLElement implements IteratorAggregate
      */
     public function setName($name, $createHandle = false)
     {
-        $this->_name = ($createHandle) ? Lang::createHandle($name) : $name;
+        $this->name = ($createHandle) ? Lang::createHandle($name) : $name;
     }
 
     /**
@@ -392,7 +392,7 @@ class XMLElement implements IteratorAggregate
         }
 
         if (!is_null($value)) {
-            $this->_value = $value;
+            $this->value = $value;
             $this->appendChild($value);
         }
     }
@@ -406,12 +406,12 @@ class XMLElement implements IteratorAggregate
      */
     public function replaceValue($value)
     {
-        foreach ($this->_children as $i => $child) {
+        foreach ($this->children as $i => $child) {
             if ($child instanceof XMLElement) {
                 continue;
             }
 
-            unset($this->_children[$i]);
+            unset($this->children[$i]);
         }
 
         $this->setValue($value);
@@ -427,7 +427,7 @@ class XMLElement implements IteratorAggregate
      */
     public function setAttribute($name, $value)
     {
-        $this->_attributes[$name] = $value;
+        $this->attributes[$name] = $value;
     }
 
     /**
@@ -467,7 +467,7 @@ class XMLElement implements IteratorAggregate
 
     /**
      * This function expects an array of `XMLElement` that will completely
-     * replace the contents of `$this->_children`. Take care when using
+     * replace the contents of `$this->children`. Take care when using
      * this function.
      *
      * @since Symphony 2.2.2
@@ -481,7 +481,7 @@ class XMLElement implements IteratorAggregate
         foreach ($children as $child) {
             $this->validateChild($child);
         }
-        $this->_children = $children;
+        $this->children = $children;
 
         return true;
     }
@@ -495,7 +495,7 @@ class XMLElement implements IteratorAggregate
     public function appendChild($child)
     {
         $this->validateChild($child);
-        $this->_children[] = $child;
+        $this->children[] = $child;
 
         return true;
     }
@@ -524,7 +524,7 @@ class XMLElement implements IteratorAggregate
      */
     public function prependChild(XMLElement $child)
     {
-        array_unshift($this->_children, $child);
+        array_unshift($this->children, $child);
     }
 
     /**
@@ -571,19 +571,19 @@ class XMLElement implements IteratorAggregate
      */
     public function getNumberOfChildren()
     {
-        return count($this->_children);
+        return count($this->children);
     }
 
     /**
-     * Given the position of the child in the `$this->_children`,
+     * Given the position of the child in the `$this->children`,
      * this function will unset the child at that position. This function
      * is not reversible. This function does not alter the key's of
-     * `$this->_children` after removing a child
+     * `$this->children` after removing a child
      *
      * @since Symphony 2.2.2
      * @param integer $index
      *  The index of the child to be removed. If the index given is negative
-     *  it will be calculated from the end of `$this->_children`.
+     *  it will be calculated from the end of `$this->children`.
      * @return boolean
      *  true if child was successfully removed, false otherwise.
      */
@@ -595,26 +595,26 @@ class XMLElement implements IteratorAggregate
 
         $index = $this->getRealIndex($index);
 
-        if (!isset($this->_children[$index])) {
+        if (!isset($this->children[$index])) {
             return false;
         }
 
-        unset($this->_children[$index]);
+        unset($this->children[$index]);
 
         return true;
     }
 
     /**
      * Given a desired index, and an `XMLElement`, this function will insert
-     * the child at that index in `$this->_children` shuffling all children
+     * the child at that index in `$this->children` shuffling all children
      * greater than `$index` down one. If the `$index` given is greater then
      * the number of children for this `XMLElement`, the `$child` will be
-     * appended to the current `$this->_children` array.
+     * appended to the current `$this->children` array.
      *
      * @since Symphony 2.2.2
      * @param integer $index
      *  The index where the `$child` should be inserted. If this is negative
-     *  the index will be calculated from the end of `$this->_children`.
+     *  the index will be calculated from the end of `$this->children`.
      * @param XMLElement $child
      *  The XMLElement to insert at the desired `$index`
      * @return boolean
@@ -631,8 +631,8 @@ class XMLElement implements IteratorAggregate
             return $this->appendChild($child);
         }
 
-        $start = array_slice($this->_children, 0, $index);
-        $end = array_slice($this->_children, $index);
+        $start = array_slice($this->children, 0, $index);
+        $end = array_slice($this->children, $index);
 
         $merge = array_merge($start, array(
             $index => $child
@@ -649,7 +649,7 @@ class XMLElement implements IteratorAggregate
      * @since Symphony 2.2.2
      * @param integer $index
      *  The index of the child to be replaced. If the index given is negative
-     *  it will be calculated from the end of `$this->_children`.
+     *  it will be calculated from the end of `$this->children`.
      * @param XMLElement $child
      *  An XMLElement of the new child
      * @return boolean
@@ -664,24 +664,24 @@ class XMLElement implements IteratorAggregate
 
         $index = $this->getRealIndex($index);
 
-        if (!isset($this->_children[$index])) {
+        if (!isset($this->children[$index])) {
             return false;
         }
 
-        $this->_children[$index] = $child;
+        $this->children[$index] = $child;
 
         return true;
     }
 
     /**
-     * Given an `$index`, return the real index in `$this->_children`
+     * Given an `$index`, return the real index in `$this->children`
      * depending on if the value is negative or not. Negative values
      * will work from the end of an array.
      *
      * @since Symphony 2.2.2
      * @param integer $index
      *  Positive indexes are returned as is, negative indexes are deducted
-     *  from the end of `$this->_children`
+     *  from the end of `$this->children`
      * @return integer
      */
     private function getRealIndex($index)
@@ -744,7 +744,7 @@ class XMLElement implements IteratorAggregate
      * @param boolean $has_parent
      *  Defaults to false, set to true when the children are being
      *  generated. Only the parent will output an XML declaration
-     *  if `$this->_includeHeader` is set to true.
+     *  if `$this->includeHeader` is set to true.
      * @return string
      */
     public function generate($indent = false, $tab_depth = 0, $has_parent = false)
@@ -753,21 +753,21 @@ class XMLElement implements IteratorAggregate
         $newline = ($indent ? PHP_EOL : null);
 
         if (!$has_parent) {
-            if ($this->_includeHeader) {
+            if ($this->includeHeader) {
                 $result .= sprintf(
                     '<?xml version="%s" encoding="%s" ?>%s',
-                    $this->_version,
-                    $this->_encoding,
+                    $this->version,
+                    $this->encoding,
                     $newline
                 );
             }
 
-            if ($this->_dtd) {
-                $result .= $this->_dtd . $newline;
+            if ($this->dtd) {
+                $result .= $this->dtd . $newline;
             }
 
-            if (is_array($this->_processingInstructions) && !empty($this->_processingInstructions)) {
-                $result .= implode(PHP_EOL, $this->_processingInstructions);
+            if (is_array($this->processingInstructions) && !empty($this->processingInstructions)) {
+                $result .= implode(PHP_EOL, $this->processingInstructions);
             }
         }
 
@@ -778,7 +778,7 @@ class XMLElement implements IteratorAggregate
         if (!empty($attributes)) {
             foreach ($attributes as $attribute => $value) {
                 $length = strlen($value);
-                if ($length !== 0 || $length === 0 && $this->_allowEmptyAttributes) {
+                if ($length !== 0 || $length === 0 && $this->allowEmptyAttributes) {
                     $result .= sprintf(' %s="%s"', $attribute, $value);
                 }
             }
@@ -787,10 +787,10 @@ class XMLElement implements IteratorAggregate
         $value = $this->getValue();
         $added_newline = false;
 
-        if ($this->getNumberOfChildren() > 0 || strlen($value) !== 0 || !$this->_selfclosing) {
+        if ($this->getNumberOfChildren() > 0 || strlen($value) !== 0 || !$this->selfclosing) {
             $result .= '>';
 
-            foreach ($this->_children as $i => $child) {
+            foreach ($this->children as $i => $child) {
                 if (!($child instanceof XMLElement)) {
                     $result .= $child;
                 } else {
@@ -799,7 +799,7 @@ class XMLElement implements IteratorAggregate
                         $result .= $newline;
                     }
 
-                    $child->setElementStyle($this->_elementStyle);
+                    $child->setElementStyle($this->elementStyle);
                     $result .= $child->generate($indent, $tab_depth + 1, true);
                 }
             }
@@ -813,9 +813,9 @@ class XMLElement implements IteratorAggregate
 
             // Empty elements:
         } else {
-            if ($this->_elementStyle === 'xml') {
+            if ($this->elementStyle === 'xml') {
                 $result .= ' />';
-            } elseif (in_array($this->_name, XMLElement::$no_end_tags) || (substr($this->getName(), 0, 3) === '!--')) {
+            } elseif (in_array($this->name, XMLElement::$no_end_tags) || (substr($this->getName(), 0, 3) === '!--')) {
                 $result .= '>';
             } else {
                 $result .= sprintf("></%s>", $this->getName());

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -908,7 +908,7 @@ class XMLElement implements IteratorAggregate
      * @param XMLElement $element
      * @param DOMNode $node
      */
-    private static function copyDOMNode(XMLElement $element, DOMNode $node)
+    protected static function copyDOMNode(XMLElement $element, DOMNode $node)
     {
         if ($node->hasAttributes()) {
             foreach ($node->attributes as $name => $attrEl) {

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -978,17 +978,13 @@ class XMLElement implements IteratorAggregate
      * @param DOMNode $node
      * @return XMLElement
      */
-    private static function convert(XMLElement $root = null, DOMNode $node)
+    private static function convert(XMLElement $root, DOMNode $node)
     {
         $el = new XMLElement($node->tagName);
 
         self::convertNode($el, $node);
 
-        if (is_null($root)) {
-            return $el;
-        } else {
-            $root->appendChild($el);
-        }
+        $root->appendChild($el);
     }
 
     /**

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -712,6 +712,8 @@ class XMLElement implements IteratorAggregate
      * appended to the current `$this->children` array.
      *
      * @since Symphony 2.2.2
+     * @uses validateChild()
+     * @uses setChildren()
      * @param integer $index
      *  The index where the `$child` should be inserted. If this is negative
      *  the index will be calculated from the end of `$this->children`.
@@ -722,7 +724,7 @@ class XMLElement implements IteratorAggregate
      * @throws Exception
      *  If the $index is not an integer.
      */
-    public function insertChildAt($index, XMLElement $child = null)
+    public function insertChildAt($index, XMLElement $child)
     {
         General::ensureType([
             'index' => ['var' => $index, 'type' => 'int'],
@@ -737,9 +739,7 @@ class XMLElement implements IteratorAggregate
         $start = array_slice($this->children, 0, $index);
         $end = array_slice($this->children, $index);
 
-        $merge = array_merge($start, array(
-            $index => $child
-        ), $end);
+        $merge = array_merge($start, [$index => $child], $end);
 
         return $this->setChildren($merge);
     }
@@ -760,7 +760,7 @@ class XMLElement implements IteratorAggregate
      * @throws Exception
      *  If the $index is not an integer or the index is not valid.
      */
-    public function replaceChildAt($index, XMLElement $child = null)
+    public function replaceChildAt($index, XMLElement $child)
     {
         General::ensureType([
             'index' => ['var' => $index, 'type' => 'int'],

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -122,17 +122,17 @@ class XMLElement implements IteratorAggregate
     public function getValue()
     {
         $value = '';
+        $values = $this->value;
 
-        if (is_array($this->value)) {
-            foreach ($this->value as $v) {
-                if ($v instanceof XMLElement) {
-                    $value .= $v->generate();
-                } else {
-                    $value .= $v;
-                }
+        if (!is_array($values)) {
+            $values = [$values];
+        }
+        foreach ($values as $v) {
+            if ($v instanceof XMLElement) {
+                $value .= $v->generate();
+            } elseif ($v) {
+                $value .= $v;
             }
-        } elseif (!is_null($this->value)) {
-            $value = $this->value;
         }
 
         return $value;

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -1022,16 +1022,3 @@ class XMLElement implements IteratorAggregate
         }
     }
 }
-
-/**
- * Creates a filter that only returns XMLElement items
- */
-class XMLElementChildrenFilter extends FilterIterator
-{
-    public function accept()
-    {
-        $item = $this->getInnerIterator()->current();
-
-        return $item instanceof XMLElement;
-    }
-}

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -90,7 +90,7 @@ class XMLElement implements IteratorAggregate
      *  eg. `<p></p>` or `<input />`
      * @var boolean
      */
-    private $selfclosing = true;
+    private $selfClosing = true;
 
     /**
      * Specifies whether attributes need to have a value or if they can
@@ -273,20 +273,26 @@ class XMLElement implements IteratorAggregate
      * Adds processing instructions to this `XMLElement`
      *
      * @param string $pi
+     * @return XMLElement
+     *  The current instance
      */
     public function addProcessingInstruction($pi)
     {
         $this->processingInstructions[] = $pi;
+        return $this;
     }
 
     /**
      * Sets the DTD for this `XMLElement`
      *
      * @param string $dtd
+     * @return XMLElement
+     *  The current instance
      */
     public function setDTD($dtd)
     {
         $this->dtd = $dtd;
+        return $this;
     }
 
     /**
@@ -294,10 +300,13 @@ class XMLElement implements IteratorAggregate
      * it's generated.
      *
      * @param string $value
+     * @return XMLElement
+     *  The current instance
      */
     public function setEncoding($value)
     {
         $this->encoding = $value;
+        return $this;
     }
 
     /**
@@ -305,10 +314,13 @@ class XMLElement implements IteratorAggregate
      * `XMLElement`
      *
      * @param string $value
+     * @return XMLElement
+     *  The current instance
      */
     public function setVersion($value)
     {
         $this->version = $value;
+        return $this;
     }
 
     /**
@@ -316,14 +328,16 @@ class XMLElement implements IteratorAggregate
      * `XMLElement` is being generated to determine whether
      * needs to be closed, is self closing or is standalone.
      *
-     * @param string $style (optional)
-     *  Defaults to 'xml', any other value will trigger the
-     *  XMLElement to be closed by itself or left standalone
-     *  if it is in the `XMLElement::no_end_tags`.
+     * @param string $style
+     *  If not 'xml', will trigger the
+     *  XMLElement to be closed by itself or left standalone.
+     * @return XMLElement
+     *  The current instance
      */
-    public function setElementStyle($style = 'xml')
+    public function setElementStyle($style)
     {
         $this->elementStyle = $style;
+        return $this;
     }
 
     /**
@@ -331,35 +345,80 @@ class XMLElement implements IteratorAggregate
      * XML declaration or not. This normally is only set to
      * true for the parent `XMLElement`, eg. 'html'.
      *
-     * @param bool|string $value (optional)
-     *  Defaults to false
+     * @param bool $value
+     * @return XMLElement
+     *  The current instance
      */
-    public function setIncludeHeader($value = false)
+    public function setIncludeHeader($value)
     {
         $this->includeHeader = $value;
+        return $this;
+    }
+
+    /**
+     * Makes this `XMLElement` output an XML declaration.
+     *
+     * @since Symphony 3.0.0
+     * @uses setIncludeHeader()
+     * @return XMLElement
+     *  The current instance
+     */
+    public function renderHeader()
+    {
+        return $this->setIncludeHeader(true);
     }
 
     /**
      * Sets whether this `XMLElement` is self closing or not.
      *
-     * @param bool|string $value (optional)
-     *  Defaults to true
+     * @param bool $value
+     * @return XMLElement
+     *  The current instance
      */
-    public function setSelfClosingTag($value = true)
+    public function setSelfClosingTag($value)
     {
-        $this->selfclosing = $value;
+        $this->selfClosing = $value;
+        return $this;
+    }
+
+    /**
+     * Makes this `XMLElement` to self close.
+     *
+     * @since Symphony 3.0.0
+     * @uses setSelfClosingTag()
+     * @return XMLElement
+     *  The current instance
+     */
+    public function renderSelfClosingTag()
+    {
+        return $this->setSelfClosingTag(true);
     }
 
     /**
      * Specifies whether attributes need to have a value
      * or if they can be shorthand on this `XMLElement`.
      *
-     * @param bool|string $value (optional)
-     *  Defaults to true
+     * @param bool $value
+     * @return XMLElement
+     *  The current instance
      */
-    public function setAllowEmptyAttributes($value = true)
+    public function setAllowEmptyAttributes($value)
     {
         $this->allowEmptyAttributes = $value;
+        return $this;
+    }
+
+    /**
+     * Makes this `XMLElement` render empty attributes.
+     *
+     * @since Symphony 3.0.0
+     * @uses setAllowEmptyAttributes()
+     * @return XMLElement
+     *  The current instance
+     */
+    public function renderEmptyAttributes()
+    {
+        return $this->setAllowEmptyAttributes(true);
     }
 
     /**
@@ -369,21 +428,23 @@ class XMLElement implements IteratorAggregate
      * @param string $name
      *  The name of the `XMLElement`, 'p'.
      * @param boolean $createHandle
-     *  Whether this function should convert the `$name` to a handle. Defaults to
-     *  `false`.
+     *  Whether this function should convert the `$name` to a handle.
+     *  Defaults to `false`.
+     * @return XMLElement
+     *  The current instance
      */
     public function setName($name, $createHandle = false)
     {
         $this->name = ($createHandle) ? Lang::createHandle($name) : $name;
+        return $this;
     }
 
     /**
-     * Sets the value of the `XMLElement`. Checks to see
-     * whether the value should be prepended or appended
-     * to the children.
+     * Sets and appends the value of the `XMLElement`.
      *
      * @param string|XMLElement|array $value
-     *  Defaults to true.
+     * @return XMLElement
+     *  The current instance
      */
     public function setValue($value)
     {
@@ -395,6 +456,8 @@ class XMLElement implements IteratorAggregate
             $this->value = $value;
             $this->appendChild($value);
         }
+
+        return $this;
     }
 
     /**
@@ -403,6 +466,8 @@ class XMLElement implements IteratorAggregate
      *
      * @since Symphony 2.4
      * @param string|XMLElement|array $value
+     * @return XMLElement
+     *  The current instance
      */
     public function replaceValue($value)
     {
@@ -415,6 +480,8 @@ class XMLElement implements IteratorAggregate
         }
 
         $this->setValue($value);
+
+        return $this;
     }
 
     /**
@@ -424,10 +491,13 @@ class XMLElement implements IteratorAggregate
      *  The name of the attribute
      * @param string $value
      *  The value of the attribute
+     * @return XMLElement
+     *  The current instance
      */
     public function setAttribute($name, $value)
     {
         $this->attributes[$name] = $value;
+        return $this;
     }
 
     /**
@@ -437,6 +507,8 @@ class XMLElement implements IteratorAggregate
      * @param array $attributes
      *  Associative array with the key being the name and
      *  the value being the value of the attribute.
+     * @return XMLElement
+     *  The current instance
      */
     public function setAttributeArray(array $attributes = null)
     {
@@ -447,6 +519,8 @@ class XMLElement implements IteratorAggregate
         foreach ($attributes as $name => $value) {
             $this->setAttribute($name, $value);
         }
+
+        return $this;
     }
 
     /**
@@ -456,13 +530,17 @@ class XMLElement implements IteratorAggregate
      * @since Symphony 2.5.0
      * @param XMLElement $child
      *  The child to validate
-     *
+     * @return XMLElement
+     *  The current instance
+     * @throws Exception
+     *  If the child is not valid
      */
     private function validateChild($child)
     {
         if ($this === $child) {
             throw new Exception(__('Can not add the element itself as one of its child'));
         }
+        return $this;
     }
 
     /**
@@ -471,10 +549,12 @@ class XMLElement implements IteratorAggregate
      * this function.
      *
      * @since Symphony 2.2.2
+     * @uses validateChild()
      * @param array $children
      *  An array of XMLElement's to act as the children for the current
      *  XMLElement instance
-     * @return boolean
+     * @return XMLElement
+     *  The current instance
      */
     public function setChildren(array $children = null)
     {
@@ -482,29 +562,32 @@ class XMLElement implements IteratorAggregate
             $this->validateChild($child);
         }
         $this->children = $children;
-
-        return true;
+        return $this;
     }
 
     /**
      * Adds an `XMLElement` to the children array
      *
+     * @uses validateChild()
      * @param XMLElement|string $child
-     * @return boolean
+     * @return XMLElement
+     *  The current instance
      */
     public function appendChild($child)
     {
         $this->validateChild($child);
         $this->children[] = $child;
-
-        return true;
+        return $this;
     }
 
     /**
      * A convenience method to add children to an `XMLElement`
      * quickly.
      *
+     * @uses appendChild()
      * @param array $children
+     * @return XMLElement
+     *  The current instance
      */
     public function appendChildArray(array $children = null)
     {
@@ -513,6 +596,7 @@ class XMLElement implements IteratorAggregate
                 $this->appendChild($child);
             }
         }
+        return $this;
     }
 
     /**
@@ -520,21 +604,30 @@ class XMLElement implements IteratorAggregate
      * array, this will mean it is output before any other
      * children when the `XMLElement` is generated
      *
+     * @uses validateChild()
      * @param XMLElement $child
+     * @return XMLElement
+     *  The current instance
      */
     public function prependChild(XMLElement $child)
     {
+        $this->validateChild($child);
         array_unshift($this->children, $child);
+        return $this;
     }
 
     /**
      * A convenience method to quickly add a CSS class to this `XMLElement`'s
      * existing class attribute. If the attribute does not exist, it will
      * be created.
+     * It also make sure that classes are separated by a single space.
      *
      * @since Symphony 2.2.2
+     * @uses setAttribute()
      * @param string $class
-     *  The CSS classname to add to this `XMLElement`
+     *  The CSS class name to add to this `XMLElement`
+     * @return XMLElement
+     *  The current instance
      */
     public function addClass($class)
     {
@@ -542,18 +635,21 @@ class XMLElement implements IteratorAggregate
         $added = preg_split('%\s+%', $class, 0, PREG_SPLIT_NO_EMPTY);
         $current = array_merge($current, $added);
         $classes = implode(' ', $current);
-
-        $this->setAttribute('class', $classes);
+        return $this->setAttribute('class', $classes);
     }
 
     /**
      * A convenience method to quickly remove a CSS class from an
      * `XMLElement`'s existing class attribute. If the attribute does not
      * exist, this method will do nothing.
+     * It also make sure that classes are separated by a single space.
      *
      * @since Symphony 2.2.2
+     * @uses setAttribute()
      * @param string $class
-     *  The CSS classname to remove from this `XMLElement`
+     *  The CSS class name to remove from this `XMLElement`
+     * @return XMLElement
+     *  The current instance
      */
     public function removeClass($class)
     {
@@ -561,8 +657,7 @@ class XMLElement implements IteratorAggregate
         $removed = preg_split('%\s+%', $class, 0, PREG_SPLIT_NO_EMPTY);
         $classes = array_diff($classes, $removed);
         $classes = implode(' ', $classes);
-
-        $this->setAttribute('class', $classes);
+        return $this->setAttribute('class', $classes);
     }
 
     /**
@@ -584,24 +679,26 @@ class XMLElement implements IteratorAggregate
      * @param integer $index
      *  The index of the child to be removed. If the index given is negative
      *  it will be calculated from the end of `$this->children`.
-     * @return boolean
-     *  true if child was successfully removed, false otherwise.
+     * @return XMLElement
+     *  The current instance
+     * @throws Exception
+     *  If the $index is not an integer or the index is not valid.
      */
     public function removeChildAt($index)
     {
-        if (!is_numeric($index)) {
-            return false;
-        }
+        General::ensureType([
+            'index' => ['var' => $index, 'type' => 'int'],
+        ]);
 
         $index = $this->getRealIndex($index);
 
         if (!isset($this->children[$index])) {
-            return false;
+            throw new Exception("Index out of range. No child at index `$index`.");
         }
 
         unset($this->children[$index]);
 
-        return true;
+        return $this;
     }
 
     /**
@@ -617,13 +714,16 @@ class XMLElement implements IteratorAggregate
      *  the index will be calculated from the end of `$this->children`.
      * @param XMLElement $child
      *  The XMLElement to insert at the desired `$index`
-     * @return boolean
+     * @return XMLElement
+     *  The current instance
+     * @throws Exception
+     *  If the $index is not an integer.
      */
     public function insertChildAt($index, XMLElement $child = null)
     {
-        if (!is_numeric($index)) {
-            return false;
-        }
+        General::ensureType([
+            'index' => ['var' => $index, 'type' => 'int'],
+        ]);
         
         $this->validateChild($child);
 
@@ -652,25 +752,28 @@ class XMLElement implements IteratorAggregate
      *  it will be calculated from the end of `$this->children`.
      * @param XMLElement $child
      *  An XMLElement of the new child
-     * @return boolean
+     * @return XMLElement
+     *  The current instance
+     * @throws Exception
+     *  If the $index is not an integer or the index is not valid.
      */
     public function replaceChildAt($index, XMLElement $child = null)
     {
-        if (!is_numeric($index)) {
-            return false;
-        }
+        General::ensureType([
+            'index' => ['var' => $index, 'type' => 'int'],
+        ]);
 
         $this->validateChild($child);
 
         $index = $this->getRealIndex($index);
 
         if (!isset($this->children[$index])) {
-            return false;
+            throw new Exception("Index out of range. No child at index `$index`.");
         }
 
         $this->children[$index] = $child;
 
-        return true;
+        return $this;
     }
 
     /**
@@ -787,7 +890,7 @@ class XMLElement implements IteratorAggregate
         $value = $this->getValue();
         $added_newline = false;
 
-        if ($this->getNumberOfChildren() > 0 || strlen($value) !== 0 || !$this->selfclosing) {
+        if ($this->getNumberOfChildren() > 0 || strlen($value) !== 0 || !$this->selfClosing) {
             $result .= '>';
 
             foreach ($this->children as $i => $child) {

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -844,21 +844,21 @@ class XMLElement implements IteratorAggregate
      *
      * @param boolean $indent
      *  Defaults to false
-     * @param integer $tab_depth
+     * @param integer $tabDepth
      *  Defaults to 0, indicates the number of tabs (\t) that this
      *  element should be indented by in the output string
-     * @param boolean $has_parent
+     * @param boolean $hasParent
      *  Defaults to false, set to true when the children are being
      *  generated. Only the parent will output an XML declaration
      *  if `$this->includeHeader` is set to true.
      * @return string
      */
-    public function generate($indent = false, $tab_depth = 0, $has_parent = false)
+    public function generate($indent = false, $tabDepth = 0, $hasParent = false)
     {
         $result = null;
         $newline = ($indent ? PHP_EOL : null);
 
-        if (!$has_parent) {
+        if (!$hasParent) {
             if ($this->includeHeader) {
                 $result .= sprintf(
                     '<?xml version="%s" encoding="%s" ?>%s',
@@ -877,7 +877,7 @@ class XMLElement implements IteratorAggregate
             }
         }
 
-        $result .= ($indent ? str_repeat("\t", $tab_depth) : null) . '<' . $this->getName();
+        $result .= ($indent ? str_repeat("\t", $tabDepth) : null) . '<' . $this->getName();
 
         $attributes = $this->getAttributes();
 
@@ -906,13 +906,13 @@ class XMLElement implements IteratorAggregate
                     }
 
                     $child->setElementStyle($this->elementStyle);
-                    $result .= $child->generate($indent, $tab_depth + 1, true);
+                    $result .= $child->generate($indent, $tabDepth + 1, true);
                 }
             }
 
             $result .= sprintf(
                 "%s</%s>%s",
-                ($indent && $added_newline ? str_repeat("\t", $tab_depth) : null),
+                ($indent && $added_newline ? str_repeat("\t", $tabDepth) : null),
                 $this->getName(),
                 $newline
             );

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -954,7 +954,7 @@ class XMLElement implements IteratorAggregate
      *
      * @since Symphony 2.4
      * @param string $root_element
-     * @param DOMDOcument $doc
+     * @param DOMDocument $doc
      * @return XMLElement
      */
     public static function convertFromDOMDocument($root_element, DOMDocument $doc)
@@ -975,7 +975,7 @@ class XMLElement implements IteratorAggregate
      *
      * @since Symphony 2.4
      * @param XMLElement $root
-     * @param DOMNOde $node
+     * @param DOMNode $node
      * @return XMLElement
      */
     private static function convert(XMLElement $root = null, DOMNode $node)

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -15,9 +15,18 @@ class XMLElement implements IteratorAggregate
      * This is an array of HTML elements that are self closing.
      * @var array
      */
-    protected static $no_end_tags = array(
-        'area', 'base', 'br', 'col', 'hr', 'img', 'input', 'link', 'meta', 'param'
-    );
+    protected static $no_end_tags = [
+        'area',
+        'base',
+        'br',
+        'col',
+        'hr',
+        'img',
+        'input',
+        'link',
+        'meta',
+        'param',
+    ];
 
     /**
      * The name of the HTML Element, eg. 'p'

--- a/symphony/lib/toolkit/class.xmlelement.php
+++ b/symphony/lib/toolkit/class.xmlelement.php
@@ -519,12 +519,8 @@ class XMLElement implements IteratorAggregate
      * @return XMLElement
      *  The current instance
      */
-    public function setAttributeArray(array $attributes = null)
+    public function setAttributeArray(array $attributes)
     {
-        if (!is_array($attributes) || empty($attributes)) {
-            return;
-        }
-
         foreach ($attributes as $name => $value) {
             $this->setAttribute($name, $value);
         }
@@ -565,7 +561,7 @@ class XMLElement implements IteratorAggregate
      * @return XMLElement
      *  The current instance
      */
-    public function setChildren(array $children = null)
+    public function setChildren(array $children)
     {
         foreach ($children as $child) {
             $this->validateChild($child);
@@ -598,12 +594,10 @@ class XMLElement implements IteratorAggregate
      * @return XMLElement
      *  The current instance
      */
-    public function appendChildArray(array $children = null)
+    public function appendChildArray(array $children)
     {
-        if (is_array($children) && !empty($children)) {
-            foreach ($children as $child) {
-                $this->appendChild($child);
-            }
+        foreach ($children as $child) {
+            $this->appendChild($child);
         }
         return $this;
     }

--- a/symphony/lib/toolkit/class.xmlelementchildrenfilter.php
+++ b/symphony/lib/toolkit/class.xmlelementchildrenfilter.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @package toolkit
+ */
+/**
+ * Creates a filter that only returns XMLElement items
+ */
+class XMLElementChildrenFilter extends FilterIterator
+{
+    public function accept()
+    {
+        $item = $this->getInnerIterator()->current();
+        return $item instanceof XMLElement;
+    }
+}

--- a/symphony/lib/toolkit/class.xmlpage.php
+++ b/symphony/lib/toolkit/class.xmlpage.php
@@ -26,7 +26,7 @@ abstract class XMLPage extends TextPage
     public function __construct()
     {
         $this->_Result = new XMLElement('result');
-        $this->_Result->setIncludeHeader(true);
+        $this->_Result->renderHeader();
 
         $this->setHttpStatus(self::HTTP_STATUS_OK);
         $this->addHeaderToPage('Content-Type', 'text/xml');

--- a/symphony/lib/toolkit/class.xmlpage.php
+++ b/symphony/lib/toolkit/class.xmlpage.php
@@ -25,7 +25,7 @@ abstract class XMLPage extends TextPage
      */
     public function __construct()
     {
-        $this->_Result = new XMLElement('result');
+        $this->_Result = new XMLDocument('result');
         $this->_Result->renderHeader();
 
         $this->setHttpStatus(self::HTTP_STATUS_OK);

--- a/tests/lib/toolkit/XMLDocumentTest.php
+++ b/tests/lib/toolkit/XMLDocumentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Symphony\XML\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers XMLDocument
+ */
+final class XMLDocumentTest extends TestCase
+{
+    public function testDefaultValues()
+    {
+        $x = new \XMLDocument('xml');
+        $this->assertEquals('xml', $x->getName());
+        $this->assertEmpty($x->getValue());
+        $this->assertEquals(0, $x->getNumberOfChildren());
+        $this->assertEmpty($x->getChildren());
+        $this->assertEmpty($x->getAttributes());
+        $this->assertEquals('1.0', $x->getVersion());
+        $this->assertEquals('utf-8', $x->getEncoding());
+        $this->assertEquals('<xml />', $x->generate());
+    }
+
+    public function testGenerateWithHeader()
+    {
+        $x = (new \XMLDocument('xml', 'value'));
+        $this->assertEquals('<xml>value</xml>', $x->generate());
+        $x->renderHeader();
+        $this->assertEquals('<?xml version="1.0" encoding="utf-8" ?><xml>value</xml>', $x->generate());
+    }
+
+    public function testAddProcessingInstruction()
+    {
+        $x = (new \XMLDocument('xml'))
+            ->addProcessingInstruction('this is a test')
+            ->appendChild((new \XMLElement('child'))->setValue('1'))
+            ->appendChild((new \XMLElement('child'))->setValue('2'));
+        $this->assertEquals('this is a test<xml><child>1</child><child>2</child></xml>', $x->generate());
+    }
+
+    public function testSetDTD()
+    {
+        $x = (new \XMLDocument('xml'))
+            ->setDTD('test-dtd')
+            ->appendChild((new \XMLElement('child'))->setValue('1'))
+            ->appendChild((new \XMLElement('child'))->setValue('2'));
+        $this->assertEquals('test-dtd<xml><child>1</child><child>2</child></xml>', $x->generate());
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testInvalidAppend()
+    {
+        $x = new \XMLDocument('xml');
+        $c = new \XMLElement('child');
+        $c->appendChild($x);
+    }
+}

--- a/tests/lib/toolkit/XMLDocumentTest.php
+++ b/tests/lib/toolkit/XMLDocumentTest.php
@@ -57,4 +57,20 @@ final class XMLDocumentTest extends TestCase
         $c = new \XMLElement('child');
         $c->appendChild($x);
     }
+
+    public function testFromDOMDocument()
+    {
+        $xml = '<xml test="dom-doc"><child>1</child><child>4</child><child>3</child></xml>';
+        $doc = new \DOMDocument();
+        $doc->loadXML($xml);
+        $x = \XMLDocument::fromDOMDocument($doc);
+        $this->assertTrue($x instanceof \XMLElement);
+        $this->assertTrue($x instanceof \XMLDocument);
+        $this->assertNotEmpty($x);
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(3, $x->getNumberOfChildren());
+        $this->assertEquals('xml', $x->getName());
+        $this->assertEquals('dom-doc', $x->getAttribute('test'));
+        $this->assertEquals('4', $x->getChild(1)->getValue());
+    }
 }

--- a/tests/lib/toolkit/XMLDocumentTest.php
+++ b/tests/lib/toolkit/XMLDocumentTest.php
@@ -22,6 +22,20 @@ final class XMLDocumentTest extends TestCase
         $this->assertEquals('<xml />', $x->generate());
     }
 
+    public function testSetVersion()
+    {
+        $x = (new \XMLDocument('xml'))->setVersion('test')->renderHeader();
+        $this->assertEquals('test', $x->getVersion());
+        $this->assertEquals('<?xml version="test" encoding="utf-8" ?><xml />', $x->generate());
+    }
+
+    public function testSetEncoding()
+    {
+        $x = (new \XMLDocument('xml'))->setEncoding('test')->renderHeader();
+        $this->assertEquals('test', $x->getEncoding());
+        $this->assertEquals('<?xml version="1.0" encoding="test" ?><xml />', $x->generate());
+    }
+
     public function testGenerateWithHeader()
     {
         $x = (new \XMLDocument('xml', 'value'));

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -108,6 +108,25 @@ final class XMLElementTest extends TestCase
         $this->assertEquals('3', $x->getChildByName('child', 1)->getValue());
     }
 
+    public function testGetValue()
+    {
+        $x = new \XMLElement('xml', 'value');
+        $this->assertEquals('value', $x->getValue());
+        $x = new \XMLElement('xml', ['value', 'value2']);
+        $this->assertEquals('value, value2', $x->getValue());
+        $x = new \XMLElement('xml', new \XMLElement('value', 'value'));
+        $this->assertEquals('<value>value</value>', $x->getValue());
+        // TODO: make this work
+        //$x = new \XMLElement('xml', [new \XMLElement('value', 'value')]);
+        //$this->assertEquals('<value>value</value>', $x->getValue());
+    }
+
+    public function testSetValue()
+    {
+        $x = (new \XMLElement('xml'))->setValue('value');
+        $this->assertEquals('value', $x->getValue());
+    }
+
     public function testWithChildrenFormatted()
     {
         $nl = PHP_EOL;

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -288,12 +288,14 @@ final class XMLElementTest extends TestCase
         $this->assertEquals('4', $x->getChild(1)->getValue());
     }
 
-    public function testfromDOMDocument()
+    public function testFromDOMDocument()
     {
         $xml = '<xml test="dom-doc"><child>1</child><child>4</child><child>3</child></xml>';
         $doc = new \DOMDocument();
         $doc->loadXML($xml);
         $x = \XMLElement::fromDOMDocument($doc);
+        $this->assertTrue($x instanceof \XMLElement);
+        $this->assertFalse($x instanceof \XMLDocument);
         $this->assertNotEmpty($x);
         $this->assertNotEmpty($x->getChildren());
         $this->assertEquals(3, $x->getNumberOfChildren());

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -78,6 +78,16 @@ final class XMLElementTest extends TestCase
         $this->assertEquals('<xml class="test test test2" />', $x->generate());
     }
 
+    public function testRemoveClass()
+    {
+        $x = (new \XMLElement('xml'))
+            ->addClass('test')
+            ->addClass('test')
+            ->addClass('test2')
+            ->removeClass('test');
+        $this->assertEquals('<xml class="test2" />', $x->generate());
+    }
+
     public function testGenerateWithSelfClosing()
     {
         $x = (new \XMLElement('xml', 'value'));

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -311,11 +311,12 @@ final class XMLElementTest extends TestCase
             ->appendChild((new \XMLElement('child'))->setValue('1'))
             ->appendChild((new \XMLElement('child'))->setValue('2'))
             ->appendChild((new \XMLElement('child'))->setValue('3'))
-            ->insertChildAt(1, (new \XMLElement('child'))->setValue('4'));
+            ->insertChildAt(1, (new \XMLElement('child'))->setValue('4'))
+            ->insertChildAt(5, (new \XMLElement('child'))->setValue('5'));
         $this->assertNotEmpty($x->getChildren());
-        $this->assertEquals(4, $x->getNumberOfChildren());
+        $this->assertEquals(5, $x->getNumberOfChildren());
         $this->assertEquals(
-            '<xml><child>1</child><child>4</child><child>2</child><child>3</child></xml>',
+            '<xml><child>1</child><child>4</child><child>2</child><child>3</child><child>5</child></xml>',
             $x->generate()
         );
     }

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -110,10 +110,11 @@ final class XMLElementTest extends TestCase
 
     public function testWithChildrenFormatted()
     {
+        $nl = PHP_EOL;
         $x = (new \XMLElement('xml'))
             ->appendChild((new \XMLElement('child'))->setValue('x'))
             ->appendChild((new \XMLElement('child'))->setValue('y'));
-        $this->assertEquals("<xml>\n\t<child>x</child>\n\t<child>y</child>\n</xml>\n", $x->generate(true));
+        $this->assertEquals("<xml>$nl\t<child>x</child>$nl\t<child>y</child>$nl</xml>$nl", $x->generate(true));
     }
 
     /**

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -163,6 +163,18 @@ final class XMLElementTest extends TestCase
         $this->assertEquals('value', $x->getValue());
     }
 
+    public function testReplaceValue()
+    {
+        $x = (new \XMLElement('xml'))
+            ->setValue('value')
+            ->appendChild('string')
+            ->appendChild(new \XMLElement('child'))
+            ->replaceValue('new value');
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(2, $x->getNumberOfChildren());
+        $this->assertEquals('new value', $x->getValue());
+    }
+
     public function testSetAttribute()
     {
         $x = (new \XMLElement('xml'))->setAttribute('value', 'yes');

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Symphony\XML\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers XMLElement
+ */
+final class XMLElementTest extends TestCase
+{
+    public function testDefaultValues()
+    {
+        $x = new \XMLElement('xml');
+        $this->assertEquals('xml', $x->getName());
+        $this->assertEmpty($x->getValue());
+        $this->assertEquals(0, $x->getNumberOfChildren());
+        $this->assertEmpty($x->getChildren());
+        $this->assertEmpty($x->getAttributes());
+        //$this->assertEquals('1.0', $x->getVersion());
+        //$this->assertEquals('utf-8', $x->getEncoding());
+        //$this->assertEquals('xml', $x->getElementStyle());
+        $this->assertEquals('<xml />', $x->generate());
+    }
+
+    public function testValueInConstructor()
+    {
+        $x = new \XMLElement('xml', 'value');
+        $this->assertEquals('xml', $x->getName());
+        $this->assertEquals('value', $x->getValue());
+        $this->assertEquals(1, $x->getNumberOfChildren());
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEmpty($x->getAttributes());
+        $this->assertEquals('<xml>value</xml>', $x->generate());
+    }
+
+    public function testAttributesAndValueInConstructor()
+    {
+        $x = new \XMLElement('xml', 'value', ['attr' => 'yes', 'null' => null]);
+        $this->assertEquals('xml', $x->getName());
+        $this->assertEquals('value', $x->getValue());
+        $this->assertEquals(1, $x->getNumberOfChildren());
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertNotEmpty($x->getAttributes());
+        $this->assertEquals('yes', $x->getAttribute('attr'));
+        $this->assertEquals('<xml attr="yes" null="">value</xml>', $x->generate());
+    }
+
+    public function testAttributesAndValueInConstructorWithHandles()
+    {
+        $x = new \XMLElement('x m l', 'value', ['attr' => 'yes', 'null' => null], true);
+        $this->assertEquals('x-m-l', $x->getName());
+        $this->assertEquals('value', $x->getValue());
+        $this->assertEquals(1, $x->getNumberOfChildren());
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertNotEmpty($x->getAttributes());
+        $this->assertEquals('yes', $x->getAttribute('attr'));
+        $this->assertEquals('<x-m-l attr="yes" null="">value</x-m-l>', $x->generate());
+    }
+
+    public function testNoEmptyAttributes()
+    {
+        $x = (new \XMLElement('xml'))
+            ->setAttribute('null', null)
+            ->setAttributeArray(['empty' => '', 'not-empty' => '1'])
+            ->setAllowEmptyAttributes(false);
+        $this->assertNotEmpty($x->getAttributes());
+        $this->assertEquals('<xml not-empty="1" />', $x->generate());
+    }
+
+    public function testGenerateWithHeader()
+    {
+        $x = (new \XMLElement('xml', 'value'));
+        $this->assertEquals('<xml>value</xml>', $x->generate());
+        $x->renderHeader();
+        $this->assertEquals('<?xml version="1.0" encoding="utf-8" ?><xml>value</xml>', $x->generate());
+    }
+
+    public function testGenerateWithSelfClosing()
+    {
+        $x = (new \XMLElement('xml', 'value'));
+        $this->assertEquals('<xml>value</xml>', $x->generate());
+        $x->renderSelfClosingTag();
+        $this->assertEquals('<xml>value</xml>', $x->generate());
+        $x = (new \XMLElement('xml', null));
+        $this->assertEquals('<xml />', $x->generate());
+        $x->setSelfClosingTag(false);
+        $this->assertEquals('<xml></xml>', $x->generate());
+    }
+
+    public function testGenerateForceNoEndTag()
+    {
+        $x = (new \XMLElement('br', null));
+        $this->assertEquals('<br />', $x->generate());
+        $x->setElementStyle('html');
+        $this->assertEquals('<br>', $x->generate());
+    }
+
+    public function testWithChildrenFormatted()
+    {
+        $x = (new \XMLElement('xml'))
+            ->appendChild((new \XMLElement('child'))->setValue('x'))
+            ->appendChild((new \XMLElement('child'))->setValue('y'));
+        $this->assertEquals("<xml>\n\t<child>x</child>\n\t<child>y</child>\n</xml>\n", $x->generate(true));
+    }
+}

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -347,7 +347,7 @@ final class XMLElementTest extends TestCase
     public function testInvalidReplaceAt()
     {
         $x = (new \XMLElement('xml'));
-        $x->removeChildAt(2, $x);
+        $x->replaceChildAt(2, $x);
     }
 
     public function testFromXMLString()

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -272,4 +272,30 @@ final class XMLElementTest extends TestCase
         $x = (new \XMLElement('xml'));
         $x->removeChildAt(2, $x);
     }
+
+    public function testConvertFromXMLString()
+    {
+        $xml = '<xml test="xml-string"><child>1</child><child>4</child><child>3</child></xml>';
+        $x = \XMLElement::convertFromXMLString('xml-test', $xml);
+        $this->assertNotEmpty($x);
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(3, $x->getNumberOfChildren());
+        $this->assertEquals('xml-test', $x->getName());
+        $this->assertEquals('xml-string', $x->getAttribute('test'));
+        $this->assertEquals('4', $x->getChild(1)->getValue());
+    }
+
+    public function testConvertFromDOMDocument()
+    {
+        $xml = '<xml test="dom-doc"><child>1</child><child>4</child><child>3</child></xml>';
+        $doc = new \DOMDocument();
+        $doc->loadXML($xml);
+        $x = \XMLElement::convertFromDOMDocument('xml-test', $doc);
+        $this->assertNotEmpty($x);
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(3, $x->getNumberOfChildren());
+        $this->assertEquals('xml-test', $x->getName());
+        $this->assertEquals('dom-doc', $x->getAttribute('test'));
+        $this->assertEquals('4', $x->getChild(1)->getValue());
+    }
 }

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -108,6 +108,14 @@ final class XMLElementTest extends TestCase
         $this->assertEquals('<br>', $x->generate());
     }
 
+    public function testGenerateHtmlStyle()
+    {
+        $x = (new \XMLElement('div', null));
+        $this->assertEquals('<div />', $x->generate());
+        $x->setElementStyle('html');
+        $this->assertEquals('<div></div>', $x->generate());
+    }
+
     public function testGetChild()
     {
         $x = (new \XMLElement('xml'))

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -98,6 +98,20 @@ final class XMLElementTest extends TestCase
         $this->assertEquals('<br>', $x->generate());
     }
 
+    public function testGetChild()
+    {
+        $x = (new \XMLElement('xml'))
+            ->appendChild((new \XMLElement('child'))->setValue('1'))
+            ->appendChild((new \XMLElement('child-not'))->setValue('2'))
+            ->appendChild((new \XMLElement('child'))->setValue('3'));
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(3, $x->getNumberOfChildren());
+        $this->assertEquals('1', $x->getChild(0)->getValue());
+        $this->assertEquals('2', $x->getChild(1)->getValue());
+        $this->assertEquals('3', $x->getChild(2)->getValue());
+        $this->assertNull($x->getChild(3));
+    }
+
     public function testGetChildrenByName()
     {
         $x = (new \XMLElement('xml'))

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -103,4 +103,151 @@ final class XMLElementTest extends TestCase
             ->appendChild((new \XMLElement('child'))->setValue('y'));
         $this->assertEquals("<xml>\n\t<child>x</child>\n\t<child>y</child>\n</xml>\n", $x->generate(true));
     }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testInvalidSetChildren()
+    {
+        $x = (new \XMLElement('xml'));
+        $x->setChildren([$x]);
+    }
+
+    public function testAppend()
+    {
+        $x = (new \XMLElement('xml'))
+            ->appendChild((new \XMLElement('child'))->setValue('1'))
+            ->appendChild((new \XMLElement('child'))->setValue('2'))
+            ->appendChild((new \XMLElement('child'))->setValue('3'));
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(3, $x->getNumberOfChildren());
+        $this->assertEquals('<xml><child>1</child><child>2</child><child>3</child></xml>', $x->generate());
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testInvalidAppend()
+    {
+        $x = (new \XMLElement('xml'));
+        $x->appendChild($x);
+    }
+
+    public function testAppendArray()
+    {
+        $x = (new \XMLElement('xml'))
+            ->appendChildArray([
+                (new \XMLElement('child'))->setValue('1'),
+                (new \XMLElement('child'))->setValue('2'),
+                (new \XMLElement('child'))->setValue('3'),
+            ]);
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(3, $x->getNumberOfChildren());
+        $this->assertEquals('<xml><child>1</child><child>2</child><child>3</child></xml>', $x->generate());
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testInvalidAppendArray()
+    {
+        $x = (new \XMLElement('xml'));
+        $x->appendChildArray([$x]);
+    }
+
+    public function testPrepend()
+    {
+        $x = (new \XMLElement('xml'))
+            ->prependChild((new \XMLElement('child'))->setValue('3'))
+            ->prependChild((new \XMLElement('child'))->setValue('2'))
+            ->prependChild((new \XMLElement('child'))->setValue('1'));
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(3, $x->getNumberOfChildren());
+        $this->assertEquals('<xml><child>1</child><child>2</child><child>3</child></xml>', $x->generate());
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testInvalidPrepend()
+    {
+        $x = (new \XMLElement('xml'));
+        $x->prependChild($x);
+    }
+
+    public function testRemoveAt()
+    {
+        $x = (new \XMLElement('xml'))
+            ->appendChild((new \XMLElement('child'))->setValue('1'))
+            ->appendChild((new \XMLElement('child'))->setValue('2'))
+            ->appendChild((new \XMLElement('child'))->setValue('3'))
+            ->removeChildAt(1);
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(2, $x->getNumberOfChildren());
+        $this->assertEquals('<xml><child>1</child><child>3</child></xml>', $x->generate());
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testInvalidRemoveAt()
+    {
+        $x = (new \XMLElement('xml'));
+        $x->removeChildAt(0);
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testInvalidRemoveAtUnsetIndex()
+    {
+        $x = (new \XMLElement('xml'))
+            ->appendChild((new \XMLElement('child'))->setValue('1'))
+            ->appendChild((new \XMLElement('child'))->setValue('2'))
+            ->appendChild((new \XMLElement('child'))->setValue('3'))
+            ->removeChildAt(1);
+        $x->removeChildAt(1);
+    }
+
+    public function testInsertAt()
+    {
+        $x = (new \XMLElement('xml'))
+            ->appendChild((new \XMLElement('child'))->setValue('1'))
+            ->appendChild((new \XMLElement('child'))->setValue('2'))
+            ->appendChild((new \XMLElement('child'))->setValue('3'))
+            ->removeChildAt(1);
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(2, $x->getNumberOfChildren());
+        $this->assertEquals('<xml><child>1</child><child>3</child></xml>', $x->generate());
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testInvalidInsertAt()
+    {
+        $x = (new \XMLElement('xml'));
+        $x->insertChildAt(2, $x);
+    }
+
+    public function testReplaceAt()
+    {
+        $x = (new \XMLElement('xml'))
+            ->appendChild((new \XMLElement('child'))->setValue('1'))
+            ->appendChild((new \XMLElement('child'))->setValue('2'))
+            ->appendChild((new \XMLElement('child'))->setValue('3'))
+            ->replaceChildAt(1, (new \XMLElement('child'))->setValue('4'));
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(3, $x->getNumberOfChildren());
+        $this->assertEquals('<xml><child>1</child><child>4</child><child>3</child></xml>', $x->generate());
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testInvalidReplaceAt()
+    {
+        $x = (new \XMLElement('xml'));
+        $x->removeChildAt(2, $x);
+    }
 }

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -169,6 +169,15 @@ final class XMLElementTest extends TestCase
         $this->assertEquals("<xml>$nl\t<child>x</child>$nl\t<child>y</child>$nl</xml>$nl", $x->generate(true));
     }
 
+    public function testSetChildren()
+    {
+        $x = (new \XMLElement('xml'))->appendChild(new \XMLElement('test-child', 'value'));
+        $x->setChildren([new \XMLElement('test-child')]);
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(1, $x->getNumberOfChildren());
+        $this->assertEquals('', $x->getChild(0)->getValue());
+    }
+
     /**
      * @expectedException Exception
      */

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -299,10 +299,13 @@ final class XMLElementTest extends TestCase
             ->appendChild((new \XMLElement('child'))->setValue('1'))
             ->appendChild((new \XMLElement('child'))->setValue('2'))
             ->appendChild((new \XMLElement('child'))->setValue('3'))
-            ->removeChildAt(1);
+            ->insertChildAt(1, (new \XMLElement('child'))->setValue('4'));
         $this->assertNotEmpty($x->getChildren());
-        $this->assertEquals(2, $x->getNumberOfChildren());
-        $this->assertEquals('<xml><child>1</child><child>3</child></xml>', $x->generate());
+        $this->assertEquals(4, $x->getNumberOfChildren());
+        $this->assertEquals(
+            '<xml><child>1</child><child>4</child><child>2</child><child>3</child></xml>',
+            $x->generate()
+        );
     }
 
     /**

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -291,6 +291,18 @@ final class XMLElementTest extends TestCase
         $this->assertEquals('test-dtd<xml><child>1</child><child>2</child></xml>', $x->generate());
     }
 
+    public function testFromXMLString()
+    {
+        $xml = '<xml test="xml-string"><child>1</child><child>4</child><child>3</child></xml>';
+        $x = \XMLElement::fromXMLString($xml);
+        $this->assertNotEmpty($x);
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(3, $x->getNumberOfChildren());
+        $this->assertEquals('xml', $x->getName());
+        $this->assertEquals('xml-string', $x->getAttribute('test'));
+        $this->assertEquals('4', $x->getChild(1)->getValue());
+    }
+
     public function testConvertFromXMLString()
     {
         $xml = '<xml test="xml-string"><child>1</child><child>4</child><child>3</child></xml>';
@@ -300,6 +312,20 @@ final class XMLElementTest extends TestCase
         $this->assertEquals(3, $x->getNumberOfChildren());
         $this->assertEquals('xml-test', $x->getName());
         $this->assertEquals('xml-string', $x->getAttribute('test'));
+        $this->assertEquals('4', $x->getChild(1)->getValue());
+    }
+
+    public function testfromDOMDocument()
+    {
+        $xml = '<xml test="dom-doc"><child>1</child><child>4</child><child>3</child></xml>';
+        $doc = new \DOMDocument();
+        $doc->loadXML($xml);
+        $x = \XMLElement::fromDOMDocument($doc);
+        $this->assertNotEmpty($x);
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(3, $x->getNumberOfChildren());
+        $this->assertEquals('xml', $x->getName());
+        $this->assertEquals('dom-doc', $x->getAttribute('test'));
         $this->assertEquals('4', $x->getChild(1)->getValue());
     }
 

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -96,6 +96,28 @@ final class XMLElementTest extends TestCase
         $this->assertEquals('<br>', $x->generate());
     }
 
+    public function testGetChildrenByName()
+    {
+        $x = (new \XMLElement('xml'))
+            ->appendChild((new \XMLElement('child'))->setValue('1'))
+            ->appendChild((new \XMLElement('child-not'))->setValue('2'))
+            ->appendChild((new \XMLElement('child'))->setValue('3'));
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(3, $x->getNumberOfChildren());
+        $this->assertEquals('3', $x->getChildByName('child', 1)->getValue());
+    }
+
+    public function testGetChildrenByNameWithValue()
+    {
+        $x = (new \XMLElement('xml', 'value'))
+            ->appendChild((new \XMLElement('child'))->setValue('1'))
+            ->appendChild((new \XMLElement('child-not'))->setValue('2'))
+            ->appendChild((new \XMLElement('child'))->setValue('3'));
+        $this->assertNotEmpty($x->getChildren());
+        $this->assertEquals(4, $x->getNumberOfChildren());
+        $this->assertEquals('3', $x->getChildByName('child', 1)->getValue());
+    }
+
     public function testWithChildrenFormatted()
     {
         $x = (new \XMLElement('xml'))

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -273,6 +273,24 @@ final class XMLElementTest extends TestCase
         $x->removeChildAt(2, $x);
     }
 
+    public function testAddProcessingInstruction()
+    {
+        $x = (new \XMLElement('xml'))
+            ->addProcessingInstruction('this is a test')
+            ->appendChild((new \XMLElement('child'))->setValue('1'))
+            ->appendChild((new \XMLElement('child'))->setValue('2'));
+        $this->assertEquals('this is a test<xml><child>1</child><child>2</child></xml>', $x->generate());
+    }
+
+    public function testSetDTD()
+    {
+        $x = (new \XMLElement('xml'))
+            ->setDTD('test-dtd')
+            ->appendChild((new \XMLElement('child'))->setValue('1'))
+            ->appendChild((new \XMLElement('child'))->setValue('2'));
+        $this->assertEquals('test-dtd<xml><child>1</child><child>2</child></xml>', $x->generate());
+    }
+
     public function testConvertFromXMLString()
     {
         $xml = '<xml test="xml-string"><child>1</child><child>4</child><child>3</child></xml>';

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -17,9 +17,7 @@ final class XMLElementTest extends TestCase
         $this->assertEquals(0, $x->getNumberOfChildren());
         $this->assertEmpty($x->getChildren());
         $this->assertEmpty($x->getAttributes());
-        //$this->assertEquals('1.0', $x->getVersion());
-        //$this->assertEquals('utf-8', $x->getEncoding());
-        //$this->assertEquals('xml', $x->getElementStyle());
+        $this->assertEquals('xml', $x->getElementStyle());
         $this->assertEquals('<xml />', $x->generate());
     }
 
@@ -66,14 +64,6 @@ final class XMLElementTest extends TestCase
             ->setAllowEmptyAttributes(false);
         $this->assertNotEmpty($x->getAttributes());
         $this->assertEquals('<xml not-empty="1" />', $x->generate());
-    }
-
-    public function testGenerateWithHeader()
-    {
-        $x = (new \XMLElement('xml', 'value'));
-        $this->assertEquals('<xml>value</xml>', $x->generate());
-        $x->renderHeader();
-        $this->assertEquals('<?xml version="1.0" encoding="utf-8" ?><xml>value</xml>', $x->generate());
     }
 
     public function testGenerateWithSelfClosing()
@@ -271,24 +261,6 @@ final class XMLElementTest extends TestCase
     {
         $x = (new \XMLElement('xml'));
         $x->removeChildAt(2, $x);
-    }
-
-    public function testAddProcessingInstruction()
-    {
-        $x = (new \XMLElement('xml'))
-            ->addProcessingInstruction('this is a test')
-            ->appendChild((new \XMLElement('child'))->setValue('1'))
-            ->appendChild((new \XMLElement('child'))->setValue('2'));
-        $this->assertEquals('this is a test<xml><child>1</child><child>2</child></xml>', $x->generate());
-    }
-
-    public function testSetDTD()
-    {
-        $x = (new \XMLElement('xml'))
-            ->setDTD('test-dtd')
-            ->appendChild((new \XMLElement('child'))->setValue('1'))
-            ->appendChild((new \XMLElement('child'))->setValue('2'));
-        $this->assertEquals('test-dtd<xml><child>1</child><child>2</child></xml>', $x->generate());
     }
 
     public function testFromXMLString()

--- a/tests/lib/toolkit/XMLElementTest.php
+++ b/tests/lib/toolkit/XMLElementTest.php
@@ -56,14 +56,26 @@ final class XMLElementTest extends TestCase
         $this->assertEquals('<x-m-l attr="yes" null="">value</x-m-l>', $x->generate());
     }
 
-    public function testNoEmptyAttributes()
+    public function testEmptyAttributes()
     {
         $x = (new \XMLElement('xml'))
             ->setAttribute('null', null)
-            ->setAttributeArray(['empty' => '', 'not-empty' => '1'])
+            ->setAttributeArray(['not-empty' => '1', 'empty' => ''])
             ->setAllowEmptyAttributes(false);
         $this->assertNotEmpty($x->getAttributes());
         $this->assertEquals('<xml not-empty="1" />', $x->generate());
+        $x->renderEmptyAttributes();
+        $this->assertEquals('<xml null="" not-empty="1" empty="" />', $x->generate());
+    }
+
+    public function testAddClass()
+    {
+        $x = (new \XMLElement('xml'))->addClass('test');
+        $this->assertEquals('<xml class="test" />', $x->generate());
+        $x->addClass('test');
+        $this->assertEquals('<xml class="test test" />', $x->generate());
+        $x->addClass('test2');
+        $this->assertEquals('<xml class="test test test2" />', $x->generate());
     }
 
     public function testGenerateWithSelfClosing()
@@ -125,6 +137,13 @@ final class XMLElementTest extends TestCase
     {
         $x = (new \XMLElement('xml'))->setValue('value');
         $this->assertEquals('value', $x->getValue());
+    }
+
+    public function testSetAttribute()
+    {
+        $x = (new \XMLElement('xml'))->setAttribute('value', 'yes');
+        $this->assertEquals('yes', $x->getAttribute('value'));
+        $this->assertNull($x->getAttribute('undefined'));
     }
 
     public function testWithChildrenFormatted()


### PR DESCRIPTION
This commit makes several changes to the XMLElement class.

First, it makes all operations returns the XMLElement instance, so that operation can be chained.

Second, it splits the XMLElement into two class by adding a new XMLDocument class.
This changes removes the need to keep a copy of properties that are only needed for the top level node in the tree. It should reduce the memory usage when dealing with large XML trees.

Third, it deprecates both convert functions. There new implementation should be faster and saner.

Finally, tests were created before the big splits, so hopefully no bugs should have been introduce (or we are missing a test!)