### PR TITLE
Remove forward slashes (/) and unicode escapes in env json

### DIFF
--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -399,7 +399,7 @@ class AdministrationPage extends HTMLPage
         );
 
         $this->addElementToHead(
-            new XMLElement('script', json_encode($environment), array(
+            new XMLElement('script', json_encode($environment, JSON_UNESCAPED_SLASHES), array(
                 'type' => 'application/json',
                 'id' => 'environment'
             )),

--- a/symphony/lib/toolkit/class.administrationpage.php
+++ b/symphony/lib/toolkit/class.administrationpage.php
@@ -398,8 +398,14 @@ class AdministrationPage extends HTMLPage
             )
         );
 
+        $envJsonOptions = 0;
+        // Those are PHP 5.4+
+        if (defined('JSON_UNESCAPED_SLASHES') && defined('JSON_UNESCAPED_UNICODE')) {
+            $envJsonOptions = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+        }
+
         $this->addElementToHead(
-            new XMLElement('script', json_encode($environment, JSON_UNESCAPED_SLASHES), array(
+            new XMLElement('script', json_encode($environment, $envJsonOptions), array(
                 'type' => 'application/json',
                 'id' => 'environment'
             )),


### PR DESCRIPTION
The json_encode function follows the standard at https://www.json.org/
which specifies to espace forward slashes. But doing so, makes all url
looks to be broken, because they are escaped.

In this particular case, since the json is outputed in a html page,
which makes it only consumable via javascript, it is safe to not espace
forward slashes, and allow reverse proxy to rewrite the urls, fixing a
bunch of problems!
