### PR TITLE
Suppress opcache warnings when opcache_invalidate does not work

### DIFF
--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -1458,7 +1458,7 @@ class contentBlueprintsDatasources extends ResourcesPage
                 // Write successful
             } else {
                 if (function_exists('opcache_invalidate')) {
-                    opcache_invalidate($file, true);
+                    @opcache_invalidate($file, true);
                 }
 
                 // Attach this datasources to pages

--- a/symphony/content/content.blueprintsevents.php
+++ b/symphony/content/content.blueprintsevents.php
@@ -605,7 +605,7 @@ class contentBlueprintsEvents extends ResourcesPage
                 // Write successful
             } else {
                 if (function_exists('opcache_invalidate')) {
-                    opcache_invalidate($file, true);
+                    @opcache_invalidate($file, true);
                 }
 
                 // Attach this event to pages

--- a/symphony/content/content.systempreferences.php
+++ b/symphony/content/content.systempreferences.php
@@ -223,7 +223,7 @@ class contentSystemPreferences extends AdministrationPage
 
                 if (Symphony::Configuration()->write()) {
                     if (function_exists('opcache_invalidate')) {
-                        opcache_invalidate(CONFIG, true);
+                        @opcache_invalidate(CONFIG, true);
                     }
 
                     redirect(SYMPHONY_URL . '/system/preferences/success/');


### PR DESCRIPTION
Avoid Symphony Warning screens when `opcache_invalidate` function does not work.

When editing filesystem based preferences like `Data Sources`, `Events` and Symphony's `Preferences`, saving changes will result in a Symphony Warning error dump screen, if Zend OPcache is enabled but `opcache_invalidate` function does not work.

![opcache](https://user-images.githubusercontent.com/2209893/46356707-8ded4800-c663-11e8-97aa-4832c8a96dba.png)

Related discussion: https://github.com/Solutions-Nitriques/anti_brute_force/issues/42#issuecomment-426083630
