### PR TITLE
Set a default log filter value when updating

### DIFF
--- a/install/migrations/2.7.8.php
+++ b/install/migrations/2.7.8.php
@@ -14,6 +14,14 @@
 
         public static function upgrade()
         {
+            // Add the log filter value
+            // This was added in 2.7.1, but the update process never took care of it
+            // Re: #2762
+            $filter = Symphony::Configuration()->get('filter', 'log');
+            if ($filter === null) {
+                Symphony::Configuration()->set('filter', E_ALL ^ E_DEPRECATED, 'log');
+            }
+
             // Update the default value for last_seen
             // This was done in 2.7.0, but the update process never took care of it
             // Re: #2594
@@ -24,5 +32,16 @@
 
             // Update the version information
             return parent::upgrade();
+        }
+
+        public static function postUpdateNotes()
+        {
+            return array(
+                'If none were defined, Symphony did set the default log filter value while updating. ' .
+                    'By default, it will log everything except deprecation notices, ' .
+                    'i.e. <code>E_ALL ^ E_DEPRECATED.</code>',
+                'Make sure to manually adjust your config.php file for your use case.' .
+                    'Symphony uses the same values as PHP\'s <code>error_reporting()</code> function.',
+            );
         }
     }


### PR DESCRIPTION
The update process never took care to set the default log filter value
which ignores depreciation warninngs. This commit also adds a post
update documentation to tell the user about this change.

Re #2762

cc @nilshoerrmann 