### PR TITLE
Force sorting on a date columns we select

### DIFF
--- a/symphony/lib/toolkit/class.entrymanager.php
+++ b/symphony/lib/toolkit/class.entrymanager.php
@@ -414,11 +414,11 @@ class EntryManager
 
         // Handle Creation Date or the old Date sorting
         } elseif (self::$_fetchSortField === 'system:creation-date' || self::$_fetchSortField === 'date') {
-            $sort = sprintf('ORDER BY `e`.`creation_date_gmt` %s', self::$_fetchSortDirection);
+            $sort = sprintf('ORDER BY `e`.`creation_date` %s', self::$_fetchSortDirection);
 
         // Handle Modification Date sorting
         } elseif (self::$_fetchSortField === 'system:modification-date') {
-            $sort = sprintf('ORDER BY `e`.`modification_date_gmt` %s', self::$_fetchSortDirection);
+            $sort = sprintf('ORDER BY `e`.`modification_date` %s', self::$_fetchSortDirection);
 
         // Handle sorting for System ID
         } elseif (self::$_fetchSortField == 'system:id' || self::$_fetchSortField == 'id') {


### PR DESCRIPTION
This prevents error in default setups of MySQL 5.7.x

In the core, we select the non GMT version and show the non GMT version:
a user could reasonably expect the sort to be done on the shown value.

Fixes #2878

RE #2517