### PR TITLE
Make sorting entries deterministic

### DIFF
--- a/symphony/lib/toolkit/class.field.php
+++ b/symphony/lib/toolkit/class.field.php
@@ -1588,7 +1588,7 @@ class Field
             $sort = 'ORDER BY RAND()';
         } else {
             $joins .= "LEFT OUTER JOIN `tbl_entries_data_".$this->get('id')."` AS `ed` ON (`e`.`id` = `ed`.`entry_id`) ";
-            $sort = sprintf('ORDER BY `ed`.`value` %s', $order);
+            $sort = sprintf('ORDER BY `ed`.`value` %1$s, `e`.`id` %1$s', $order);
         }
     }
 

--- a/symphony/lib/toolkit/fields/field.author.php
+++ b/symphony/lib/toolkit/fields/field.author.php
@@ -548,7 +548,7 @@ class FieldAuthor extends Field implements ExportableField
                 LEFT OUTER JOIN `tbl_entries_data_".$this->get('id')."` AS `ed` ON (`e`.`id` = `ed`.`entry_id`)
                 LEFT OUTER JOIN `tbl_authors` AS `a` ON (ed.author_id = a.id)
             ";
-            $sort = sprintf('ORDER BY `a`.`first_name` %1$s, `a`.`last_name` %1$s', $order);
+            $sort = sprintf('ORDER BY `a`.`first_name` %1$s, `a`.`last_name` %1$s, `e`.`id` %1$s', $order);
         }
     }
 

--- a/symphony/lib/toolkit/fields/field.checkbox.php
+++ b/symphony/lib/toolkit/fields/field.checkbox.php
@@ -417,9 +417,10 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
                     SELECT %s
                     FROM tbl_entries_data_%d AS `ed`
                     WHERE entry_id = e.id
-                ) %s',
+                ) %s, `e`.`id` %s',
                 '`ed`.value',
                 $this->get('id'),
+                $order,
                 $order
             );
         }

--- a/symphony/lib/toolkit/fields/field.date.php
+++ b/symphony/lib/toolkit/fields/field.date.php
@@ -752,9 +752,10 @@ class FieldDate extends Field implements ExportableField, ImportableField
                     SELECT %s
                     FROM tbl_entries_data_%d AS `ed`
                     WHERE entry_id = e.id
-                ) %s',
+                ) %s, `e`.`id` %s',
                 '`ed`.date',
                 $this->get('id'),
+                $order,
                 $order
             );
         }

--- a/symphony/lib/toolkit/fields/field.input.php
+++ b/symphony/lib/toolkit/fields/field.input.php
@@ -356,9 +356,10 @@ class FieldInput extends Field implements ExportableField, ImportableField
                     SELECT %s
                     FROM tbl_entries_data_%d AS `ed`
                     WHERE entry_id = e.id
-                ) %s',
+                ) %s, `e`.`id` %s',
                 '`ed`.value',
                 $this->get('id'),
+                $order,
                 $order
             );
         }

--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -800,9 +800,10 @@ class FieldUpload extends Field implements ExportableField, ImportableField
                     SELECT %s
                     FROM tbl_entries_data_%d AS `ed`
                     WHERE entry_id = e.id
-                ) %s',
+                ) %s, `e`.`id` %s',
                 '`ed`.file',
                 $this->get('id'),
+                $order,
                 $order
             );
         }


### PR DESCRIPTION
MySQL does not offer deterministic order bys. This leads to problems
where the user could see records move in the list or see a record that
was displayed in the previous page, which it not nice UX.

It is up to the programmer to create a deterministic sort. When the
fields contains mostly random data, the problem is not visible. But when
there are multiple records with the same value, the problem becomes
apparent: our order by clause is not unique.

The simplest fix I could find was to add the entry id as the last order
by clause. This clause needs to follow the same sort direction, to make
sure the last item becomes the first one when the order is flipped.

Fixes #2856

cc @jurajkapsz 