### PR TITLE
Validate section id upon entry edit

### DIFF
--- a/symphony/content/content.publish.php
+++ b/symphony/content/content.publish.php
@@ -1200,6 +1200,15 @@ class contentPublish extends AdministrationPage
         }
         $existingEntry = $existingEntry[0];
 
+        // If the entry does not belong in the context's section
+        if ($section_id != $existingEntry->get('section_id')) {
+            Administration::instance()->throwCustomError(
+                __('Wrong section'),
+                __('The Entry, %s, does not belong in section %s', array($entry_id, $section_id)),
+                Page::HTTP_STATUS_BAD_REQUEST
+            );
+        }
+
         // If there is post data floating around, due to errors, create an entry object
         if (isset($_POST['fields'])) {
             $fields = $_POST['fields'];


### PR DESCRIPTION
This commit adds a validation on the section in the url version the
entry's section id.

Without this patch, it is possible to load entries in any section.
If the user hit save, it wipes all data in the entry and does not give
any errors back to the user.

Even if Symphony does not generate such invalid links, it must not allow users
to wipe data like this.

cc @twiro @jonmifsud 