### PR TITLE
Fix broken sessions with PHP 7.0.*

### DIFF
--- a/symphony/lib/core/class.session.php
+++ b/symphony/lib/core/class.session.php
@@ -185,15 +185,21 @@ class Session
         $session_data = Session::read($id);
         if (!$session_data) {
             $empty = true;
-            $unserialized_data = Session::unserialize($data);
+            if (session_status() === PHP_SESSION_ACTIVE) {
+                $unserialized_data = Session::unserialize($data);
 
-            foreach ($unserialized_data as $d) {
-                if (!empty($d)) {
-                    $empty = false;
+                foreach ($unserialized_data as $d) {
+                    if (!empty($d)) {
+                        $empty = false;
+                    }
                 }
-            }
 
-            if ($empty) {
+                if ($empty) {
+                    return true;
+                }
+            // PHP 7.0 makes the session inactive in write callback,
+            // so we try to detect empty sessions without decoding them
+            } elseif ($data === Symphony::Configuration()->get('cookie_prefix', 'symphony') . '|a:0:{}') {
                 return true;
             }
         }


### PR DESCRIPTION
6040574e25 (#2821) Prevented empty sessions to be stored, which made
Session:read() returned null, which made the session_decode call to be
made in PHP 7.0 for the first time in the lts release.

This commit is a hack to patch PHP 7.0 behavior and try to detect empty
sessions without decoding them.