### PR TITLE
Make sure array_map does not create warnings

### DIFF
--- a/symphony/lib/core/class.session.php
+++ b/symphony/lib/core/class.session.php
@@ -112,7 +112,7 @@ class Session
         if (empty($path)) {
             return '/';
         }
-        $path = array_map(rawurlencode, $path);
+        $path = array_map('rawurlencode', $path);
         return '/' . implode('/', $path);
     }
 


### PR DESCRIPTION
Re: #2828

This has already been fixed in 3.0.x.