### PR TITLE
$provides array in Extension class should be protected, not private.

### DIFF
--- a/symphony/lib/toolkit/class.extension.php
+++ b/symphony/lib/toolkit/class.extension.php
@@ -64,7 +64,7 @@ abstract class Extension
      * @since Symphony 2.5.0
      * @var array
      */
-    private static $provides = array();
+    protected static $provides = array();
 
     /**
      * Default constructor for an Extension, at this time it does nothing


### PR DESCRIPTION
In the `Extension` class, the `$provides` array is there to be loaded with provider information using a `registerProviders` function in the extension driver that extends `Extension`. At present this is prevented by `$provides` being private.
